### PR TITLE
Make OpenVINO platform-conditional, re-enable Windows builds

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -21,11 +21,11 @@ jobs:
       extension_name: anofox_tabular
       # Exclude WASM builds - extension uses features not compatible with WASM
       # (libpostal, libphonenumber, DNS/SMTP network operations)
-      # Exclude WASM and MinGW builds - WASM lacks required features, MinGW has vcpkg OpenSSL build issues
+      # Exclude MinGW builds - vcpkg OpenSSL build issues
       # Exclude musl builds - OpenVINO binary components require glibc
-      # Exclude ARM64 builds - vcpkg OpenVINO has build issues on ARM64 Linux (GitHub Actions resource limits)
-      # Exclude Windows builds - vcpkg OpenVINO has MSVC C1083 parallel compilation race conditions
-      exclude_archs: wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw;linux_amd64_musl;linux_arm64;windows_amd64
+      # Exclude ARM64 Linux builds - vcpkg OpenVINO build timeout issues
+      # Note: Windows builds WITHOUT OpenVINO (NER unavailable, pattern-based PII works)
+      exclude_archs: wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw;linux_amd64_musl;linux_arm64
 
   duckdb-v1_4_3-build:
     name: Build extension binaries (v1.4.3)
@@ -36,11 +36,11 @@ jobs:
       extension_name: anofox_tabular
       # Exclude WASM builds - extension uses features not compatible with WASM
       # (libpostal, libphonenumber, DNS/SMTP network operations)
-      # Exclude WASM and MinGW builds - WASM lacks required features, MinGW has vcpkg OpenSSL build issues
+      # Exclude MinGW builds - vcpkg OpenSSL build issues
       # Exclude musl builds - OpenVINO binary components require glibc
-      # Exclude ARM64 builds - vcpkg OpenVINO has build issues on ARM64 Linux (GitHub Actions resource limits)
-      # Exclude Windows builds - vcpkg OpenVINO has MSVC C1083 parallel compilation race conditions
-      exclude_archs: wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw;linux_amd64_musl;linux_arm64;windows_amd64
+      # Exclude ARM64 Linux builds - vcpkg OpenVINO build timeout issues
+      # Note: Windows builds WITHOUT OpenVINO (NER unavailable, pattern-based PII works)
+      exclude_archs: wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw;linux_amd64_musl;linux_arm64
 
   # Disabled format and tidy checks - local development environment doesn't match CI formatter versions
   # code-quality-check:

--- a/README.md
+++ b/README.md
@@ -369,8 +369,8 @@ Detect and mask Personally Identifiable Information (PII) in text data with 17 s
 - **Pattern-based (13 types):** EMAIL, PHONE, CREDIT_CARD, US_SSN, IBAN, IP_ADDRESS, URL, MAC_ADDRESS, UK_NINO, US_PASSPORT, API_KEY, CRYPTO_ADDRESS, DE_TAX_ID
 - **NER-based (4 types):** NAME, ORGANIZATION, LOCATION, MISC (using OpenVINO + DistilBERT)
   - Available on: Linux x64 (glibc), macOS (x64 & ARM64)
-  - Temporarily excluded: Linux ARM64 (glibc), Windows x64
-  - Not available on: Linux musl (Alpine) - NAME falls back to dictionary-based detection
+  - Not available on: Windows x64, Linux ARM64, Linux musl (Alpine)
+  - On unsupported platforms: NAME uses dictionary fallback, other NER types unavailable
 
 **Masking Strategies:**
 - `REDACT` - Replace with [TYPE] label

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -911,10 +911,10 @@ Detect and mask Personally Identifiable Information (PII) in text data. Supports
 - Confidence threshold: 0.7 (70%) for entity acceptance
 - NAME has dictionary fallback if NER unavailable; ORGANIZATION, LOCATION, MISC require NER
 - **Platform Availability:**
-  - Linux x64 (glibc), macOS x64, macOS ARM64
-  - Linux ARM64 - temporarily excluded due to vcpkg OpenVINO build issues
-  - Windows x64 - temporarily excluded due to MSVC parallel compilation issues
-  - Linux musl (Alpine) - NER-based detection unavailable, NAME uses dictionary fallback
+  - ✅ Linux x64 (glibc), macOS x64, macOS ARM64 - Full NER detection available
+  - ❌ Windows x64 - OpenVINO not installed, NAME uses dictionary fallback, ORG/LOC/MISC unavailable
+  - ❌ Linux ARM64 - vcpkg OpenVINO build timeout issues, excluded from CI
+  - ❌ Linux musl (Alpine) - OpenVINO requires glibc, excluded from CI
 - Entity types:
   - NAME: Person names (PER entities) - e.g., "John Smith"
   - ORGANIZATION: Company/org names (ORG entities) - e.g., "Microsoft"

--- a/vcpkg.json
+++ b/vcpkg.json
@@ -7,7 +7,8 @@
                 {
                         "name": "openvino",
                         "default-features": false,
-                        "features": ["auto", "cpu", "onnx"]
+                        "features": ["auto", "cpu", "onnx"],
+                        "platform": "!windows"
                 }
         ],
         "vcpkg-configuration": {


### PR DESCRIPTION
## Summary

- Make OpenVINO a platform-conditional dependency (`platform: !windows` in vcpkg.json)
- Re-enable Windows builds (removed from `exclude_archs`)
- Windows builds now succeed without OpenVINO
- Update platform availability documentation

## Changes

| Platform | OpenVINO | PII Types Available |
|----------|----------|---------------------|
| Linux x64 (glibc) | ✅ Installed | All 17 (13 pattern + 4 NER) |
| macOS x64/ARM64 | ✅ Installed | All 17 (13 pattern + 4 NER) |
| **Windows x64** | ❌ Not installed | **13 pattern-based** |
| Linux ARM64 | ⚠️ Excluded | - |
| Linux musl | ⚠️ Excluded | - |

## Test plan

- [ ] Windows build succeeds without OpenVINO
- [ ] Linux/macOS builds succeed with OpenVINO
- [ ] Pattern-based PII detection works on Windows
- [ ] NER tests skipped on Windows (no `OPENVINO_AVAILABLE` env)
- [ ] NER tests pass on Linux/macOS