### PR TITLE
chore(python): bump version to 0.5.0

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "anofox-tabular"
-version = "0.4.0"
+version = "0.5.0"
 description = "Python wrapper for the anofox-tabular DuckDB extension — data quality, PII, and validation primitives"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## Summary

- Bumps `python/pyproject.toml` version from `0.4.0` to `0.5.0`
- Tags `v0.5.0` and `py-v0.5.0` are already pushed and CI pipelines are running