### PR TITLE
chore(python): bump version to 0.5.1

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "anofox-tabular"
-version = "0.5.0"
+version = "0.5.1"
 description = "Python wrapper for the anofox-tabular DuckDB extension — data quality, PII, and validation primitives"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Bump Python package version to 0.5.1 to include DuckDB v1.5.2 support merged in #37.