### PR TITLE
docs: add consolidated per-module code review

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,7 @@ vcpkg_installed/
 .ai/
 ai/
 third_party/
+.cache/
+
+# Codex delegation data (AI session responses)
+.codex-delegate/

--- a/docs/reviews/2026-06-12-codex-code-review.md
+++ b/docs/reviews/2026-06-12-codex-code-review.md
@@ -1,0 +1,244 @@
+# Consolidated Code Review — anofox-tabular
+
+- **Date:** 2026-06-12
+- **Reviewer:** OpenAI Codex (gpt-5.5), one independent read-only review per module, consolidated by Claude Code
+- **Scope:** All C++ functionality modules in `src/` (email, postal, phonenumber, metric/quality, outlier detection, diff, money, PII, NER, VAT, core/trace/telemetry)
+- **Goal:** Input for planning code-quality improvements: correctness, performance/memory, source-code modelling
+- **Detail:** Full per-module reviews with code sketches live in `docs/reviews/modules/review_<module>.md`
+
+**Finding counts:** 23 HIGH, 37 MEDIUM, 19 LOW across 11 modules.
+
+---
+
+## 1. Cross-module themes
+
+These recurring patterns account for the majority of findings. Fixing them centrally (shared helper + sweep) gives far more leverage than patching module by module.
+
+### T1 — SQL built by string concatenation without escaping (HIGH)
+**Modules:** metric, outlier_tree, pii, diff.
+Table names, column names, and string literals are interpolated into generated SQL. Quotes or keywords in valid identifiers break the query; crafted input can alter it (SQL injection through `query_table('...')`, `pii_scan_table`, `outlier_tree`, diff join/compare columns).
+**Fix:** one shared header with `QuoteIdentifier()` / `QuoteLiteral()` (or DuckDB's `KeywordHelper::WriteOptionallyQuoted`), used by every SQL-generating path. Add sqllogictests with quoted/`'`-containing identifiers.
+
+### T2 — Process-global mutable singletons without consistent synchronization or scoping (HIGH)
+**Modules:** email (options), phonenumber (default region), pii (`PIIConfig`, Base58 map), ner (model manager, LRU cache), money (`CurrencyRegistry` init), postal (`PostalManager` fields), core (telemetry `_queue`/`_api_key`).
+Concrete data races exist (unsynchronized lazy init, plain-`bool`/`std::string` reads while another thread writes). Beyond races, settings are process-wide, so one connection's `SET` changes another connection's running query, and `FunctionStability::CONSISTENT` is claimed for functions whose results depend on mutable global state.
+**Fix pattern:** (a) make one-time init safe via constructor-init or `std::call_once`; (b) snapshot settings per query into `FunctionData` at bind time instead of reading the singleton per row; (c) audit every singleton so all reads/writes of non-atomic fields hold the same mutex; (d) re-evaluate `FunctionStability` flags.
+
+### T3 — Per-row work that belongs at chunk/registry level (MEDIUM, perf)
+**Modules:** phonenumber and vat compile `std::regex` per row; email calls `ToUnifiedFormat` per row; money/vat/postal/pii copy every `string_t` into `std::string`; money calls `StructVector::GetEntries` inside row loops.
+**Fix:** precompile regexes once (registry/metadata level); hoist vector normalization out of loops; pass `string_t`/`string_view` into row lambdas; use `UnaryExecutor`/`BinaryExecutor`/`GenericExecutor` for simple scalar functions to preserve constant/dictionary vector handling.
+
+### T4 — Table functions fully materialize input and output (MEDIUM, memory)
+**Modules:** metric (isolation forest path), outlier_tree, pii (`pii_scan_table`, `pii_audit_table`).
+Whole source tables are fetched through a nested `Connection`, copied cell-by-cell via `DataChunk::GetValue`, plus a second full copy of results before any row is emitted.
+**Fix:** stream output per `STANDARD_VECTOR_SIZE` chunk from table-function state; read input through `UnifiedVectorFormat`; avoid the duplicate results vector; document/guard unavoidable full-materialization (model fitting).
+
+### T5 — Parameter validation gaps (MEDIUM)
+**Modules:** metric, outlier, phonenumber, ner, email.
+Signed `BIGINT` inputs are assigned to `size_t` before range checks (`min_pts = -1` wraps to huge), `NaN`/`Inf` pass `<=`/`>` checks, unknown enum-ish strings silently fall back to defaults (`output_mode`, phone format option), and settings accept invalid values (`default_region='ZZ'`, DNS tries > `INT_MAX`).
+**Fix:** validate into `int64_t` first then cast; `std::isfinite()` checks; reject unknown option strings with `BinderException`/`InvalidInputException`; validate settings in their `SET` callbacks.
+
+### T6 — STRUCT-result NULL semantics are inconsistent (HIGH for postal, MEDIUM for money)
+`postal_parse_address(NULL)` and invalid money rows mark only child vectors NULL, leaving a non-NULL parent struct — `f(NULL) IS NULL` is false.
+**Fix:** define one invariant (invalid ⇒ parent struct NULL) and apply it via a small shared helper; add tests.
+
+### T7 — Functions that don't do what their name/signature promises (HIGH)
+- metric: `dbscan`/`dbscan_mv` are bind-replace **placeholders** returning constants, despite a real `DBSCAN` class existing.
+- vat: `vat_format` always returns NULL; `vat_is_valid` is syntax-only despite modeling `has_checksum`.
+- diff: `diff_hashdiff` accepts `bisection_threshold`/`bisection_factor` and ignores both (runs the same join as joindiff).
+- ner: `anofox_ner_model` option exists but model paths/URLs are hard-coded; no reload path. `ExtractEntitiesBatch(max_batch_size)` is not batched.
+- money: `money_from_cents(10050,'USD')` returns `10050.0`, not `100.50` — `subunit_to_unit` is fetched but unused.
+**Fix:** implement, or unregister/rename until implemented. Silent stubs are worse than missing functions.
+
+### T8 — `<cctype>` UB on signed char (LOW, trivial sweep)
+**Modules:** pii, vat (ner tokenizer relatedly). `std::isdigit(c)` etc. with plain `char` is UB for negative values. **Fix:** sweep to `static_cast<unsigned char>`.
+
+### T9 — Dead/legacy code paths increase review risk (LOW)
+metric keeps deprecated isolation-forest SQL generators; diff carries a complete unregistered native table-function scaffold that would return empty results if wired up. **Fix:** delete.
+
+### T10 — Alias helpers silently drop function metadata (MEDIUM, affects all modules)
+`anofox_function_alias.hpp` reconstructs `ScalarFunction`/`TableFunction` copying only a subset of fields — aliases lose `init_local_state`, statistics/pushdown callbacks, error mode, serialization, etc., and will drift further as DuckDB evolves.
+**Fix:** copy the whole function object, then rename (`auto alias = func; alias.name = alias_name;`); add primary-vs-alias regression tests.
+
+---
+
+## 2. Per-module findings
+
+### 2.1 Email (`anofox_email*.cpp/.hpp`)
+
+| Sev | Finding | Where |
+|-----|---------|-------|
+| HIGH | SMTP validation can succeed after DNS failure: fallback hosts include the raw domain, `localhost`, and `127.0.0.1`, so a local SMTP server makes invalid domains validate. Also surprising local network probing. | `anofox_email.cpp:86-88,317-321` |
+| HIGH | `FD_SET` with descriptors ≥ `FD_SETSIZE` is UB (memory corruption) in DNS and SMTP `select()` loops. Replace with `poll()`/`WSAPoll()` or guard fd values. | `anofox_email_dns.cpp:188-195`, `anofox_email_smtp.cpp:155-165,350-357` |
+| MED | Null MX (`"."` exchange, RFC 7505) treated as deliverable MX host; DNS mode reports such domains valid. Detect and return `dns_null_mx`. | `anofox_email_dns.cpp:121-124,426,434` |
+| MED | `ReadLine` has no max line length / total response size / multi-line count — a hostile peer can grow memory unboundedly. Enforce protocol limits (e.g. 8 KiB line / 64 KiB response). | `anofox_email_smtp.cpp:607-670` |
+| MED | Overall SMTP timeout only checked between hosts; one host with many endpoints can exceed `MAX_TOTAL_TIMEOUT_MS` by a wide margin. Thread an absolute deadline through `AttemptHost`/`ConnectSocket`/`ReadResponse`/`SendCommand`. | `anofox_email_smtp.cpp:927-935` |
+| MED | Per-row `args.GetValue()` + `std::string` conversion + repeated `ToUnifiedFormat` in `ExtractValidationMode`. Normalize once per chunk; vectorize the regex-only path. | `anofox_email.cpp:420-481` |
+| LOW | Options are a process-global singleton — one connection's `SET` changes another's running query (theme T2). Snapshot into bind data. | `anofox_email.cpp:92-99,674-676` |
+| LOW | DNS tries option accepts up to `uint32_t::max()` then casts to `int` for c-ares — can wrap negative. Cap to a small documented range. | `anofox_email.cpp:568-573`, `anofox_email_dns.cpp:363` |
+
+**Quick wins:** drop localhost fallback; Null-MX handling; guard/replace `FD_SET`; SMTP size limits; RAII for sockets/c-ares channels; reconsider `CONSISTENT` stability on network-dependent overloads.
+
+### 2.2 Postal (`anofox_postal.cpp/.hpp`)
+
+| Sev | Finding | Where |
+|-----|---------|-------|
+| HIGH | `postal_parse_address(NULL)` returns a non-NULL struct with all-NULL children — parent validity never set (theme T6). | `anofox_postal.cpp:323-325` |
+| HIGH | User-controlled data path interpolated into `std::system("tar -xzf \"...\" -C \"...\"")` — shell metacharacter injection. Replace with non-shell extraction (library or argv-based process spawn). | `anofox_postal.cpp:219-220,492` |
+| MED | `LoadData` bypasses `init_lock`: concurrent `postal_load_data()` calls can clobber each other's downloads; per-call `curl_global_init`/`cleanup` affects other curl users process-wide. Serialize + process-lifetime curl RAII. | `anofox_postal.cpp:127-227,472` |
+| MED | Partial libpostal initialization not rolled back on failure — retry can re-setup already-initialized global state; destructor tears down stages that never completed. Track stages / RAII guard. | `anofox_postal.cpp:263-276` |
+| MED | `data_directory` written under mutex but read without it (`GetDataDirectory`, `LoadData`, `GetStatus`) — `std::string` data race. Lock all accessors. | `anofox_postal.hpp:52-53`, `anofox_postal.cpp:74-235` |
+| LOW | Error message says `anofox_postal_data_path` but the registered option is `anofox_tab_postal_data_path`; disabled tests use the old name too. | `anofox_postal.cpp:293-295,492` |
+| LOW | Per-row intermediates: input→`std::string`, libpostal components→vector→`Value` copies. Write directly into DuckDB vectors with RAII for libpostal responses. | `anofox_postal.cpp:88-118,330-386` |
+
+**Quick wins:** parent struct validity fix; remove duplicate `RegisterPostalOptions` call; fix option-name mismatch; mutex around `LoadData`; RAII for `FILE*`/`CURL*`.
+
+### 2.3 Phonenumber (`anofox_phonenumber*.cpp/.hpp`)
+
+Note: this is a custom implementation, not libphonenumber-backed (README wording may be stale).
+
+| Sev | Finding | Where |
+|-----|---------|-------|
+| HIGH | Process-wide `default_region` mutable via `SET` mid-query; functions marked `CONSISTENT` despite depending on it (theme T2). Snapshot via bind data. | `anofox_phonenumber.cpp:504,511,560,971` |
+| HIGH | Region hints ignored for shared country codes: `+1` always resolves to first region (`US`), so `phonenumber_is_valid_for_region('+1 506…','CA')` fails. Prefer the hint when it belongs to the code's region list. | `anofox_phonenumber.cpp:214`, `anofox_phonenumber_metadata.cpp:8` |
+| MED | `ExtractCountryCode` consumes 1–3 leading digits even without `+`, so national numbers whose prefix matches a country code (e.g. US area code 442 → GB) are misparsed and never fall back to the region hint. Only extract country code for explicit international formats. | `anofox_phonenumber.cpp:52,177,180` |
+| MED | Up to 3 `std::regex` objects compiled per row in `DeterminePhoneNumberType`, and again in `IsValid` after `Parse` already classified. Precompile per region; share classification. | `anofox_phonenumber.cpp:96-113,374-379` |
+| LOW | Unknown format strings silently become `NATIONAL`; formatting failures return the input via blanket `catch (std::exception)`. Reject unknown formats; decide NULL-vs-throw for invalid numbers. | `anofox_phonenumber.cpp:529,669-674` |
+| LOW | `SET anofox_tab_phonenumber_default_region='ZZ'` accepted silently; later parsing quietly fails. Validate against `REGION_METADATA` in the SET callback. | `anofox_phonenumber.cpp:504,560` |
+
+**Quick wins:** NANPA/CA regression tests; per-region precompiled regexes; validate region setting; strict format option.
+
+### 2.4 Metric / Quality (`anofox_metric.cpp/.hpp`)
+
+| Sev | Finding | Where |
+|-----|---------|-------|
+| HIGH | Table/column names, required columns, interval strings concatenated into generated SQL without escaping (theme T1). | `anofox_metric.cpp:56-255,653,699,1265` |
+| HIGH | `anofox_tab_dbscan`/`dbscan_mv` are placeholder bind-replace SQL: constant `cluster_id=0`, `point_type='CORE'`, hard-coded `cluster_count=3`, `noise_count=1`, `total_count=10` — the real `DBSCAN` class is included but never called. Implement as real table function like `IsolationForestExecute`, or unregister. | `anofox_metric.cpp:1242-1345` |
+| MED | Bind functions contain defaults (`n_trees=100`…) but registration only adds fixed-arity overloads — `isolation_forest('t','x')` can never bind. Register all intended arities or delete dead defaulting code. | `anofox_metric.cpp:414,508,1155-1217,1434-1472,1569` |
+| MED | Empty/degenerate inputs: `0/0` null_rate, zscore returns zero rows on empty input (cross join with empty CTE), NULL freshness messages, `STDDEV` NULL/0 unhandled. Guarantee exactly one row with explicit semantics (`NULLIF`, `COALESCE`, stddev special-case). | `anofox_metric.cpp:70-130,151,229` |
+| MED | `BIGINT`→`size_t` before validation (`min_pts=-1` wraps and passes); NaN passes `eps <= 0.0` / `contamination > 0.5` checks (theme T5). | `anofox_metric.cpp:415-424,509-518,581,1253-1254,1324-1325` |
+| MED | Isolation forest materializes the full input via per-cell `GetValue`, full scores vector, plus a duplicate `state.results` copy (theme T4). | `anofox_metric.cpp:701-872` |
+| LOW | Any `output_mode` other than exact `"scores"`/`"clusters"` silently means summary — typos change behavior. Reject unknown modes at bind. | `anofox_metric.cpp:440,599,891,1173,1235,1268,1338` |
+| LOW | Dead legacy isolation-forest SQL generators and bind-replace functions remain alongside the live C++ path (theme T9). | `anofox_metric.cpp:944-1181` |
+
+**Quick wins:** quoting helpers; strict `output_mode`; signed validation then cast; reject NaN/Inf; tests for quoted identifiers, empty tables, all-NULL columns, constant z-score input.
+
+### 2.5 Outlier detection (`anofox_dbscan.cpp`, `anofox_isolation_forest.cpp`, `anofox_outlier_tree.cpp`)
+
+| Sev | Finding | Where |
+|-----|---------|-------|
+| HIGH | DBSCAN semantics wrong: `minPts` effectively one stricter (self excluded from `RegionQuery` but compared directly), and noise points reachable from a core point stay noise instead of becoming border points (skipped by the `visited` check). | `anofox_dbscan.cpp:50,62,97,105,161` |
+| HIGH | `outlier_tree` builds SQL from unescaped table/column names and runs it on a nested `Connection` (theme T1). | `anofox_outlier_tree.cpp:795-807,909-912` |
+| HIGH | `max_depth`/`min_size_*` read as `int64_t` but assigned to `size_t` before validation — negative values wrap and pass (theme T5). | `anofox_outlier_tree.cpp:823-826` |
+| MED | Reported `row_id` is the index into the NULL-filtered compacted dataset, not the source row; `total_rows` is the filtered count. Carry original row ids through (e.g. `row_number() over ()`). | `anofox_outlier_tree.cpp:941-990` |
+| MED | Refitting an `IsolationForest` appends to old `nodes_` (never cleared, `trees_.resize` reuses instances) — second fit scores through stale tree state. Clear per build. | `anofox_isolation_forest.cpp:385,517,955,1176` |
+| MED | Categorical right-branch explanations lack negation: outliers explained as `col IN (...)` when the branch means `NOT IN`. Add an operator/negation flag to `SplitCondition`. | `anofox_outlier_tree.cpp:154-157`, hpp:40,56 |
+| MED | Duplicate-outlier suppression appends a better-scoring duplicate without removing the worse one — inflated counts. Keep a `(row,col)`→best map. | `anofox_outlier_tree.cpp:239,314,736` |
+| MED | `SplitCondition::ToJSON` writes unescaped strings into JSON — malformed output for quotes/control chars. | `anofox_outlier_tree.hpp:56-66,120` |
+| MED | `Fit`/`Score`/`FitMixed` assume consistent shapes; violations can underflow `uniform_int_distribution(0, n_features-1)` or read out of bounds. Validate at API boundaries. | `anofox_isolation_forest.cpp:393-499,1126-1278` |
+| MED | Full-table materialization through nested `Connection` + per-cell `GetValue`/`SetValue` (theme T4). | `anofox_outlier_tree.cpp:915-990` |
+| LOW | `uint16_t` feature indices/depths, `uint8_t` ndim — silent truncation on wide tables. Use `idx_t` or validate before narrowing. | `anofox_isolation_forest.hpp:108-117` |
+| LOW | Hot-path waste: per-candidate variance/entropy recomputation, double partitioning (score then recurse), fresh neighbor vector per region query. Cache stats, reuse scratch buffers; consider spatial index for DBSCAN. | `anofox_outlier_tree.cpp:120-125,382,398`, `anofox_isolation_forest.cpp:112,139`, `anofox_dbscan.cpp:50` |
+
+**Quick wins:** DBSCAN minPts/border regression tests; clear `nodes_` per build; JSON escaping; categorical negation flag; preserve source row ids; signed-validate-then-cast.
+
+### 2.6 Diff (`anofox_diff.cpp/.hpp`)
+
+| Sev | Finding | Where |
+|-----|---------|-------|
+| HIGH | Nullable primary keys break classification: join on `s.pk = t.pk` plus presence inferred from `s.<first_pk> IS NULL` misclassifies NULL-key and compound-key rows as added/removed. Use side-presence marker columns + `IS NOT DISTINCT FROM`, or reject NULL PKs explicitly. | `anofox_diff.cpp:228,237,254-255` |
+| MED | PK/compare column identifiers concatenated unquoted (theme T1); table names go through `QualifiedName` but columns don't. Use `KeywordHelper::WriteOptionallyQuoted`. | `anofox_diff.cpp:228-278` |
+| MED | `ValidatePrimaryKeys`/`ValidateCompareColumns` exist but are never called; schema mismatches surface as confusing binder errors or silently wrong whole-row-struct comparisons. Validate at bind; compare column-by-column. | `anofox_diff.cpp:82,97,259-277` |
+| MED | `diff_hashdiff` registers `bisection_threshold`/`bisection_factor` overloads and ignores both — same plan as joindiff (theme T7). Implement or reject. | `anofox_diff.cpp:382-388,521-533` |
+| LOW | Complete unregistered native table-function scaffold (would return empty results) plus unused constants/helpers (theme T9). Delete or finish. | `anofox_diff.cpp:22-189` |
+| LOW | Manual alias copying instead of `RegisterTableFunctionSetWithAlias` from `anofox_function_alias.hpp`. | `anofox_diff.cpp:400,484,507,561` |
+
+### 2.7 Money (`anofox_money*.cpp/.hpp`)
+
+| Sev | Finding | Where |
+|-----|---------|-------|
+| HIGH | `CurrencyRegistry::GetInstance()` does an unsynchronized `if (!initialized) Initialize()` after the static — two threads can mutate `currencies` concurrently. Init in constructor or `std::call_once`. | `anofox_money_currency.cpp:7-15`, hpp:51-52 |
+| HIGH | `money_from_cents(10050,'USD')` returns `10050.0 USD` — `subunit_to_unit` fetched but never divided by (theme T7). Also wrong for zero-decimal currencies. | `anofox_money.cpp:70,101-108` |
+| HIGH | Amounts modeled as `DOUBLE`: inexact arithmetic, NaN/Inf representable, integer precision loss above 2^53. Move to `BIGINT` minor units or `DECIMAL(18,2)` with overflow checks. | `anofox_money.cpp:19-21,364-630`, hpp:18,45 |
+| MED | Functions that throw (`InvalidInputException` on bad currency / mismatch) registered with default `CANNOT_ERROR` — planner may treat them as non-throwing. `SetFallible()` everywhere applicable. | `anofox_money.cpp:57-220,619`, hpp:154 |
+| MED | Child-field NULLs produce a valid parent money struct (theme T6); define one invariant for accessors/comparisons. | hpp:144-148, `anofox_money.cpp:343,408` |
+| MED | Case-insensitive lookup accepts `'usd'` but stores original string; later case-sensitive comparison makes `money_add(money(1,'usd'), money(1,'USD'))` throw. Canonicalize to `iso_code` at construction. | `anofox_money.cpp:54-61`, hpp:151,154 |
+| LOW | `money_format` ignores `subunit_to_unit` scale (JPY → `¥1000.00`), never inserts `thousands_separator`, can emit `nan`/`inf`. Centralize a metadata-driven formatter. | `anofox_money.cpp:227-253` |
+| LOW | Per-row `GetString()` copies, `StructVector::GetEntries` inside row loops (theme T3). | hpp:71-151, `anofox_money.cpp:153-169,365` |
+
+### 2.8 PII (`anofox_pii.cpp/.hpp`)
+
+| Sev | Finding | Where |
+|-----|---------|-------|
+| HIGH | `PIIConfig` singleton: mutable vectors/doubles/enums read by parallel workers while SET callbacks write, no mutex, no `ClientContext` scoping (theme T2). Snapshot per query. | `anofox_pii.cpp:106-147,3153,3182`, hpp:507,537 |
+| HIGH | Lazy Base58 map populated on `empty()` check — classic data race for parallel crypto-address validation. Use immutable static array initialized by lambda. | `anofox_pii.cpp:992-998` |
+| HIGH | `pii_scan_table`/`pii_audit_table` execute SQL rebuilt from the raw table name; column quotes unescaped (theme T1). | `anofox_pii.cpp:2638,2695,2853,2929` |
+| MED | `anofox_pii_enabled_types` ignored by main scalar APIs (`engine.Detect(text)` without config); `min_confidence` only applied in audit; NER recognizers hard-code 0.7. Centralize filtering in `Detect()`. | `anofox_pii.cpp:147-169,1627,1778,1875,2727-2730,3231` |
+| MED | Overlapping matches from multiple recognizers only sorted by start — `Mask()` can double-mask spans with stale offsets. Resolve overlaps by priority/length before masking. | `anofox_pii.cpp:1627-1650,1726-1734` |
+| MED | Both table functions materialize all results before emitting; audit retains full original+masked values per match (theme T4). Stream chunks. | `anofox_pii.cpp:2654,2742,2891,2962,2977` |
+| LOW | Multiple `std::isdigit`/`isalpha` calls on plain `char` (theme T8) — some sites already cast, this is consistency debt. | `anofox_pii.cpp:311-560` |
+
+### 2.9 NER (`anofox_ner.cpp/.hpp`)
+
+| Sev | Finding | Where |
+|-----|---------|-------|
+| HIGH | Shared mutable tokenizer state (`offsets_` cleared/replaced across threads) and a single shared `ov::InferRequest` used concurrently — data races / wrong results under parallel execution. Per-call infer requests + tokenization returning offsets by value (or a mutex as stopgap). | `anofox_ner.cpp:701-761,1051-1089`, hpp:198-199,348-352 |
+| HIGH | `LRUCache::Capacity()` reads unlocked while `SetCapacity()` writes; capacity-zero between check and `Put` ⇒ `lru_list_.back()` on empty list (UB/crash when `anofox_ner_cache_size` changes mid-query). Lock/atomic + handle zero inside `Put`. | hpp:61-109, call sites 708-1139 |
+| MED | `anofox_ner_model` advertised (incl. `xlm-roberta-multi`) but paths/URLs hard-coded to DistilBERT; no reload; mismatched tokenizer/model pairs possible (theme T7). Drive assets from `ModelMetadata` or reject the option. | `anofox_ner.cpp:73-87,437,546-613,1142-1160` |
+| MED | `status_message_`, `model_path_`, `current_model_name_` are plain strings read by status functions while loading threads write — torn reads. Publish immutable snapshots. | `anofox_ner.cpp:433-506,631,697`, `anofox_pii.cpp:2522-2546` |
+| MED | No max-sequence-length enforcement (BERT-class models ~512 tokens) and output tensor shape never validated before copying logits. Truncate/window + shape check. | `anofox_ner.cpp:722-767,1051-1095` |
+| MED | Hand-written WordPiece ignores tokenizer.json normalizer/pre-tokenizer settings; byte-level `isspace`/`ispunct` splitting breaks UTF-8 → wrong offsets → wrong PII spans. Use full tokenizer config or constrain+document ASCII. | `anofox_ner.cpp:150-301` |
+| LOW | Raw `FILE*`/`CURL*` with manual cleanup; assets written to final paths (partial downloads leave mismatched pairs). RAII + temp-file + atomic rename. | `anofox_ner.cpp:633-677` |
+| LOW | `ExtractEntities`/`ExtractEntitiesBatch` duplicate the full pipeline; `max_batch_size` unused. Factor `RunSingleInference()`. | `anofox_ner.cpp:716-769,1046-1097` |
+
+### 2.10 VAT (`anofox_vat*.cpp/.hpp`)
+
+| Sev | Finding | Where |
+|-----|---------|-------|
+| HIGH | `vat_format` is a registered public function that always returns NULL (theme T7). Implement using `SplitVAT`/`ConvertISOToVAT` or unregister. | `anofox_vat.cpp:128-151,286` |
+| HIGH | `vat_is_valid` is syntax-only although the country table models `has_checksum` for most countries — significant false-positive risk. Add checksum implementations; split syntax vs full validation in the API. | `anofox_vat_country.cpp:25,57`, hpp:141-143, `anofox_vat.cpp:161-172` |
+| MED | Country utilities do raw map lookups: `is_valid_vat_country('de')`, `'EL'`, `vat_is_eu_member('EL')` return false though `SplitVAT` accepts those forms. Centralize `NormalizeCountryCode`. | `anofox_vat_country.cpp:15-72`, `anofox_vat.cpp:41,106,115` |
+| MED | `<cctype>` on plain char in `NormalizeVAT` (theme T8). | `anofox_vat_country.cpp:95-100` |
+| MED | `IsValidSyntax` compiles a `std::regex` per row (theme T3). Precompile in `CountryInfo` during registry init. | `anofox_vat_country.cpp:80-89` |
+| LOW | Generic iterators copy every `string_t` to `std::string`; pass `string_view`/`string_t`, consider `UnaryExecutor`. | hpp:30-81 |
+
+### 2.11 Core (extension entry, trace, telemetry, alias helpers)
+
+| Sev | Finding | Where |
+|-----|---------|-------|
+| HIGH | Telemetry: `_queue` lazily initialized without `_thread_lock`; `_api_key` copied unguarded in capture paths while `SetAPIKey` writes under mutex — races under parallel execution / concurrent SET. Snapshot under one lock, enqueue outside. | `anofox_tabular_extension.cpp:22-60`, `posthog-telemetry/src/telemetry.cpp:132-185` |
+| MED | Alias helpers reconstruct functions copying a small field subset — aliases silently lose bind/statistics/pushdown/serialization/error-mode metadata (theme T10). Copy-then-rename. | `anofox_function_alias.hpp:18-74` |
+| MED | `extension_load` telemetry fires before any SQL `SET anofox_telemetry_enabled=false` can run — the comment claiming otherwise is wrong; only `DATAZOO_DISABLE_TELEMETRY` works. Read effective setting first or document honestly. | `anofox_tabular_extension.cpp:54-69` |
+| LOW | `AnofoxTrace` multi-op writes to `std::cerr` interleave across parallel tasks and drop the level string. Compose line, guard with mutex, include level. | `anofox_trace.cpp:73,81` |
+
+---
+
+## 3. Suggested implementation plan (for later refinement)
+
+### Phase 1 — Correctness & safety (HIGH, do first)
+1. **Shared SQL-quoting helpers** + sweep of metric, outlier_tree, pii, diff (T1).
+2. **Thread-safety batch:** CurrencyRegistry ctor-init; PII Base58 static array; PII config snapshotting; NER inference mutex (stopgap) + LRU capacity fix; postal `LoadData`/`data_directory` locking; telemetry lock discipline (T2).
+3. **Behavioral bugs:** `money_from_cents` division; DBSCAN minPts/border semantics; isolation-forest refit state clearing; diff nullable-PK presence markers; postal/money parent-struct NULL (T6); email SMTP localhost fallback removal; `FD_SET` guards; replace `std::system("tar …")`.
+
+### Phase 2 — API honesty & validation (HIGH/MEDIUM)
+4. Implement or unregister: metric DBSCAN placeholders, `vat_format`, `diff_hashdiff` params, NER model option (T7).
+5. VAT checksum validation; phonenumber NANPA region-hint handling and national-number parsing.
+6. Validation sweep (T5): signed-then-cast, `isfinite`, strict `output_mode`/format/region options, `SetFallible()` on throwing money functions, metric empty-input semantics.
+
+### Phase 3 — Performance & memory (MEDIUM)
+7. Precompile regexes (phonenumber, vat); hoist per-row normalization (email); `string_view`-based row lambdas; `UnaryExecutor`/`BinaryExecutor` adoption for simple scalars (T3).
+8. Streaming table functions for pii scan/audit, outlier_tree, isolation forest; `UnifiedVectorFormat` input reads; drop duplicate result copies (T4).
+9. Algorithm hot-path cleanups: cached split statistics, reused scratch buffers, DBSCAN neighbor-buffer reuse.
+
+### Phase 4 — Structure & hygiene (LOW)
+10. Alias helper copy-then-rename + primary-vs-alias regression tests (T10).
+11. Delete dead code: diff native scaffold, metric legacy IF SQL (T9).
+12. `<cctype>` unsigned-char sweep (T8); RAII wrappers (sockets, c-ares, curl, `FILE*`); JSON escaping helper; trace mutex + level output; settings-scoping/`FunctionStability` audit.
+
+### Cross-cutting test additions
+- Quoted/`'`-containing identifiers through every SQL-generating function.
+- `f(NULL) IS NULL` for all struct-returning functions.
+- Empty tables, all-NULL columns, constant columns for every metric.
+- NaN/Inf/negative parameters for all numeric options.
+- Concurrency smoke tests (parallel queries + concurrent `SET`) for ner, pii, money, postal.
+- DBSCAN border-point and `min_pts` semantics; isolation-forest double-fit; NANPA `CA` parsing; VAT checksum vectors; `money_from_cents` subunit cases (USD, JPY).

--- a/docs/reviews/modules/review_core.md
+++ b/docs/reviews/modules/review_core.md
@@ -1,0 +1,80 @@
+## Summary
+The core loader is compact and mostly delegates correctly to module-level registration, but it also wires process-wide telemetry and alias helpers that affect the whole extension surface. The highest-risk issue is thread safety in telemetry: the extension exposes settings that mutate singleton state while function bind/execution paths enqueue telemetry from DuckDB worker/client threads. The alias helper code is another structural risk because it manually reconstructs DuckDB function objects and silently loses metadata as DuckDB’s API evolves. Trace support is simple and uses atomics for configuration, but its output path could be made more robust under parallel execution.
+
+## Findings
+
+### [HIGH] Telemetry singleton access is not consistently synchronized
+Affected: `src/anofox_tabular_extension.cpp:22`, `src/anofox_tabular_extension.cpp:30`, `src/anofox_tabular_extension.cpp:60`; context: `posthog-telemetry/src/telemetry.cpp:132`, `posthog-telemetry/src/telemetry.cpp:160`, `posthog-telemetry/src/telemetry.cpp:185`
+
+`OnTelemetryEnabled` and `OnTelemetryKey` mutate a process-wide `PostHogTelemetry` singleton, while function bind paths across the extension call `CaptureFunctionExecution`. In the telemetry implementation, `_queue` is lazily initialized without holding `_thread_lock`, and `_api_key` is copied directly in `CaptureExtensionLoad`/`CaptureFunctionExecution` while `SetAPIKey` writes it under a mutex. Under parallel DuckDB execution or concurrent sessions changing settings, this is a data race on `_queue` and `_api_key`, with possible double queue construction, lost tasks, or undefined behavior from concurrent `std::string` access.
+
+Suggested improvement: make capture methods take one lock to snapshot enabled/key/platform/version and initialize the queue, then enqueue outside the lock if desired.
+
+```cpp
+void PostHogTelemetry::CaptureFunctionExecution(...) {
+    std::string api_key;
+    TelemetryTaskQueue<PostHogEvent> *queue;
+    {
+        std::lock_guard<std::mutex> lock(_thread_lock);
+        if (!_telemetry_enabled.load()) {
+            return;
+        }
+        EnsureQueueInitializedLocked();
+        api_key = _api_key;
+        queue = _queue.get();
+    }
+    queue->EnqueueTask([api_key](auto event) { PostHogProcess(api_key, event); }, event);
+}
+```
+
+### [MEDIUM] Function alias helpers drop DuckDB callback and optimizer metadata
+Affected: `src/include/anofox_function_alias.hpp:18`, `src/include/anofox_function_alias.hpp:36`, `src/include/anofox_function_alias.hpp:56`, `src/include/anofox_function_alias.hpp:74`
+
+The alias helpers reconstruct `ScalarFunction` and `TableFunction` objects by manually copying a small subset of fields. Current DuckDB scalar functions also carry fields such as `bind_extended`, `init_local_state`, `statistics`, `bind_expression`, `get_modified_databases`, serialization callbacks, `function_info`, error mode, and collation handling. Table functions carry many more callbacks and flags, including `bind_operator`, statistics/cardinality/progress callbacks, serialization, pushdown flags, pruning flags, ordering, function info, and initialization timing. Any function using those fields will behave differently through its alias, which is especially dangerous because aliases look semantically equivalent in the catalog.
+
+Suggested improvement: copy the function object first, then only change the exposed name, or centralize a complete metadata-copy helper with tests.
+
+```cpp
+ScalarFunction alias_func = func;
+alias_func.name = alias_name;
+
+TableFunction alias_func = func;
+alias_func.name = alias_name;
+```
+
+If direct assignment is not supported for all DuckDB versions, explicitly copy every public field from the current DuckDB structs and add regression tests that compare primary and alias behavior for bind data, null handling, errors, and pushdown flags.
+
+### [MEDIUM] SQL telemetry setting cannot suppress the extension-load event
+Affected: `src/anofox_tabular_extension.cpp:54`, `src/anofox_tabular_extension.cpp:57`, `src/anofox_tabular_extension.cpp:60`, `src/anofox_tabular_extension.cpp:69`
+
+`LoadInternal` registers telemetry options first, but then immediately enables the default API key and captures `extension_load`. A user cannot normally execute `SET anofox_telemetry_enabled=false` until after the extension has loaded and registered the option, so the SQL setting does not prevent the first telemetry event. This contradicts the comment that registering options first allows users to disable telemetry via SQL settings.
+
+Suggested improvement: check a pre-load source before emitting the load event, or avoid sending `extension_load` until after the current database setting has been read. At minimum, remove the misleading comment and document that only `DATAZOO_DISABLE_TELEMETRY` can suppress load-time telemetry.
+
+```cpp
+if (telemetry.IsEnabled()) {
+    telemetry.CaptureExtensionLoad("anofox_tabular", version);
+}
+```
+
+Also avoid resetting the API key unconditionally after registering the option if settings are meant to override it.
+
+### [LOW] Trace writes can interleave across parallel tasks
+Affected: `src/anofox_trace.cpp:73`, `src/anofox_trace.cpp:81`
+
+`AnofoxTrace` writes to `std::cerr` using multiple stream operations. Standard streams avoid memory corruption, but messages from parallel DuckDB tasks can interleave at token boundaries, making trace output hard to read and potentially misleading during debugging. The function also drops the level string, so severity filtering is invisible in the emitted log line.
+
+Suggested improvement: compose the full line first and guard the write with a small mutex, or route through the project’s existing logging dependency.
+
+```cpp
+static std::mutex trace_mutex;
+std::lock_guard<std::mutex> lock(trace_mutex);
+std::cerr << "[anofox][" << LevelToString(level) << "] " << message << '\n';
+```
+
+## Quick wins
+- Replace manual alias reconstruction with copy-then-rename helpers for both scalar and table functions.
+- Add unit tests that execute a primary function and its alias through NULL inputs, bind callbacks, and table-function bind replacement.
+- Lock telemetry queue initialization and all `_api_key` reads.
+- Make the load-time telemetry behavior explicit and test disabling via environment variable and SQL settings separately.
+- Include the log level in `AnofoxTrace` output and serialize trace writes with a mutex.

--- a/docs/reviews/modules/review_diff.md
+++ b/docs/reviews/modules/review_diff.md
@@ -1,0 +1,86 @@
+## Summary
+The diff module is small and mostly implemented as a `bind_replace` SQL generator rather than a native vectorized table function. That keeps execution inside DuckDB’s optimizer, but the generated SQL has correctness holes around nullable keys and identifier handling. The module also contains a substantial unused native table-function path, which makes the implementation look more complete than it is. `src/include/anofox_diff.hpp` is minimal and has no notable issues.
+
+## Findings
+
+### [HIGH] Nullable primary keys are misclassified and can duplicate rows
+Affected: `src/anofox_diff.cpp:228`, `src/anofox_diff.cpp:254`, `src/anofox_diff.cpp:255`, `src/anofox_diff.cpp:237`
+
+The generated join uses `s.pk = t.pk`, and row presence is inferred from `s.<first_pk> IS NULL` / `t.<first_pk> IS NULL`. If a primary key column is nullable, matching NULL keys do not join, and source-only rows with NULL keys are classified as `added` because the first `CASE` branch checks `s.pk IS NULL`. This also affects compound keys where the first key is NULL even if the row exists on both sides.
+
+Suggested improvement: either reject nullable/NULL primary key values explicitly, or join with NULL-safe equality and track side presence separately.
+
+```sql
+FROM (SELECT true AS _s_present, * FROM source) s
+FULL OUTER JOIN (SELECT true AS _t_present, * FROM target) t
+ON s.pk IS NOT DISTINCT FROM t.pk
+
+CASE
+  WHEN s._s_present IS NULL THEN 'added'
+  WHEN t._t_present IS NULL THEN 'removed'
+  WHEN ... THEN 'changed'
+  ELSE 'unchanged'
+END
+```
+
+### [MEDIUM] Column identifiers are concatenated without quoting
+Affected: `src/anofox_diff.cpp:228`, `src/anofox_diff.cpp:237`, `src/anofox_diff.cpp:254`, `src/anofox_diff.cpp:255`, `src/anofox_diff.cpp:269`, `src/anofox_diff.cpp:278`
+
+Primary key and compare column names are inserted directly into SQL. Columns named `select`, containing spaces, quotes, dots, or other special characters fail to parse or bind, and maliciously crafted strings can alter the generated expression. The table names get parsed through `QualifiedName`, but columns do not receive equivalent identifier serialization.
+
+Suggested improvement: quote every identifier component with DuckDB’s `KeywordHelper::WriteOptionallyQuoted`.
+
+```cpp
+#include "duckdb/parser/keyword_helper.hpp"
+
+static string Q(const string &identifier) {
+    return KeywordHelper::WriteOptionallyQuoted(identifier);
+}
+
+pk_join_condition += "s." + Q(primary_keys[i]) + " IS NOT DISTINCT FROM t." + Q(primary_keys[i]);
+pk_select += "COALESCE(s." + Q(pk) + ", t." + Q(pk) + ") AS " + Q(pk);
+```
+
+### [MEDIUM] No schema validation before generating the diff query
+Affected: `src/anofox_diff.cpp:82`, `src/anofox_diff.cpp:97`, `src/anofox_diff.cpp:259`, `src/anofox_diff.cpp:261`, `src/anofox_diff.cpp:277`
+
+`ValidatePrimaryKeys` and `ValidateCompareColumns` exist but are never called. As a result, missing compare columns surface as binder errors from generated SQL, while mismatched source/target schemas can silently produce surprising results because `s IS DISTINCT FROM t` compares whole row structs and the output always projects `t.* EXCLUDE (...)`. This is especially risky when the source has columns the target lacks, or the same column names have incompatible types.
+
+Suggested improvement: during bind, inspect both table schemas and validate that primary keys exist on both sides, compare columns exist on both sides, and the default “compare all” set is explicitly computed as the shared non-PK columns. Generate comparisons column-by-column instead of relying on whole-row struct comparison.
+
+```cpp
+// Pseudocode
+auto columns = ResolveComparableColumns(context, source_table, target_table, primary_keys, compare_columns);
+for (auto &col : columns) {
+    diff_predicates.push_back("s." + Q(col) + " IS DISTINCT FROM t." + Q(col));
+}
+```
+
+### [MEDIUM] `diff_hashdiff` accepts tuning parameters but ignores them
+Affected: `src/anofox_diff.cpp:382`, `src/anofox_diff.cpp:388`, `src/anofox_diff.cpp:521`, `src/anofox_diff.cpp:533`
+
+`diff_hashdiff` registers overloads with `bisection_threshold` and `bisection_factor`, but `HashDiffBindReplace` discards both values and runs the same full outer join as `diff_joindiff`. This is a correctness and performance contract issue: callers can reasonably expect those parameters to change the algorithm, memory profile, or result shape. For large tables, the name implies a hash/bisection strategy but the implementation always materializes a join plan.
+
+Suggested improvement: either implement the hash/bisection behavior, or remove/rename the overloads until supported. If retained as a compatibility shim, emit a clear binder error or warning rather than silently ignoring the parameters.
+
+### [LOW] Dead native table-function implementation is misleading
+Affected: `src/anofox_diff.cpp:22`, `src/anofox_diff.cpp:30`, `src/anofox_diff.cpp:55`, `src/anofox_diff.cpp:115`, `src/anofox_diff.cpp:162`, `src/anofox_diff.cpp:189`
+
+The native bind/local state/execution/finalize path is not registered, and the execution function would return an empty result set if it ever were used. The unused diff-type constants and validation helpers add to the impression that there is a second implementation path. This increases maintenance risk because future changes may accidentally wire up a stub.
+
+Suggested improvement: delete the unused native table-function scaffolding, or complete it and register it intentionally. Keeping only the `bind_replace` implementation would make the module’s actual behavior much easier to review.
+
+### [LOW] Registration code duplicates alias plumbing instead of using the project helper
+Affected: `src/anofox_diff.cpp:400`, `src/anofox_diff.cpp:484`, `src/anofox_diff.cpp:507`, `src/anofox_diff.cpp:561`
+
+The module manually copies `TableFunctionSet` entries into alias sets even though `anofox_function_alias.hpp` already provides `RegisterTableFunctionSetWithAlias`. The manual copy path is easy to forget when new fields are added to `TableFunction`, and it duplicates a project-level abstraction already intended for this purpose.
+
+Suggested improvement: build the function sets, then register them with `RegisterTableFunctionSetWithAlias(loader, joindiff_set, "diff_joindiff")` and the equivalent hashdiff call.
+
+## Quick wins
+- Quote all primary key and compare column identifiers with `KeywordHelper::WriteOptionallyQuoted`.
+- Replace PK-null row presence checks with side-presence marker columns.
+- Decide whether NULL primary keys are supported; if not, fail with a clear binder/runtime error.
+- Remove the unused native table-function scaffolding or add a comment stating that the module is SQL-rewrite-only.
+- Call or remove the unused validation helpers.
+- Make `diff_hashdiff` parameters effective, or reject them until the algorithm exists.

--- a/docs/reviews/modules/review_email.md
+++ b/docs/reviews/modules/review_email.md
@@ -1,0 +1,111 @@
+## Summary
+The email module has a reasonable split between scalar registration, DNS lookup, and SMTP probing, but several network-facing paths need tightening before this is safe under DuckDB workloads. The biggest correctness issue is that SMTP validation continues with fallback hosts, including loopback, after DNS failure, which can turn invalid domains into valid addresses depending on the local environment. The DNS/SMTP event loops also use `select()`/`FD_SET` without guarding against high file descriptors, which is a real undefined-behavior risk in long-running processes. Performance-wise, the scalar functions are row-oriented and allocation-heavy, with repeated vector normalization and blocking network calls per row.
+
+## Findings
+
+### [HIGH] SMTP validation can succeed after DNS failure by probing fallback hosts
+Affected: `src/anofox_email.cpp:317`, `src/anofox_email.cpp:320`, `src/anofox_email.cpp:321`, `src/anofox_email.cpp:86`, `src/anofox_email.cpp:87`, `src/anofox_email.cpp:88`
+
+When DNS lookup fails, SMTP mode builds fallback hosts from the original domain plus `localhost` and `127.0.0.1`, then continues SMTP verification. This means `email_validate('user@nonexistent.invalid', 'smtp')` can still become valid if a local SMTP server accepts the recipient, even though the recipient domain did not resolve. That is a correctness bug and also creates surprising local network probing behavior.
+
+Suggested improvement: fail SMTP validation when DNS fails, or only use fallback hosts behind an explicit test/debug option.
+
+```cpp
+if (!dns_lookup.success) {
+    dns_stage.valid = false;
+    dns_stage.reason = dns_lookup.reason.empty() ? EMAIL_REASON_DNS_FAIL : dns_lookup.reason;
+    return dns_stage;
+}
+```
+
+### [HIGH] `select()` use can corrupt memory for high-numbered sockets
+Affected: `src/anofox_email_dns.cpp:188`, `src/anofox_email_dns.cpp:192`, `src/anofox_email_dns.cpp:195`, `src/anofox_email_smtp.cpp:155`, `src/anofox_email_smtp.cpp:162`, `src/anofox_email_smtp.cpp:165`, `src/anofox_email_smtp.cpp:350`, `src/anofox_email_smtp.cpp:354`, `src/anofox_email_smtp.cpp:357`
+
+The DNS and SMTP loops put arbitrary socket descriptors into `fd_set` without checking `sock < FD_SETSIZE`. On Unix, `FD_SET` with a descriptor greater than or equal to `FD_SETSIZE` is undefined behavior and commonly writes past the bitmap. DuckDB may run inside processes with many open files, so this can surface nondeterministically.
+
+Suggested improvement: replace `select()` with `poll()`/`WSAPoll()` or c-ares’ socket/event helpers that do not depend on `FD_SETSIZE`. If retaining `select()` temporarily, reject oversized descriptors before `FD_SET`.
+
+```cpp
+#ifndef _WIN32
+if (sock < 0 || sock >= FD_SETSIZE) {
+    error_reason = "dns_socket_fd_too_large";
+    return false;
+}
+#endif
+```
+
+### [MEDIUM] Null MX records are treated as deliverable MX hosts
+Affected: `src/anofox_email_dns.cpp:121`, `src/anofox_email_dns.cpp:122`, `src/anofox_email_dns.cpp:124`, `src/anofox_email_dns.cpp:426`, `src/anofox_email_dns.cpp:434`
+
+Domains can publish a Null MX record with exchange `"."` to state that they accept no email. The current parser stores any MX exchange string and later marks DNS validation successful whenever the MX record list is non-empty. As a result, DNS mode can report a Null MX domain as valid, and SMTP mode may try to resolve/connect to `"."`.
+
+Suggested improvement: detect `"."` during MX parsing and return a specific failure reason such as `dns_null_mx`.
+
+```cpp
+if (exchange && std::string(exchange) == ".") {
+    state.status = ARES_ENODATA;
+    state.error = "dns_null_mx";
+    continue;
+}
+```
+
+### [MEDIUM] SMTP reads have no response size or line-count limits
+Affected: `src/anofox_email_smtp.cpp:607`, `src/anofox_email_smtp.cpp:611`, `src/anofox_email_smtp.cpp:646`, `src/anofox_email_smtp.cpp:670`
+
+`ReadLine` keeps appending to `buffer` until it sees `\r\n`, with no maximum line length or total response size. A peer can continuously send data without line terminators and grow memory until the process is pressured; because each successful read restarts the wait cycle, this can also run much longer than expected. Multi-line SMTP responses are similarly unbounded.
+
+Suggested improvement: enforce protocol limits for line length, total response bytes, and multi-line count.
+
+```cpp
+constexpr size_t MAX_SMTP_LINE = 8192;
+constexpr size_t MAX_SMTP_RESPONSE = 65536;
+if (buffer.size() > MAX_SMTP_RESPONSE) {
+    result.reason = "smtp_response_too_large";
+    return false;
+}
+```
+
+### [MEDIUM] SMTP total timeout is not actually enforced inside a host attempt
+Affected: `src/anofox_email_smtp.cpp:927`, `src/anofox_email_smtp.cpp:928`, `src/anofox_email_smtp.cpp:931`, `src/anofox_email_smtp.cpp:935`
+
+`SmtpClient::Verify` computes an overall deadline, but it only checks that deadline before each host. `AttemptHost` can then spend one connect timeout plus several read/write timeouts per endpoint, and a host with many resolved endpoints can exceed `MAX_TOTAL_TIMEOUT_MS` by a wide margin. This makes query latency hard to bound, especially under parallel execution.
+
+Suggested improvement: pass an absolute deadline into `AttemptHost`, `ConnectSocket`, `ReadResponse`, and `SendCommand`, and cap each wait by the remaining budget.
+
+```cpp
+auto remaining = std::chrono::duration_cast<milliseconds>(deadline - Clock::now());
+if (remaining <= milliseconds::zero()) {
+    result.reason = "smtp_overall_timeout";
+    return false;
+}
+```
+
+### [MEDIUM] Scalar execution bypasses DuckDB vectorized access patterns
+Affected: `src/anofox_email.cpp:420`, `src/anofox_email.cpp:421`, `src/anofox_email.cpp:432`, `src/anofox_email.cpp:469`, `src/anofox_email.cpp:470`, `src/anofox_email.cpp:481`
+
+Both scalar functions call `args.GetValue(0, row)` per row, convert values to `std::string`, and call `ExtractValidationMode`, which itself may call `ToUnifiedFormat` for every row. This adds avoidable allocations and repeated vector normalization, and it is especially expensive for regex-only validation where DuckDB can process flat/constant vectors much more cheaply.
+
+Suggested improvement: normalize input vectors once per chunk, use `UnifiedVectorFormat`, and cache constant/default mode outside the row loop. For regex-only paths, consider `UnaryExecutor`/`BinaryExecutor`-style execution.
+
+### [LOW] Global email options do not respect connection/database scoping
+Affected: `src/anofox_email.cpp:92`, `src/anofox_email.cpp:94`, `src/anofox_email.cpp:99`, `src/anofox_email.cpp:674`, `src/anofox_email.cpp:676`
+
+The extension registers DuckDB options, but the actual runtime state is a process-global singleton. The mutex prevents data races, but one connection changing `anofox_tab_email_regex_pattern` or SMTP settings affects other concurrent connections and databases using the same extension instance. That can produce surprising query results under parallel or embedded use.
+
+Suggested improvement: store effective options in DuckDB configuration/client context where possible, or bind a snapshot of the relevant settings into `FunctionData` so a query has stable semantics.
+
+### [LOW] DNS retry option can overflow/truncate internally
+Affected: `src/anofox_email.cpp:568`, `src/anofox_email.cpp:572`, `src/anofox_email.cpp:573`, `src/anofox_email_dns.cpp:363`
+
+`SetDnsTriesOption` allows values up to `uint32_t::max()`, returns the value as `INTEGER`, and later casts it to `int` for c-ares. Values above `INT_MAX` can wrap or become negative in those casts. The registered DuckDB option is `INTEGER`, so the practical input path may already constrain this, but the validation and internal types disagree.
+
+Suggested improvement: cap tries to a small documented maximum that fits `int`, such as `1..10`, and use the same bound everywhere.
+
+## Quick wins
+- Remove `localhost` and `127.0.0.1` from SMTP fallback behavior.
+- Add explicit Null MX handling in DNS parsing.
+- Replace or guard all `FD_SET` calls.
+- Hoist `ToUnifiedFormat` calls out of per-row loops.
+- Add maximum SMTP line/response sizes.
+- Use RAII wrappers for sockets and c-ares channels to avoid leaks on future exception paths.
+- Mark DNS/SMTP scalar overloads with a less aggressive stability classification than `CONSISTENT`.

--- a/docs/reviews/modules/review_metric.md
+++ b/docs/reviews/modules/review_metric.md
@@ -1,0 +1,106 @@
+## Summary
+The metric module has useful coverage for simple SQL-rewritten checks and a C++ isolation forest path, but it is currently fragile around SQL construction, edge cases, and API consistency. The highest-risk issue is that user-provided table and column names are interpolated directly into SQL without identifier/literal escaping, which breaks valid names and can change the generated query. DBSCAN metric functions are especially concerning because they do not call the existing DBSCAN implementation and instead return placeholder results. The isolation forest path is functionally more complete, but it materializes all input rows and scores in memory and leaves several validation and API-default paths inconsistent with the advertised interface.
+
+## Findings
+
+### [HIGH] User input is interpolated into generated SQL without escaping
+Affected: `src/anofox_metric.cpp:56`, `src/anofox_metric.cpp:71`, `src/anofox_metric.cpp:98`, `src/anofox_metric.cpp:111`, `src/anofox_metric.cpp:153`, `src/anofox_metric.cpp:195`, `src/anofox_metric.cpp:215`, `src/anofox_metric.cpp:221`, `src/anofox_metric.cpp:255`, `src/anofox_metric.cpp:653`, `src/anofox_metric.cpp:699`, `src/anofox_metric.cpp:1265`
+
+Table names, column names, schema-check required columns, interval/timestamp strings, and `query_table('...')` arguments are assembled by string concatenation. A table name containing `'`, a column name containing `"`, or a required column containing `'` will either fail to parse or change the generated SQL. The same issue applies to schema checks, where `table_name` is also embedded as a string literal and not schema-qualified.
+
+Suggested improvement: centralize SQL quoting helpers and use them everywhere generated SQL is unavoidable.
+
+```cpp
+static string QuoteLiteral(const string &s) {
+	return "'" + StringUtil::Replace(s, "'", "''") + "'";
+}
+
+static string QuoteIdentifier(const string &s) {
+	return "\"" + StringUtil::Replace(s, "\"", "\"\"") + "\"";
+}
+
+static string QueryTableRef(const string &table_name) {
+	return "query_table(" + QuoteLiteral(table_name) + ")";
+}
+```
+
+Then build column references as `QuoteIdentifier(column_name)` and list literals as `QuoteLiteral(required_col)` rather than manually adding quotes.
+
+### [HIGH] DBSCAN functions return placeholder SQL instead of DBSCAN results
+Affected: `src/anofox_metric.cpp:1242`, `src/anofox_metric.cpp:1267`, `src/anofox_metric.cpp:1273`, `src/anofox_metric.cpp:1276`, `src/anofox_metric.cpp:1290`, `src/anofox_metric.cpp:1337`, `src/anofox_metric.cpp:1343`, `src/anofox_metric.cpp:1345`
+
+`anofox_tab_dbscan` and `anofox_tab_dbscan_mv` include `anofox_dbscan.hpp`, but the registered functions are `bind_replace` SQL stubs. Univariate clusters always return `cluster_id = 0`, `point_type = 'CORE'`, fixed neighbor/anomaly values, and summary mode derives `cluster_count` from `COUNT(DISTINCT value)` plus a hard-coded noise predicate. Multivariate summary is even more detached from input data, returning constants like `cluster_count = 3`, `noise_count = 1`, and `total_count = 10`.
+
+Suggested improvement: implement DBSCAN as a real table function, analogous to `IsolationForestExecute`, using `DBSCAN::Fit`, `GetResults`, `GetClusterCount`, `GetNoiseCount`, `GetLargestClusterSize`, and `ComputeAnomalyScores`. Until then, do not expose these functions as production metrics or rename them clearly as test/demo placeholders.
+
+### [MEDIUM] Optional defaults are coded but not actually registered
+Affected: `src/anofox_metric.cpp:414`, `src/anofox_metric.cpp:508`, `src/anofox_metric.cpp:1155`, `src/anofox_metric.cpp:1217`, `src/anofox_metric.cpp:1434`, `src/anofox_metric.cpp:1439`, `src/anofox_metric.cpp:1467`, `src/anofox_metric.cpp:1472`, `src/anofox_metric.cpp:1569`
+
+The bind functions contain defaults and error messages say isolation forest requires “at least 2 arguments”, while comments advertise calls like `n_trees=100`, `sample_size=256`, and so on. Registration only adds fixed 6- and 7-argument overloads for univariate isolation forest, fixed 6- through 13-argument overloads for multivariate isolation forest, and a fixed 5-argument overload for DBSCAN. Calls such as `isolation_forest('t', 'x')` or `dbscan('t', 'x')` will not reach the bind functions despite defaults being present.
+
+Suggested improvement: either register all intended arities or remove the unreachable defaulting code/comments. Prefer one consistent mechanism, for example table function sets covering 2..7 arities for isolation forest and 2..5 arities for DBSCAN.
+
+### [MEDIUM] Empty and degenerate aggregate inputs produce inconsistent or missing metric rows
+Affected: `src/anofox_metric.cpp:70`, `src/anofox_metric.cpp:73`, `src/anofox_metric.cpp:109`, `src/anofox_metric.cpp:114`, `src/anofox_metric.cpp:121`, `src/anofox_metric.cpp:130`, `src/anofox_metric.cpp:151`, `src/anofox_metric.cpp:229`
+
+Several SQL metrics divide by `COUNT(*)` or rely on cross joins with derived data without guarding zero-row or zero-variance cases. `null_rate` on an empty table computes `0 / 0`, yielding a NULL rate and likely a misleading fail/message. `zscore` can return no row at all for an empty/non-null-free input because `stats` is cross joined with an empty `with_zscore`; for a single value or constant column, `STDDEV` is NULL/zero and z-score expressions become NULL/undefined. `freshness` on an empty table produces NULL timestamps and a NULL message.
+
+Suggested improvement: make every metric return exactly one row with explicit empty-input semantics. Use `NULLIF(total_count, 0)`, `COALESCE`, and special-case `stddev IS NULL OR stddev = 0`.
+
+```sql
+CASE
+  WHEN total_count = 0 THEN 'fail'
+  WHEN stddev IS NULL OR stddev = 0 THEN 'pass'
+  WHEN outlier_count = 0 THEN 'pass'
+  ELSE 'fail'
+END
+```
+
+### [MEDIUM] Numeric parameter validation misses NaN and signed conversion edge cases
+Affected: `src/anofox_metric.cpp:415`, `src/anofox_metric.cpp:416`, `src/anofox_metric.cpp:417`, `src/anofox_metric.cpp:424`, `src/anofox_metric.cpp:509`, `src/anofox_metric.cpp:510`, `src/anofox_metric.cpp:511`, `src/anofox_metric.cpp:518`, `src/anofox_metric.cpp:581`, `src/anofox_metric.cpp:1253`, `src/anofox_metric.cpp:1254`, `src/anofox_metric.cpp:1324`, `src/anofox_metric.cpp:1325`
+
+Several signed `BIGINT` inputs are read directly into `size_t`, so negative values wrap before validation. Some cases are later caught by upper-bound checks, but `min_pts = -1` becomes a huge `size_t` and passes `min_pts < 1`. Floating-point checks also do not reject `NaN`: comparisons like `eps <= 0.0` and `contamination > 0.5` are false for NaN, allowing invalid parameters into SQL generation or algorithm code.
+
+Suggested improvement: read integer parameters into `int64_t`, validate signed ranges first, then cast. Reject non-finite doubles explicitly.
+
+```cpp
+auto min_pts_i = input.inputs[3].GetValue<int64_t>();
+if (min_pts_i < 1) {
+	throw BinderException("min_pts must be >= 1");
+}
+auto min_pts = static_cast<size_t>(min_pts_i);
+
+if (!std::isfinite(eps) || eps <= 0.0) {
+	throw BinderException("eps must be finite and > 0.0");
+}
+```
+
+### [MEDIUM] Isolation forest materializes all data and results before producing output
+Affected: `src/anofox_metric.cpp:701`, `src/anofox_metric.cpp:743`, `src/anofox_metric.cpp:801`, `src/anofox_metric.cpp:808`, `src/anofox_metric.cpp:828`, `src/anofox_metric.cpp:866`, `src/anofox_metric.cpp:872`
+
+The isolation forest table function fetches the entire source query, copies each cell through `DataChunk::GetValue`, stores the full feature matrix, computes a full scores vector, and then stores a second full `state.results` vector. This is costly for large tables and especially expensive for categorical data due to repeated `Value` materialization and `ToString()` conversions. The algorithm may require a batch fit, but output does not need to duplicate every score in a separate result struct.
+
+Suggested improvement: reserve approximate storage where possible, avoid per-cell `GetValue` in favor of vector access APIs, and for scores mode stream directly from the scores/data arrays after fitting instead of copying into `state.results`. If full materialization is unavoidable, document it and consider an explicit input-size guard or memory error with a clear message.
+
+### [LOW] Invalid `output_mode` silently falls back to summary
+Affected: `src/anofox_metric.cpp:440`, `src/anofox_metric.cpp:599`, `src/anofox_metric.cpp:891`, `src/anofox_metric.cpp:1173`, `src/anofox_metric.cpp:1235`, `src/anofox_metric.cpp:1268`, `src/anofox_metric.cpp:1338`
+
+Any `output_mode` other than exactly `"scores"` for isolation forest or `"clusters"` for DBSCAN is treated as summary. Typos like `'score'`, `'cluster'`, or casing differences are accepted and change behavior silently.
+
+Suggested improvement: normalize the mode once and reject unknown values with a binder error. For isolation forest: allow only `"summary"` and `"scores"`. For DBSCAN: allow only `"summary"` and `"clusters"`.
+
+### [LOW] Dead legacy isolation-forest SQL code remains in the module
+Affected: `src/anofox_metric.cpp:944`, `src/anofox_metric.cpp:948`, `src/anofox_metric.cpp:986`, `src/anofox_metric.cpp:1022`, `src/anofox_metric.cpp:1085`, `src/anofox_metric.cpp:1147`, `src/anofox_metric.cpp:1181`
+
+The file keeps deprecated SQL-generation functions and bind-replace functions for isolation forest, but registration uses the C++ table functions at `src/anofox_metric.cpp:1437` and `src/anofox_metric.cpp:1470`. The stale code includes placeholder anomaly logic and duplicates parsing/validation paths, which makes the module harder to review and increases the chance a future registration change accidentally exposes incorrect behavior.
+
+Suggested improvement: remove the unused legacy functions or move them to tests/docs if they are intentionally retained as historical reference.
+
+## Quick wins
+- Add `QuoteLiteral`, `QuoteIdentifier`, and `QueryTableRef` helpers and replace all hand-built quote fragments.
+- Validate `output_mode` explicitly in every bind path.
+- Read signed integer parameters into `int64_t`, validate, then cast to `size_t`.
+- Reject `NaN` and infinite values for `eps`, `contamination`, thresholds, and probabilities.
+- Register the advertised shorter overloads or remove the unreachable defaulting code and comments.
+- Add sqllogictests for quoted identifiers, apostrophes in names, empty tables, all-NULL columns, constant z-score input, `NaN` parameters, negative `min_pts`, and invalid output modes.
+- Replace DBSCAN placeholder SQL with a real table-function implementation or temporarily mark the exposed functions as unsupported.

--- a/docs/reviews/modules/review_money.md
+++ b/docs/reviews/modules/review_money.md
@@ -1,0 +1,119 @@
+## Summary
+The money module has a compact implementation and follows DuckDB’s chunked callback shape, but several correctness contracts are under-specified or broken. The largest risks are exactness of monetary arithmetic, incorrect cents conversion, unsynchronized singleton initialization, and registering fallible functions as non-fallible. NULL handling is mostly covered for top-level SQL NULLs, but child-field NULLs inside `STRUCT` values can produce non-NULL money structs with invalid fields. Performance is acceptable for small vectors, but the current loops do avoidable per-row string copies and repeated struct entry lookups.
+
+## Findings
+
+### [HIGH] Currency registry initialization is not thread-safe
+Affected files: `src/anofox_money_currency.cpp:7`, `src/anofox_money_currency.cpp:9`, `src/anofox_money_currency.cpp:15`, `src/include/anofox_money_currency.hpp:51`, `src/include/anofox_money_currency.hpp:52`
+
+`GetInstance()` uses a thread-safe function-local static, but then performs a separate unsynchronized `if (!instance.initialized) instance.Initialize()` check. Under DuckDB parallel execution, two threads can enter this block on first use, concurrently mutate `currencies`, and race on the plain `bool initialized`. That is undefined behavior and can corrupt the registry.
+
+Suggested improvement: initialize the registry in the constructor or use `std::call_once`.
+
+```cpp
+class CurrencyRegistry {
+private:
+    CurrencyRegistry() {
+        LoadCurrencies();
+    }
+    case_insensitive_map_t<unique_ptr<CurrencyInfo>> currencies;
+};
+
+CurrencyRegistry &CurrencyRegistry::GetInstance() {
+    static CurrencyRegistry instance;
+    return instance;
+}
+```
+
+### [HIGH] `money_from_cents` returns cents as units
+Affected files: `src/anofox_money.cpp:70`, `src/anofox_money.cpp:101`, `src/anofox_money.cpp:106`, `src/anofox_money.cpp:108`, `src/include/anofox_money_currency.hpp:18`
+
+`anofox_money_from_cents(10050, 'USD')` returns `10050.0 USD`, not `100.50 USD`. The code even fetches `subunit_to_unit` but does not use it. This makes the function name and normal monetary semantics wrong for every currency with subunits, and it also mishandles zero-decimal currencies such as JPY.
+
+Suggested improvement: divide by `currency->subunit_to_unit`, and reject invalid or zero denominators defensively.
+
+```cpp
+const auto divisor = currency->subunit_to_unit;
+if (divisor <= 0) {
+    throw InternalException("Invalid subunit_to_unit for currency: %s", currency_code.c_str());
+}
+double amount = static_cast<double>(cents_values[cents_idx]) / static_cast<double>(divisor);
+```
+
+### [HIGH] Monetary values are stored and computed as `DOUBLE`
+Affected files: `src/anofox_money.cpp:19`, `src/anofox_money.cpp:21`, `src/anofox_money.cpp:364`, `src/anofox_money.cpp:378`, `src/anofox_money.cpp:415`, `src/anofox_money.cpp:630`, `src/include/anofox_money.hpp:18`, `src/include/anofox_money.hpp:45`
+
+The module models `amount` as `DOUBLE`, which makes common money operations inexact and allows `NaN`, infinities, and silent overflow to infinities. Values from cents above `2^53` also lose integer precision when converted to double. This is especially risky because the module exposes arithmetic helpers and formatting, so users will reasonably expect stable cent-level behavior.
+
+Suggested improvement: store minor units as `BIGINT` or use DuckDB `DECIMAL`, with explicit overflow checks for add/subtract/multiply. For a decimal representation, make the struct type explicit:
+
+```cpp
+children.push_back(make_pair("amount", LogicalType::DECIMAL(18, 2)));
+```
+
+If using minor units, expose formatting and amount extraction through controlled conversion rather than storing approximate floating point values.
+
+### [MEDIUM] Fallible scalar functions are registered as `CANNOT_ERROR`
+Affected files: `src/anofox_money.cpp:57`, `src/anofox_money.cpp:97`, `src/anofox_money.cpp:166`, `src/anofox_money.cpp:220`, `src/include/anofox_money.hpp:154`, `src/anofox_money.cpp:619`
+
+DuckDB scalar functions default to `FunctionErrors::CANNOT_ERROR`, but this module throws `InvalidInputException` for invalid currencies and currency mismatches. `BoundFunctionExpression::CanThrow()` relies on the function error mode, so the planner can treat these expressions as non-throwing even though they can fail at runtime.
+
+Suggested improvement: call `SetFallible()` on functions that can throw before registration, including aliases via the existing alias helper.
+
+```cpp
+money_func.SetFallible();
+currency_symbol_func.SetFallible();
+money_add_func.SetFallible();
+```
+
+### [MEDIUM] Child-field NULLs produce valid parent money structs
+Affected files: `src/include/anofox_money.hpp:144`, `src/include/anofox_money.hpp:148`, `src/anofox_money.cpp:343`, `src/anofox_money.cpp:408`
+
+For `STRUCT` results, invalid rows only mark child vectors invalid. The parent result vector remains valid, so a row can become a non-NULL money struct whose `amount` and `currency` fields are NULL. That differs from normal SQL NULL propagation and can leak through `money_amount`, `money_currency`, or comparisons when users pass manually constructed structs with NULL children.
+
+Suggested improvement: define one invariant. If invalid money means SQL NULL, set the parent struct validity too:
+
+```cpp
+FlatVector::SetNull(result, i, true);
+builder.amount_validity.SetInvalid(i);
+builder.currency_validity.SetInvalid(i);
+```
+
+If partially NULL money structs are valid by design, then accessors and predicates should document and consistently handle that model.
+
+### [MEDIUM] Currency normalization is inconsistent
+Affected files: `src/anofox_money.cpp:54`, `src/anofox_money.cpp:57`, `src/anofox_money.cpp:61`, `src/include/anofox_money.hpp:151`, `src/include/anofox_money.hpp:154`
+
+The registry lookup is case-insensitive, so `anofox_tab_money(100, 'usd')` is accepted, but the original input string is stored. Later operations compare stored strings case-sensitively, so `money_add(money(1, 'usd'), money(1, 'USD'))` throws even though both resolved to the same currency.
+
+Suggested improvement: canonicalize currency codes at construction time by storing `currency->iso_code`, and use canonical codes for all comparisons and formatting.
+
+```cpp
+auto currency = registry.GetCurrency(currency_code);
+if (!currency) {
+    throw InvalidInputException("Invalid currency code: %s", currency_code.c_str());
+}
+SetMoneyResult(builder, i, amount, currency->iso_code, result);
+```
+
+### [LOW] Formatting ignores currency metadata and special floating-point values
+Affected files: `src/anofox_money.cpp:227`, `src/anofox_money.cpp:230`, `src/anofox_money.cpp:248`, `src/anofox_money.cpp:253`, `src/include/anofox_money_currency.hpp:18`, `src/include/anofox_money_currency.hpp:21`
+
+`money_format` always prints two decimals, does not use `subunit_to_unit` to determine scale, never inserts `thousands_separator`, and only swaps the first decimal mark character. It will format JPY as `¥1000.00` and can emit strings for `nan`/`inf` values if such amounts enter the struct.
+
+Suggested improvement: derive scale from currency metadata, reject non-finite amounts if `DOUBLE` remains, and centralize formatting in a helper so symbol/code/long styles share validation.
+
+### [LOW] Per-row string copies and repeated vector lookups add avoidable overhead
+Affected files: `src/include/anofox_money.hpp:71`, `src/include/anofox_money.hpp:75`, `src/include/anofox_money.hpp:96`, `src/include/anofox_money.hpp:151`, `src/anofox_money.cpp:153`, `src/anofox_money.cpp:169`, `src/anofox_money.cpp:365`
+
+Most loops call `GetString()` per row, copy into `std::string`, and sometimes call `StructVector::GetEntries(result)` inside the row loop or helper. For DuckDB vectors, this is unnecessary overhead, especially for dictionary/constant vectors with repeated currency codes.
+
+Suggested improvement: cache result child vector references outside loops and pass `string_t` or `string_view` where possible. For simple extraction and predicates, consider DuckDB’s `UnaryExecutor`, `BinaryExecutor`, or `GenericExecutor` patterns to preserve constant/dictionary vector optimizations.
+
+## Quick wins
+- Make `CurrencyRegistry` initialize in its constructor and remove the mutable `initialized` flag.
+- Fix `money_from_cents` to divide by `subunit_to_unit`.
+- Call `SetFallible()` on every function that can throw.
+- Canonicalize accepted currency codes to `CurrencyInfo::iso_code` before storing them in money structs.
+- Add tests for `money('usd') + money('USD')`, invalid currency errors, child-field NULL structs, `NaN`/`Inf`, and large cent values.
+- Move repeated `FlatVector::GetData` and `StructVector::GetEntries` calls out of row lambdas and loops.

--- a/docs/reviews/modules/review_ner.md
+++ b/docs/reviews/modules/review_ner.md
@@ -1,0 +1,102 @@
+## Summary
+The NER module has a workable high-level shape, but the singleton model manager is not safe under DuckDB parallel execution. The most serious risks are shared mutable tokenizer/OpenVINO inference state and cache races that can produce data races, corrupted offsets, undefined behavior, or wrong results. Model configuration is also only partially wired: advertised multilingual/model-selection support does not actually download or load distinct model assets reliably. Performance is acceptable for small inputs, but the current implementation leaves significant row-by-row allocation and tokenization overhead on the hot path.
+
+## Findings
+
+### HIGH shared inference and tokenizer state is not thread-safe
+Affected: `src/anofox_ner.cpp:701`, `src/anofox_ner.cpp:722`, `src/anofox_ner.cpp:727`, `src/anofox_ner.cpp:757`, `src/anofox_ner.cpp:761`, `src/anofox_ner.cpp:1051`, `src/anofox_ner.cpp:1056`, `src/anofox_ner.cpp:1085`, `src/anofox_ner.cpp:1089`, `src/include/anofox_ner.hpp:198`, `src/include/anofox_ner.hpp:199`, `src/include/anofox_ner.hpp:348`, `src/include/anofox_ner.hpp:352`
+
+`NERModelManager` is a process-wide singleton, and DuckDB scalar/table function execution can call into it from multiple worker threads. `ExtractEntities` and `ExtractEntitiesBatch` mutate shared `tokenizer_` state via `Encode`, then read `GetOffsets`, while another thread can clear and replace `offsets_` before post-processing. The same functions also reuse one shared `ov::InferRequest`; OpenVINO infer requests are stateful objects and should not be concurrently `set_tensor`/`infer`-ed from multiple threads.
+
+Suggested improvement: make tokenization output offsets by value and use per-call/per-thread inference requests, or guard the whole tokenize/infer path with a mutex if correctness is preferred over throughput.
+
+```cpp
+struct TokenizedInput {
+    std::vector<int64_t> ids;
+    std::vector<std::pair<size_t, size_t>> offsets;
+};
+
+virtual TokenizedInput EncodeWithOffsets(std::string_view text) const = 0;
+
+// Prefer thread-local/request-local infer request:
+auto request = compiled_model_->create_infer_request();
+request.set_tensor("input_ids", input_ids_tensor);
+request.set_tensor("attention_mask", attention_mask_tensor);
+request.infer();
+```
+
+### HIGH LRU cache has data races and capacity-zero undefined behavior
+Affected: `src/include/anofox_ner.hpp:61`, `src/include/anofox_ner.hpp:73`, `src/include/anofox_ner.hpp:74`, `src/include/anofox_ner.hpp:104`, `src/include/anofox_ner.hpp:109`, `src/anofox_ner.cpp:708`, `src/anofox_ner.cpp:772`, `src/anofox_ner.cpp:1013`, `src/anofox_ner.cpp:1100`, `src/anofox_ner.cpp:1139`
+
+`LRUCache::Capacity()` reads `capacity_` without locking while `SetCapacity()` writes it under a mutex, which is a C++ data race. The call sites check `Capacity() > 0` before `Put`, but that check is outside the cache lock; if another thread sets capacity to zero between the check and `Put`, `Put` can execute `lru_list_.back()` on an empty list because `cache_.size() >= capacity_` is true when capacity is zero. This is undefined behavior and can crash when users change `anofox_ner_cache_size` concurrently with queries.
+
+Suggested improvement: make `Capacity()` lock or make `capacity_` atomic, and make `Put` handle zero capacity internally while holding the mutex.
+
+```cpp
+void Put(const Key &key, const Value &value) {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (capacity_ == 0) {
+        return;
+    }
+    ...
+}
+```
+
+### MEDIUM model selection is advertised but not actually implemented end-to-end
+Affected: `src/anofox_ner.cpp:73`, `src/anofox_ner.cpp:87`, `src/anofox_ner.cpp:437`, `src/anofox_ner.cpp:546`, `src/anofox_ner.cpp:596`, `src/anofox_ner.cpp:613`, `src/anofox_ner.cpp:1142`, `src/anofox_ner.cpp:1155`, `src/anofox_ner.cpp:1160`
+
+The module exposes `anofox_ner_model` and metadata for `xlm-roberta-multi`, but `GetModelPath()` always resolves to the same `model_quantized.onnx`, `DownloadModel()` always uses hard-coded DistilBERT URLs, and `EnsureInitialized()` returns immediately once any model is loaded. Setting the option after load logs “reload required” but there is no reload path, and setting it before load still downloads the DistilBERT assets while selecting tokenizer behavior from the configured metadata. This can lead to mismatched tokenizer/model pairs or a setting that silently has no effect.
+
+Suggested improvement: derive model/tokenizer paths and download URLs from `ModelMetadata`, store each model in a distinct directory, and either reject changing the option after load or implement an atomic reload that clears the cache and replaces model/tokenizer state under a lock.
+
+### MEDIUM status and path fields are read without synchronization
+Affected: `src/anofox_ner.cpp:433`, `src/anofox_ner.cpp:437`, `src/anofox_ner.cpp:500`, `src/anofox_ner.cpp:506`, `src/anofox_ner.cpp:631`, `src/anofox_ner.cpp:697`, `src/anofox_ner.cpp:576`, `src/anofox_pii.cpp:2522`, `src/anofox_pii.cpp:2540`, `src/anofox_pii.cpp:2546`
+
+`status_` is atomic, but related fields such as `status_message_`, `model_path_`, and `current_model_name_` are plain strings accessed from status table functions and query paths while model loading/download updates them. Concurrent reads/writes of `std::string` are data races. `anofox_ner_status()` can therefore observe torn or invalid string state while another thread initializes the model.
+
+Suggested improvement: protect status metadata with a mutex, or publish an immutable status snapshot object after each update.
+
+### MEDIUM long inputs are not bounded to model limits
+Affected: `src/anofox_ner.cpp:722`, `src/anofox_ner.cpp:733`, `src/anofox_ner.cpp:745`, `src/anofox_ner.cpp:767`, `src/anofox_ner.cpp:1051`, `src/anofox_ner.cpp:1061`, `src/anofox_ner.cpp:1073`, `src/anofox_ner.cpp:1095`
+
+The tokenizer can emit arbitrary-length sequences, and the code reshapes the OpenVINO input to that length. BERT-style NER models usually have a fixed maximum positional embedding length, commonly 512 tokens; longer text may fail inference, return empty results after an exception, or allocate very large intermediate tensors/vectors. The code also assumes the output buffer contains exactly `seq_length * NUM_LABELS` floats without checking the actual output shape.
+
+Suggested improvement: enforce the model’s maximum sequence length, preferably with a sliding-window strategy if full-text coverage is needed, and validate the output tensor shape before copying logits.
+
+```cpp
+constexpr size_t MAX_SEQ_LENGTH = 512;
+if (input_ids.size() > MAX_SEQ_LENGTH) {
+    input_ids.resize(MAX_SEQ_LENGTH);
+    offsets.resize(MAX_SEQ_LENGTH);
+    input_ids.back() = SEP_TOKEN_ID;
+}
+```
+
+### MEDIUM tokenizer implementation does not match tokenizer.json semantics
+Affected: `src/anofox_ner.cpp:150`, `src/anofox_ner.cpp:212`, `src/anofox_ner.cpp:249`, `src/anofox_ner.cpp:263`, `src/anofox_ner.cpp:287`, `src/anofox_ner.cpp:301`
+
+`WordPieceTokenizer::Load` only reads `model.vocab`; it ignores the normalizer, pre-tokenizer, post-processor, unknown-token policy, and truncation settings from `tokenizer.json`. The hand-written tokenizer splits on bytes with `std::isspace`/`std::ispunct`, so UTF-8 punctuation and non-ASCII text can be split into invalid byte fragments and mapped poorly to offsets. This is not just a quality issue: downstream PII spans can become incorrect when token offsets do not correspond to model tokenization.
+
+Suggested improvement: use a tokenizer implementation that consumes the full HuggingFace tokenizer configuration, or explicitly constrain this module to ASCII/English and document/test the offset behavior. If keeping this implementation, return offsets as part of tokenization and add UTF-8 aware pre-tokenization.
+
+### LOW `DownloadModel` uses C resources manually and can leave partial asset sets
+Affected: `src/anofox_ner.cpp:633`, `src/anofox_ner.cpp:641`, `src/anofox_ner.cpp:665`, `src/anofox_ner.cpp:666`, `src/anofox_ner.cpp:677`
+
+The download path uses raw `FILE*` and `CURL*` with manual cleanup. The current control flow closes both on the visible paths, but RAII would make this safer as the function grows. Also, tokenizer and model files are written directly to their final paths; a failure after the tokenizer download but before model completion can leave a stale tokenizer paired with a missing or later-replaced model.
+
+Suggested improvement: wrap `FILE*`/`CURL*` in `unique_ptr` with custom deleters and download to temporary files before atomically renaming completed assets.
+
+### LOW duplicated inference setup increases maintenance risk
+Affected: `src/anofox_ner.cpp:716`, `src/anofox_ner.cpp:744`, `src/anofox_ner.cpp:769`, `src/anofox_ner.cpp:1046`, `src/anofox_ner.cpp:1072`, `src/anofox_ner.cpp:1097`
+
+`ExtractEntities` and `ExtractEntitiesBatch` duplicate nearly the same tokenization, padding, tensor creation, inference, logits copy, post-process, and cache-store logic. This makes concurrency fixes, shape checks, max-length handling, and output validation easy to apply in one path but miss in the other. The `max_batch_size` parameter is also currently unused, so the batch API name overstates what it does.
+
+Suggested improvement: factor a private `RunSingleInference(text)` helper that returns `std::vector<NEREntity>`, and have both single and batch paths share it. Either remove `max_batch_size` or implement true batched inference.
+
+## Quick wins
+- Add a mutex around `ExtractEntities` and `ExtractEntitiesBatch` immediately to stop shared tokenizer/infer-request races while a better per-thread request design is built.
+- Fix `LRUCache::Put` to return when `capacity_ == 0`, and make `Capacity()` synchronized.
+- Add an early `if (text.empty()) return {};` in `ExtractEntities` to match the batch path and avoid unnecessary inference.
+- Validate output tensor shape before constructing `std::vector<float>` from `logits_data`.
+- Replace hard-coded download URLs with `ModelMetadata` fields, or remove the unsupported multilingual option until reload and asset management are implemented.
+- Factor the duplicated single-row inference code into one private helper before adding truncation, shape checks, or per-thread request handling.

--- a/docs/reviews/modules/review_outlier.md
+++ b/docs/reviews/modules/review_outlier.md
@@ -1,0 +1,142 @@
+## Summary
+The outlier module has useful algorithm coverage, but several correctness issues can produce wrong clusters, wrong row ids, duplicate outlier rows, or stale isolation-forest models. The biggest risks are in DBSCAN’s cluster expansion semantics and the table-function SQL/data-loading path for `outlier_tree`. The implementations also rely heavily on full materialization, `Value` extraction, repeated vector allocations, and repeated statistics recomputation, which will not scale well on larger DuckDB tables. There are also a few places where unchecked casts or narrow integer storage can turn valid SQL inputs or wide data into undefined or misleading behavior.
+
+## Findings
+
+### [HIGH] DBSCAN misclassifies core and border points
+Affected file:line references: `src/anofox_dbscan.cpp:50`, `src/anofox_dbscan.cpp:62`, `src/anofox_dbscan.cpp:97`, `src/anofox_dbscan.cpp:105`, `src/anofox_dbscan.cpp:161`
+
+`RegionQuery` excludes the point itself, but `Fit` and `ExpandCluster` compare `neighbors.size()` directly to `min_pts_`. Standard DBSCAN defines `minPts` as including the query point, so this implementation is effectively one point stricter. More importantly, `ExpandCluster` only assigns points when `!visited[current_idx]`; a point previously marked `NOISE` can later be reached from a core point but will be skipped and remain noise instead of becoming a border point.
+
+Suggested improvement: either include `point_idx` in `RegionQuery`, or compare `neighbors.size() + 1 >= min_pts_`, and always attach reachable noise/unassigned points to the cluster before the visited check.
+
+```cpp
+if (results_[current_idx].cluster_id == -1) {
+    results_[current_idx].cluster_id = cluster_id;
+}
+if (visited[current_idx]) {
+    if (point_types[current_idx] == PointType::NOISE) {
+        point_types[current_idx] = PointType::BORDER;
+        results_[current_idx].point_type = PointType::BORDER;
+    }
+    continue;
+}
+```
+
+### [HIGH] `outlier_tree` builds SQL by concatenating unescaped user input
+Affected file:line references: `src/anofox_outlier_tree.cpp:795`, `src/anofox_outlier_tree.cpp:807`, `src/anofox_outlier_tree.cpp:909`, `src/anofox_outlier_tree.cpp:912`
+
+The table name and column names are interpolated directly into a SQL string. Double quotes in column names and single quotes in table names are not escaped, so valid DuckDB identifiers can fail, and malicious input can alter the generated query. This is especially risky because the function opens a new `Connection` and runs the generated query at execution time.
+
+Suggested improvement: avoid query construction where possible by using `bind_replace` and DuckDB’s parser/binder structures. If this function must build SQL, centralize identifier/literal quoting and escape embedded quotes.
+
+```cpp
+static string QuoteIdentifier(const string &s) {
+    return "\"" + StringUtil::Replace(s, "\"", "\"\"") + "\"";
+}
+static string QuoteLiteral(const string &s) {
+    return "'" + StringUtil::Replace(s, "'", "''") + "'";
+}
+```
+
+### [HIGH] Negative integer parameters wrap to huge `size_t` values before validation
+Affected file:line references: `src/anofox_outlier_tree.cpp:823`, `src/anofox_outlier_tree.cpp:825`, `src/anofox_outlier_tree.cpp:826`, `src/include/anofox_outlier_tree.hpp:145`
+
+`max_depth`, `min_size_numeric`, and `min_size_categ` are read as `int64_t` but immediately assigned to `size_t`. A negative SQL value such as `-1` becomes a very large unsigned value before the `max_depth < 1` validation runs, so it passes validation and can cause excessive recursion limits or make minimum-size checks impossible to satisfy.
+
+Suggested improvement: validate signed temporaries first, then cast.
+
+```cpp
+auto depth_i = input.inputs[3].GetValue<int64_t>();
+if (depth_i < 1 || depth_i > 1024) {
+    throw BinderException("max_depth must be between 1 and 1024");
+}
+auto max_depth = static_cast<size_t>(depth_i);
+```
+
+### [MEDIUM] Reported `row_id` values do not match source table rows after NULL filtering
+Affected file:line references: `src/anofox_outlier_tree.cpp:941`, `src/anofox_outlier_tree.cpp:953`, `src/anofox_outlier_tree.cpp:970`, `src/anofox_outlier_tree.cpp:990`
+
+Rows containing any NULL are skipped during materialization, and `OutlierExplanation::row_idx` is based on the compacted, filtered dataset. The output then reports `row_idx + 1`, which is not the original source row number whenever earlier rows were skipped. `total_rows` also reports the filtered row count, not the scanned table count, which may surprise users.
+
+Suggested improvement: preserve source row ids while scanning and store/report those ids in `OutlierExplanation`, or make the output column explicitly named as a filtered-row ordinal. Prefer adding `row_number() over ()` to the source query and carrying that through the model input.
+
+### [MEDIUM] Isolation trees append to old nodes when models are refit
+Affected file:line references: `src/anofox_isolation_forest.cpp:385`, `src/anofox_isolation_forest.cpp:517`, `src/anofox_isolation_forest.cpp:955`, `src/anofox_isolation_forest.cpp:1176`, `src/include/anofox_isolation_forest.hpp:171`
+
+`IsolationTree::BuildTree` and `BuildTreeMixed` append nodes without clearing `nodes_`, and `root_idx_` remains `0`. `IsolationForest::Fit`/`FitMixed` use `trees_.resize(n_trees_)`, which reuses existing `IsolationTree` instances when fitting the same forest object again. A second fit can therefore score through the stale first tree rooted at node 0.
+
+Suggested improvement: clear tree state at the start of each build, or make `Fit` replace `trees_` with fresh instances.
+
+```cpp
+void IsolationTree::BuildTree(...) {
+    nodes_.clear();
+    root_idx_ = 0;
+    BuildTreeRecursive(...);
+}
+```
+
+### [MEDIUM] Categorical right-branch explanations are logically wrong
+Affected file:line references: `src/anofox_outlier_tree.cpp:154`, `src/anofox_outlier_tree.cpp:157`, `src/include/anofox_outlier_tree.hpp:40`, `src/include/anofox_outlier_tree.hpp:56`
+
+For numeric splits, the right branch flips `is_less_than`; for categorical splits, the right branch keeps the same `left_categories` and has no negation flag. As a result, outliers found in the right branch can be explained as `column IN (...)` even though that branch actually means `column NOT IN (...)`.
+
+Suggested improvement: add an operator/negation field to `SplitCondition` for categorical conditions and use it in `ToString`, `ToJSON`, and right-branch construction.
+
+### [MEDIUM] Duplicate outlier suppression does not replace worse existing results
+Affected file:line references: `src/anofox_outlier_tree.cpp:239`, `src/anofox_outlier_tree.cpp:314`, `src/anofox_outlier_tree.cpp:736`
+
+`ShouldSkipDuplicateOutlier` returns `false` when the new score is more extreme than an existing row/column result, but it does not remove or update the existing result. The caller then appends the new outlier, leaving duplicate row/column findings and inflating summary counts.
+
+Suggested improvement: return the existing index and replace it when the new score is better, or keep a map keyed by `(row_idx, target_col)`.
+
+```cpp
+std::unordered_map<RowColKey, size_t> best;
+```
+
+### [MEDIUM] JSON output is assembled without escaping strings
+Affected file:line references: `src/include/anofox_outlier_tree.hpp:56`, `src/include/anofox_outlier_tree.hpp:58`, `src/include/anofox_outlier_tree.hpp:66`, `src/include/anofox_outlier_tree.hpp:120`
+
+`SplitCondition::ToJSON` writes column names and category names directly into JSON string literals. Quotes, backslashes, control characters, and newlines will produce malformed JSON and can change the apparent structure of the `conditions` field.
+
+Suggested improvement: use DuckDB’s JSON utilities if available in this extension, or add a small JSON string escaper and apply it to every string value.
+
+### [MEDIUM] Isolation forest accepts inconsistent shapes and can read out of bounds
+Affected file:line references: `src/anofox_isolation_forest.cpp:393`, `src/anofox_isolation_forest.cpp:415`, `src/anofox_isolation_forest.cpp:499`, `src/anofox_isolation_forest.cpp:1126`, `src/anofox_isolation_forest.cpp:1149`, `src/anofox_isolation_forest.cpp:1278`
+
+`Fit` assumes `data[0]` has at least one feature and all rows have the same width; `Score` assumes the point has all trained features. `FitMixed` assumes `column_info.size() == data.size()` and all `ColumnData` columns have the same row count. Violating these assumptions can underflow `uniform_int_distribution(0, n_features - 1)` or read past vector bounds.
+
+Suggested improvement: validate inputs at public API boundaries and throw `InvalidInputException`/`std::invalid_argument` before training or scoring.
+
+### [MEDIUM] `outlier_tree` materializes and processes data row-by-row through `Value`
+Affected file:line references: `src/anofox_outlier_tree.cpp:915`, `src/anofox_outlier_tree.cpp:938`, `src/anofox_outlier_tree.cpp:946`, `src/anofox_outlier_tree.cpp:957`, `src/anofox_outlier_tree.cpp:990`
+
+The execution path fetches the full source table through a nested `Connection`, calls `DataChunk::GetValue` for every cell, builds full in-memory `std::vector` columns, and writes output with `SetValue` per cell. This loses most of DuckDB’s vectorized execution benefits and creates many temporary `Value` and `std::string` objects. Large tables will be memory-heavy and slow before the algorithm itself runs.
+
+Suggested improvement: use `UnifiedVectorFormat`/flat vector access while reading chunks, reserve column storage when row counts are known, and write outputs through flat vector buffers. If the function remains whole-table by design, expose or enforce row limits and document the full materialization behavior.
+
+### [LOW] DBSCAN and isolation forest use narrow integer storage for feature/depth metadata
+Affected file:line references: `src/include/anofox_isolation_forest.hpp:108`, `src/include/anofox_isolation_forest.hpp:113`, `src/include/anofox_isolation_forest.hpp:117`, `src/anofox_isolation_forest.cpp:354`, `src/anofox_isolation_forest.cpp:358`, `src/anofox_isolation_forest.cpp:641`
+
+Feature indices and depths are stored as `uint16_t`, and hyperplane dimensionality is stored as `uint8_t`. Wide tables or high `ndim` values can silently truncate metadata and send scoring down the wrong feature path. Even if current SQL overloads make this unlikely, the C++ API itself does not enforce those limits.
+
+Suggested improvement: use `size_t`/`idx_t` for feature indices and dimensions, or validate before narrowing and throw a clear error.
+
+### [LOW] Repeated allocations and recomputation make tree building unnecessarily expensive
+Affected file:line references: `src/anofox_outlier_tree.cpp:120`, `src/anofox_outlier_tree.cpp:125`, `src/anofox_outlier_tree.cpp:382`, `src/anofox_outlier_tree.cpp:398`, `src/anofox_isolation_forest.cpp:112`, `src/anofox_isolation_forest.cpp:139`, `src/anofox_dbscan.cpp:50`
+
+Several hot paths repeatedly allocate temporary vectors and recompute the same statistics: OutlierTree recomputes current variance/entropy for each candidate split, partitioning is performed once to score a split and again to recurse, isolation split candidates rebuild value vectors for parent/children, and DBSCAN allocates a new neighbor vector for every region query. This is not a correctness bug, but it raises CPU and allocator pressure substantially.
+
+Suggested improvement: cache current cluster statistics, return partition results with the chosen split, reuse scratch buffers, and consider a spatial index or distance-cache strategy for DBSCAN when inputs are large.
+
+## Quick wins
+- Validate all `Value` inputs for NULL before calling `ToString()`/`GetValue<T>()` in bind functions.
+- Validate `output_mode` explicitly instead of treating unknown modes as summary.
+- Preserve original row numbers through NULL filtering for all table outputs.
+- Add a categorical negation flag to `SplitCondition`.
+- Escape strings in `ToJSON`.
+- Clear `IsolationTree::nodes_` before every tree build.
+- Add shape checks for row width, column count, and mixed-column lengths.
+- Replace signed-to-unsigned parameter parsing with signed validation followed by casting.
+- Reserve `OutlierTree` column vectors once a row estimate is known.
+- Add focused regression tests for DBSCAN noise-to-border promotion and `min_pts` semantics.

--- a/docs/reviews/modules/review_phonenumber.md
+++ b/docs/reviews/modules/review_phonenumber.md
@@ -1,0 +1,86 @@
+## Summary
+The phonenumber module is small and memory-safe in the narrow sense, with no obvious raw-resource leaks and reasonable use of DuckDB vectors for manual row loops. The main correctness risk is semantic: parsing treats many national numbers as international before considering the region hint, and shared country codes such as NANPA are collapsed to the first configured region. The module also keeps default-region state in a process-wide singleton even though DuckDB can execute queries concurrently and has scoped settings. Performance will degrade on large inputs because regexes are compiled repeatedly per row and often more than once per function call.
+
+## Findings
+
+### [HIGH] Process-wide default region can produce inconsistent results across sessions and parallel queries
+Affected: `src/anofox_phonenumber.cpp:504`, `src/anofox_phonenumber.cpp:511`, `src/anofox_phonenumber.cpp:560`, `src/anofox_phonenumber.cpp:971`
+
+`PhoneNumberManager` stores `default_region` in a global singleton and the SET callback writes directly to it. The mutex prevents a C++ data race, but it does not give DuckDB query-level consistency: a concurrent `SET anofox_tab_phonenumber_default_region = ...` can change results while another query is processing chunks with `NULL` region hints. The scalar functions are also marked `FunctionStability::CONSISTENT`, which is misleading because results depend on mutable global state outside the function arguments.
+
+Suggested improvement: avoid storing the setting in the singleton. Read/snapshot the DuckDB setting through bind/local function data and pass that region into the parser for the whole query, or make the default region an explicit argument-only concern. At minimum, validate and snapshot the current value once per function invocation/chunk and reconsider `FunctionStability`.
+
+```cpp
+struct PhoneBindData : FunctionData {
+    string default_region;
+    unique_ptr<FunctionData> Copy() const override { return make_uniq<PhoneBindData>(*this); }
+    bool Equals(const FunctionData &other) const override { return true; }
+};
+```
+
+### [HIGH] Region hints are ignored for shared country codes
+Affected: `src/anofox_phonenumber.cpp:214`, `src/include/anofox_phonenumber_metadata.hpp:63`, `src/anofox_phonenumber_metadata.cpp:8`
+
+After extracting country code `1`, parsing always calls `GetMainRegionForCountryCode`, which returns the first region in the metadata list. For NANPA numbers this means Canadian numbers parse as `US` even when the caller passes `CA`; `phonenumber_is_valid_for_region('+1 5062345678', 'CA')` will fail because `parts.region_code` becomes `US`. The metadata explicitly models `{1, {"US", "CA"}}`, but the parser never uses the region hint to disambiguate.
+
+Suggested improvement: when a country code maps to multiple regions, prefer a region hint whose metadata has the same country code, then fall back by trying each region's length and type patterns.
+
+```cpp
+auto regions = COUNTRY_CODE_TO_REGIONS.at(country_code);
+if (!region_hint.empty()) {
+    auto hint = StringUtil::Upper(region_hint);
+    if (std::find(regions.begin(), regions.end(), hint) != regions.end()) {
+        region_code = hint;
+    }
+}
+```
+
+### [MEDIUM] National numbers are parsed as international numbers before using the region hint
+Affected: `src/anofox_phonenumber.cpp:52`, `src/anofox_phonenumber.cpp:177`, `src/anofox_phonenumber.cpp:180`
+
+`ExtractCountryCode` attempts to consume a 1-3 digit country code even when the normalized input does not start with `+`. That makes valid national numbers fail or be misclassified if their leading digits match a known country code. For example, a US national number in area code `442` can be treated as country code `44`, fail GB length validation, and never fall back to the explicit `US` region.
+
+Suggested improvement: only extract a country code unconditionally for explicit international formats, e.g. `+...` or a recognized international dialing prefix. For plain national input, select metadata from `region_hint` or the default region first and strip only that region's national prefix.
+
+```cpp
+if (!normalized.empty() && normalized[0] == '+') {
+    std::tie(country_code, national_number) = ExtractCountryCode(normalized);
+} else {
+    // interpret as national using region_hint/default_region
+}
+```
+
+### [MEDIUM] Regexes are compiled per row and often multiple times per row
+Affected: `src/anofox_phonenumber.cpp:96`, `src/anofox_phonenumber.cpp:108`, `src/anofox_phonenumber.cpp:113`, `src/anofox_phonenumber.cpp:374`, `src/anofox_phonenumber.cpp:379`
+
+`DeterminePhoneNumberType` constructs up to three `std::regex` objects for every parsed number, and `IsValid` constructs fixed/mobile regexes again after `Parse` already did type detection. On large DuckDB vectors this creates substantial CPU and heap churn. `std::regex` compilation is far more expensive than matching and should not be in the per-row hot path.
+
+Suggested improvement: precompile patterns once per region, either by storing `std::regex` members alongside metadata or by building an immutable region-pattern cache with `std::call_once`. Also let `Parse` expose enough classification detail for `IsValid` to avoid matching the same patterns twice.
+
+### [LOW] Invalid format options silently become NATIONAL and formatting failures return the input
+Affected: `src/anofox_phonenumber.cpp:529`, `src/anofox_phonenumber.cpp:669`, `src/anofox_phonenumber.cpp:674`
+
+`ParseFormatOption` maps any unknown format string to `NATIONAL`, and `PhoneFormatFunction` catches all `std::exception` values and returns the original number. This hides typos like `'INTERNATIONL'`, invalid inputs, and unexpected internal errors behind a plausible-looking non-NULL result. It makes bad data harder to detect in SQL pipelines.
+
+Suggested improvement: throw `InvalidInputException` for unknown format strings and decide explicitly whether invalid phone numbers should return `NULL` or raise. Avoid catching broad `std::exception` unless the function contract is documented as best-effort normalization.
+
+### [LOW] Default region values are not validated
+Affected: `src/anofox_phonenumber.cpp:504`, `src/anofox_phonenumber.cpp:560`
+
+`SetDefaultRegion` uppercases and stores any string, including unsupported or malformed regions. After `SET anofox_tab_phonenumber_default_region='ZZ'`, null-region parsing silently starts failing for otherwise valid local numbers. The status function will report the invalid setting as if it were usable.
+
+Suggested improvement: validate the region against `REGION_METADATA` in the SET callback and reject unsupported values.
+
+```cpp
+auto region = StringUtil::Upper(parameter.ToString());
+if (!phonenumber::GetMetadataForRegion(region)) {
+    throw InvalidInputException("Unsupported phone region: %s", region);
+}
+```
+
+## Quick wins
+- Add regression tests for `CA`/NANPA parsing, `phonenumber_is_valid_for_region('+1 ...', 'CA')`, and national numbers whose leading digits match known country codes.
+- Precompile fixed/mobile/toll-free regexes once per region and reuse them from both `Parse` and `IsValid`.
+- Validate `anofox_tab_phonenumber_default_region` on `SET`.
+- Make `ParseFormatOption` reject unknown format strings instead of defaulting to `NATIONAL`.
+- Update README/API wording that still describes this as libphonenumber-backed if the custom implementation is now intentional.

--- a/docs/reviews/modules/review_pii.md
+++ b/docs/reviews/modules/review_pii.md
@@ -1,0 +1,111 @@
+## Summary
+The PII module has a useful recognizer layout and generally avoids repeated regex compilation by storing compiled recognizers in the `PIIEngine` singleton. The highest-risk issues are around global mutable state and thread safety under DuckDB parallel execution, plus table functions that build SQL from user-controlled identifiers. Several registered configuration options are only partially honored, so users can set options that do not affect the main scalar APIs. Performance is acceptable for small strings, but the table functions and type-specific detection paths materialize many `Value` objects and full result sets instead of streaming/vectorizing.
+
+## Findings
+
+### [HIGH] Global PII configuration is unsynchronized and process-wide
+Affected: `src/anofox_pii.cpp:106`, `src/anofox_pii.cpp:117`, `src/anofox_pii.cpp:147`, `src/anofox_pii.cpp:3153`, `src/anofox_pii.cpp:3182`, `src/include/anofox_pii.hpp:507`, `src/include/anofox_pii.hpp:537`
+
+`PIIConfig` is a process-wide singleton with mutable `double`, `MaskStrategy`, `std::vector<PIIType>`, and `bool` fields. DuckDB can execute scalar/table functions in parallel while another connection changes extension options, so reads like `GetDefaultMaskStrategy()`, `IsTypeEnabled()`, and `IsDeepValidationEnabled()` can race with setters mutating the same fields. It also ignores `ClientContext` and `SetScope`, so settings from one database/connection can leak into another.
+
+Suggested improvement: avoid mutable process-wide config for query behavior. Bind a per-query snapshot from DuckDB settings into `FunctionData`, or store state per database/client. If a singleton remains, guard all fields with a mutex and return copies rather than references:
+
+```cpp
+class PIIConfig {
+public:
+    PIIConfigSnapshot Snapshot() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return {min_confidence_, default_mask_strategy_, enabled_types_, deep_validation_};
+    }
+
+private:
+    mutable std::mutex mutex_;
+    std::vector<PIIType> enabled_types_;
+};
+```
+
+### [HIGH] Lazy Base58 lookup initialization has a data race
+Affected: `src/anofox_pii.cpp:992`, `src/anofox_pii.cpp:997`, `src/anofox_pii.cpp:998`
+
+`CryptoAddressRecognizer::DecodeBase58()` uses a function-static `std::unordered_map` and populates it when `base58_map.empty()`. Two DuckDB worker threads validating crypto addresses can both observe the map as empty and mutate it concurrently, which is undefined behavior.
+
+Suggested improvement: initialize the lookup in a thread-safe function-local static lambda, or use a fixed array:
+
+```cpp
+static const auto base58_map = [] {
+    std::array<int, 256> map;
+    map.fill(-1);
+    for (int i = 0; i < 58; ++i) {
+        map[static_cast<unsigned char>(BASE58_ALPHABET[i])] = i;
+    }
+    return map;
+}();
+```
+
+### [HIGH] Table scan/audit functions build SQL with unescaped identifiers
+Affected: `src/anofox_pii.cpp:2638`, `src/anofox_pii.cpp:2695`, `src/anofox_pii.cpp:2853`, `src/anofox_pii.cpp:2929`
+
+`pii_audit_table()` and `pii_scan_table()` parse the table name for catalog lookup, but then execute a new SQL string using the original `bind_data.table_name`. Column names are wrapped in double quotes but embedded quotes are not escaped, and the table name is appended raw. This can break on valid identifiers and creates SQL-injection risk if these functions are exposed to untrusted SQL inputs.
+
+Suggested improvement: do not reconstruct SQL from raw strings. Prefer DuckDB relation/table scan APIs, or construct fully quoted identifiers from catalog-resolved names and escape embedded quotes. Also validate column filters against catalog columns before query construction.
+
+### [MEDIUM] Configured enabled types and confidence are not applied consistently
+Affected: `src/anofox_pii.cpp:147`, `src/anofox_pii.cpp:169`, `src/anofox_pii.cpp:1627`, `src/anofox_pii.cpp:1778`, `src/anofox_pii.cpp:1875`, `src/anofox_pii.cpp:2727`, `src/anofox_pii.cpp:2730`, `src/anofox_pii.cpp:3231`
+
+`anofox_pii_enabled_types` is described as controlling which PII types to detect, but `PIIEngine::Detect()` only honors an explicit `types` argument and the main scalar functions call `engine.Detect(text)` without consulting `PIIConfig`. `anofox_pii_min_confidence` is only applied in `pii_audit_table()`, while NER recognizers use hard-coded `0.7` thresholds and most scalar/table detection functions return all matches. This makes the configuration misleading and query results inconsistent across APIs.
+
+Suggested improvement: pass a config snapshot into `Detect()` and apply enabled-type/confidence filtering in one central place:
+
+```cpp
+auto config = PIIConfig::Get().Snapshot();
+auto matches = engine.Detect(text, config.EnabledTypes());
+EraseIf(matches, [&](const PIIMatch &m) {
+    return m.confidence < config.min_confidence;
+});
+```
+
+### [MEDIUM] Overlapping matches can corrupt masking semantics
+Affected: `src/anofox_pii.cpp:1627`, `src/anofox_pii.cpp:1650`, `src/anofox_pii.cpp:1726`, `src/anofox_pii.cpp:1734`
+
+`Detect()` aggregates matches from every recognizer and only sorts by `start_pos`; it does not resolve overlaps or duplicates. Since patterns can overlap across recognizers, `Mask()` may apply multiple replacements over the same source span using stale offsets. This can produce surprising output, double-mask text, or let a lower-priority recognizer overwrite a better match.
+
+Suggested improvement: define recognizer priority and normalize matches before returning or masking. For example, sort by start position, then longer length or higher priority/confidence, and discard overlaps:
+
+```cpp
+std::sort(matches.begin(), matches.end(), ByStartThenPriority);
+std::vector<PIIMatch> non_overlapping;
+size_t covered_until = 0;
+for (const auto &m : matches) {
+    if (m.start_pos >= covered_until) {
+        non_overlapping.push_back(m);
+        covered_until = m.end_pos;
+    }
+}
+```
+
+### [MEDIUM] Table functions materialize entire scans before producing output
+Affected: `src/anofox_pii.cpp:2654`, `src/anofox_pii.cpp:2742`, `src/anofox_pii.cpp:2891`, `src/anofox_pii.cpp:2962`, `src/anofox_pii.cpp:2977`
+
+`pii_audit_table()` and `pii_scan_table()` scan all selected columns on the first call and store all results in `state.results` before returning any rows. Large tables or high-match columns can consume substantial memory, delay first output, and bypass DuckDB’s normal streaming execution model. `pii_audit_table()` is especially expensive because each match stores the full original and masked value.
+
+Suggested improvement: stream work through table-function state: keep the active column, query result, chunk, row offset, and pending output rows, and emit up to `STANDARD_VECTOR_SIZE` rows per invocation. For scan summaries, aggregate incrementally but avoid retaining per-match original values.
+
+### [LOW] Several `std::isdigit`/`std::isalpha` calls have undefined behavior for negative `char`
+Affected: `src/anofox_pii.cpp:311`, `src/anofox_pii.cpp:341`, `src/anofox_pii.cpp:374`, `src/anofox_pii.cpp:408`, `src/anofox_pii.cpp:457`, `src/anofox_pii.cpp:514`, `src/anofox_pii.cpp:560`
+
+Multiple recognizers call C character-classification functions with plain `char`. For non-ASCII bytes where `char` is signed, passing a negative value other than `EOF` is undefined behavior. Some functions already use the correct `static_cast<unsigned char>` pattern, so this is mostly consistency debt.
+
+Suggested improvement:
+
+```cpp
+if (std::isdigit(static_cast<unsigned char>(c))) {
+    clean += c;
+}
+```
+
+## Quick wins
+- Apply `static_cast<unsigned char>` consistently for every `std::isdigit`, `std::isalpha`, `std::tolower`, and `std::toupper` call.
+- Replace the mutable Base58 `unordered_map` with a thread-safe static lookup array.
+- Centralize match filtering for enabled types, confidence threshold, and overlap resolution in `PIIEngine::Detect()`.
+- Escape or avoid SQL identifier string construction in `pii_scan_table()` and `pii_audit_table()`.
+- Refactor repeated `pii_detect_*` functions through one helper that writes LIST/STRUCT vectors directly instead of constructing `Value::LIST` per row.

--- a/docs/reviews/modules/review_postal.md
+++ b/docs/reviews/modules/review_postal.md
@@ -1,0 +1,118 @@
+## Summary
+The postal module is compact and mostly follows DuckDB’s manual vector loop style, but it has several correctness and operational hazards around NULL semantics, global libpostal/curl state, and filesystem work. The biggest user-visible bug is that `postal_parse_address(NULL)` returns a non-NULL struct whose children are NULL, which differs from expected SQL NULL propagation. The data download path also mixes user-controlled paths with `std::system`, and the load/initialization lifecycle is not robust under concurrent calls or partial failures. Performance is acceptable for small batches, but parse/expand currently do avoidable per-row materialization and copies.
+
+## Findings
+
+### [HIGH] `postal_parse_address(NULL)` returns a valid struct instead of SQL NULL
+Affected: `src/anofox_postal.cpp:323`, `src/anofox_postal.cpp:324`, `src/anofox_postal.cpp:325`
+
+For NULL input rows, the function only marks each struct child as NULL. It never marks the parent `STRUCT` vector row as NULL, so SQL sees a non-NULL struct value with all fields NULL rather than `NULL`. This breaks predicates like `postal_parse_address(NULL) IS NULL` and differs from the explicit parent-null handling used elsewhere in the project for struct results.
+
+Suggested improvement: set parent validity first, and clear it for non-NULL rows.
+
+```cpp
+if (!input_data.validity.RowIsValid(idx)) {
+	FlatVector::SetNull(result, i, true);
+	continue;
+}
+
+FlatVector::SetNull(result, i, false);
+for (auto &child : children) {
+	FlatVector::SetNull(*child, i, true);
+}
+```
+
+### [HIGH] User-controlled data path is interpolated into a shell command
+Affected: `src/anofox_postal.cpp:219`, `src/anofox_postal.cpp:220`, `src/anofox_postal.cpp:492`
+
+`anofox_tab_postal_data_path` is user configurable, and `LoadData` builds a shell command by concatenating `destination` and `data_dir` into `tar -xzf ... -C ...`. Double quotes are not sufficient escaping: a path containing `"` or shell metacharacters can break the command, fail extraction, or execute unintended shell syntax. This is especially risky because DuckDB settings can be supplied from SQL and extension load paths often run with the hosting process’s privileges.
+
+Suggested improvement: avoid the shell entirely. Use a tar/gzip extraction library or a process API that passes argv without shell parsing. If that is not immediately feasible, reject unsafe path characters before command construction as a stopgap, but that should not be the long-term fix.
+
+```cpp
+if (data_dir.find('"') != string::npos || destination.find('"') != string::npos) {
+	throw InvalidInputException("Postal data path contains unsupported quote character");
+}
+// Prefer: ExtractTarGz(destination, data_dir) without std::system.
+```
+
+### [MEDIUM] `LoadData` is not synchronized and can corrupt shared downloads
+Affected: `src/anofox_postal.cpp:127`, `src/anofox_postal.cpp:138`, `src/anofox_postal.cpp:157`, `src/anofox_postal.cpp:219`, `src/anofox_postal.cpp:227`, `src/anofox_postal.cpp:472`
+
+`EnsureInitialized` calls `Initialize` under `init_lock`, but `postal_load_data()` calls `LoadData` directly without taking that lock. Two concurrent connections can download the same tarball to the same destination, remove each other’s partial files, or extract over the same directory. The function also calls process-wide `curl_global_init`/`curl_global_cleanup`; cleanup at the end of one concurrent call can affect another curl user in the same process, including other extension code.
+
+Suggested improvement: serialize data loading through the same manager mutex or a dedicated load mutex, and manage curl global initialization with process-lifetime RAII rather than per-call cleanup.
+
+```cpp
+void PostalManager::LoadData(ClientContext &context) {
+	std::lock_guard<std::mutex> lock(init_lock);
+	LoadDataLocked(context);
+}
+```
+
+### [MEDIUM] Partial libpostal initialization is not rolled back on failure
+Affected: `src/anofox_postal.cpp:263`, `src/anofox_postal.cpp:267`, `src/anofox_postal.cpp:271`, `src/anofox_postal.cpp:276`
+
+`Initialize` performs multiple global libpostal setup calls and throws immediately on the first failed stage. If core setup succeeds but parser or language classifier setup fails, `initialized` remains false while libpostal may be partially initialized. A later retry can then call setup again against already-initialized global state, and the destructor will still call all teardown functions regardless of which setup stages completed.
+
+Suggested improvement: track setup stages and tear down completed stages before throwing, or wrap libpostal setup in an RAII guard that only commits by setting `initialized = true` after every stage succeeds.
+
+```cpp
+bool core_ready = false;
+bool parser_ready = false;
+
+try {
+	if (!libpostal_setup_datadir(data_dir_c) || !libpostal_setup()) {
+		throw IOException(...);
+	}
+	core_ready = true;
+
+	if (!libpostal_setup_parser_datadir(data_dir_c) || !libpostal_setup_parser()) {
+		throw IOException(...);
+	}
+	parser_ready = true;
+	...
+} catch (...) {
+	if (parser_ready) libpostal_teardown_parser();
+	if (core_ready) libpostal_teardown();
+	throw;
+}
+```
+
+### [MEDIUM] `data_directory` is read without synchronization
+Affected: `src/include/anofox_postal.hpp:52`, `src/include/anofox_postal.hpp:53`, `src/anofox_postal.cpp:74`, `src/anofox_postal.cpp:84`, `src/anofox_postal.cpp:129`, `src/anofox_postal.cpp:235`
+
+`SetDataDirectory` writes `data_directory` under `init_lock`, but `GetDataDirectory`, `LoadData`, and `GetStatus` read it without taking the mutex. A concurrent `SET anofox_tab_postal_data_path = ...` and `postal_status()`/initialization call before libpostal is initialized can race on the `std::string`, which is undefined behavior in C++. The `initialized` atomic does not protect the string itself.
+
+Suggested improvement: copy `data_directory` under the mutex before using it, or make all manager public methods that read/write configuration synchronize consistently.
+
+```cpp
+std::string PostalManager::GetDataDirectory() const {
+	std::lock_guard<std::mutex> lock(init_lock);
+	return data_directory;
+}
+```
+
+This requires making the mutex `mutable` for `const` access.
+
+### [LOW] Public option name and error message are inconsistent with postal aliases
+Affected: `src/anofox_postal.cpp:293`, `src/anofox_postal.cpp:295`, `src/anofox_postal.cpp:492`
+
+The option registered is `anofox_tab_postal_data_path`, but the NULL error message says `anofox_postal_data_path`, and the disabled postal tests also use `anofox_postal_data_path`. The functions expose non-`tab` aliases like `postal_parse_address`, so this mismatch is easy for users to hit and hard to diagnose.
+
+Suggested improvement: either register `anofox_postal_data_path` as an alias option if DuckDB supports that pattern, or standardize all messages/tests/docs on `anofox_tab_postal_data_path`.
+
+### [LOW] Parse and expand materialize avoidable per-row intermediates
+Affected: `src/anofox_postal.cpp:88`, `src/anofox_postal.cpp:98`, `src/anofox_postal.cpp:107`, `src/anofox_postal.cpp:118`, `src/anofox_postal.cpp:330`, `src/anofox_postal.cpp:381`, `src/anofox_postal.cpp:386`
+
+Each parse row copies the input to `std::string`, copies all libpostal components into a `std::vector<PostalComponent>`, then copies selected values into DuckDB vectors. Expansion similarly builds a `std::vector<std::string>` and then wraps each item in a `Value` for `ListVector::PushBack`. This is simple but allocation-heavy for large columns and especially expensive for expansion-heavy addresses.
+
+Suggested improvement: keep the libpostal response lifetime local to the vector loop and write directly into DuckDB vectors, using small RAII wrappers for libpostal response destruction. For list output, append directly from `expansions[i]` into the list child vector where possible instead of building a second vector of strings.
+
+## Quick wins
+- Set the parent struct validity mask in `PostalParseAddressFunction` for both NULL and non-NULL rows.
+- Remove the duplicate `RegisterPostalOptions(loader)` call from either extension load or `RegisterPostalFunctions`.
+- Fix the option-name mismatch in `SetPostalDataPathOption`’s error text.
+- Add `result.Verify(args.size())` to postal scalar functions during development/tests.
+- Guard `LoadData` with a mutex and use RAII for `FILE *`, `CURL *`, and curl global initialization.
+- Replace `std::system("tar ...")` with non-shell extraction, or reject unsafe path characters until that replacement lands.

--- a/docs/reviews/modules/review_vat.md
+++ b/docs/reviews/modules/review_vat.md
@@ -1,0 +1,112 @@
+## Summary
+The VAT module is compact and mostly read-only after initialization, so it is unlikely to have resource leaks or obvious thread-safety issues under parallel DuckDB execution. The largest correctness risk is that exposed “valid” and “format” functions do not implement the behavior their names imply: `vat_format` is a public stub, and `vat_is_valid` performs syntax-only validation while the model already tracks checksum capability. The implementation also leaves several edge cases around VAT/ISO country aliases and case normalization. Performance is acceptable for small inputs, but repeated regex construction and per-row string materialization will become expensive on DuckDB-sized vectors.
+
+## Findings
+
+### [HIGH] `vat_format` always returns `NULL`
+Affected file:line references: `src/anofox_vat.cpp:128`, `src/anofox_vat.cpp:140`, `src/anofox_vat.cpp:150`, `src/anofox_vat.cpp:151`, `src/anofox_vat.cpp:286`
+
+`anofox_tab_vat_format` is registered as a public scalar function, but the implementation ignores both non-null arguments and sets every non-null row to `NULL`. This makes the function unusable and can silently corrupt downstream transformations that expect formatted VAT strings.
+
+Suggested improvement: either remove/avoid registering the function until implemented, or implement the advertised styles by reusing `SplitVAT`, `ConvertISOToVAT`, and `SetStringResult`.
+
+```cpp
+IterateTwoStringInputs(args, result, [&](const std::string &vat, const std::string &style, size_t idx) {
+  auto parsed = registry.SplitVAT(vat);
+  if (!parsed) {
+    FlatVector::SetNull(result, idx, true);
+    return;
+  }
+  auto [country, digits] = *parsed;
+  auto normalized_style = StringUtil::Lower(style);
+  if (normalized_style == "plain") {
+    SetStringResult(result, idx, digits);
+  } else if (normalized_style == "iso") {
+    SetStringResult(result, idx, registry.ConvertISOToVAT(country) + digits);
+  } else {
+    throw InvalidInputException("Unsupported VAT format style: %s", style);
+  }
+});
+```
+
+### [HIGH] `vat_is_valid` does not perform checksum validation
+Affected file:line references: `src/anofox_vat_country.cpp:25`, `src/anofox_vat_country.cpp:57`, `src/include/anofox_vat.hpp:141`, `src/include/anofox_vat.hpp:143`, `src/anofox_vat.cpp:161`, `src/anofox_vat.cpp:171`, `src/anofox_vat.cpp:172`
+
+The country table models `has_checksum`, and most countries are marked as having checksum support, but `anofox_tab_vat_is_valid` only calls `IsValidSyntax`. That means values with a valid shape but invalid check digits will be reported as valid. For a function named `vat_is_valid`, this is a significant false-positive risk.
+
+Suggested improvement: split the API explicitly into syntax validation and full validation. Add checksum implementations for countries where `has_checksum` is true, and make `VATIsValidFunc` call both syntax and checksum checks.
+
+```cpp
+if (!registry.IsValidSyntax(country, digits)) {
+  SetBoolResult(result, idx, false);
+  return;
+}
+SetBoolResult(result, idx, registry.IsValidChecksum(country, digits));
+```
+
+### [MEDIUM] Country utility functions reject VAT aliases and lowercase country codes
+Affected file:line references: `src/anofox_vat_country.cpp:15`, `src/anofox_vat_country.cpp:18`, `src/anofox_vat_country.cpp:60`, `src/anofox_vat_country.cpp:64`, `src/anofox_vat_country.cpp:72`, `src/anofox_vat.cpp:41`, `src/anofox_vat.cpp:106`, `src/anofox_vat.cpp:115`
+
+`SplitVAT` accepts lowercase VAT strings and converts VAT prefixes such as `EL` to `GR` and `XI` to `GB`, but the country-code utilities perform direct map lookups. As a result, `anofox_tab_is_valid_vat_country('de')`, `anofox_tab_is_valid_vat_country('EL')`, and `anofox_tab_vat_is_eu_member('EL')` return false even though those are natural inputs for VAT users.
+
+Suggested improvement: centralize country-code normalization and use it in all country-code entry points.
+
+```cpp
+std::string VATRegistry::NormalizeCountryCode(const std::string &code) const {
+  auto normalized = NormalizeVAT(code);
+  return ConvertVATToISO(normalized);
+}
+
+bool VATRegistry::IsValidCountry(const std::string &code) const {
+  return countries_.find(NormalizeCountryCode(code)) != countries_.end();
+}
+```
+
+### [MEDIUM] `std::isalnum` and `std::toupper` have undefined behavior for negative `char`
+Affected file:line references: `src/anofox_vat_country.cpp:95`, `src/anofox_vat_country.cpp:98`, `src/anofox_vat_country.cpp:99`, `src/anofox_vat_country.cpp:100`
+
+`NormalizeVAT` passes a plain `char` to `<cctype>` functions. If `char` is signed and the input contains bytes with the high bit set, this is undefined behavior unless the value is converted to `unsigned char` or is `EOF`.
+
+Suggested improvement: cast before calling `<cctype>`, and cast the result back to `char`.
+
+```cpp
+for (unsigned char c : input) {
+  if (std::isalnum(c)) {
+    result += static_cast<char>(std::toupper(c));
+  }
+}
+```
+
+### [MEDIUM] Regex patterns are compiled once per row
+Affected file:line references: `src/anofox_vat_country.cpp:80`, `src/anofox_vat_country.cpp:87`, `src/anofox_vat_country.cpp:88`, `src/anofox_vat_country.cpp:89`
+
+`IsValidSyntax` constructs a new `std::regex` for every row. In DuckDB scalar execution this is expensive, especially for large vectors or repeated calls over a table, and the patterns are static after registry initialization.
+
+Suggested improvement: precompile anchored regexes during `InitializeCountries` or the `VATRegistry` constructor and store them in `CountryInfo`.
+
+```cpp
+struct CountryInfo {
+  std::string country_code;
+  std::string country_name;
+  std::string pattern;
+  std::regex compiled_pattern;
+  bool is_eu_member;
+  bool has_checksum;
+};
+```
+
+### [LOW] Manual vector loops copy every input string
+Affected file:line references: `src/include/anofox_vat.hpp:30`, `src/include/anofox_vat.hpp:47`, `src/include/anofox_vat.hpp:57`, `src/include/anofox_vat.hpp:80`, `src/include/anofox_vat.hpp:81`
+
+The generic iterators convert every `string_t` to `std::string` before invoking the operation. Several operations only need to inspect the string or normalize it once, so this forces avoidable per-row allocation and copying.
+
+Suggested improvement: pass `string_t` or `std::string_view` into the lambda and only allocate when normalization or result construction requires it. For simple boolean functions, consider `UnaryExecutor::Execute<string_t, bool>` or `BinaryExecutor` patterns so DuckDB can preserve constant/dictionary behavior more efficiently.
+
+## Quick wins
+
+- Implement or unregister `anofox_tab_vat_format`; avoid shipping a public function that always returns `NULL`.
+- Add a `NormalizeCountryCode` helper and use it in `IsValidCountry`, `IsEUMember`, and `GetCountryName`.
+- Fix `<cctype>` calls by casting to `unsigned char`.
+- Precompile VAT regexes once in the registry instead of per row.
+- Reserve `NormalizeVAT` output capacity with `result.reserve(input.size())`.
+- Add non-skipped tests for lowercase country utility inputs, `EL`/`XI` aliases, invalid checksum examples, and real `vat_format` outputs.


### PR DESCRIPTION
Adds the 2026-06-12 consolidated code review (79 findings across all 11 modules) and the detailed per-module reviews that the issue set #42–#61 references.

Cherry-picked from `feat/duckdb-v1.5.2` so the documents the milestone issues permalink to also live on `main`.

Part of #61.