### PR TITLE
fix: money correctness — from_cents subunits, currency canonicalization, struct NULLs, registry init

### DIFF
--- a/README.md
+++ b/README.md
@@ -844,7 +844,7 @@ WHERE money_in_range(amount, 0.01, 99999.99)
 | Function | Signature | Returns | Description |
 |----------|-----------|---------|-------------|
 | `anofox_tab_money` | `(amount, currency_code)` | STRUCT | Create a money value from amount and currency code |
-| `anofox_tab_money_from_cents` | `(cents, currency_code)` | STRUCT | Create a money value from integer cents |
+| `anofox_tab_money_from_cents` | `(cents, currency_code)` | STRUCT | Create a money value from an integer amount in the smallest currency unit (e.g. 10050 cents → 100.50 USD) |
 | `anofox_tab_money_amount` | `(money)` | DOUBLE | Extract amount from money struct |
 | `anofox_tab_money_currency` | `(money)` | VARCHAR | Extract currency code from money struct |
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -453,7 +453,7 @@ SELECT anofox_tab_money (alias: money(100.50, 'USD');
 
 #### `anofox_tab_money (alias: money_from_cents`
 
-Create a money value from integer cents.
+Create a money value from an integer amount in the currency's smallest unit (e.g. cents). The amount is divided by the currency's `subunit_to_unit` (100 for USD/EUR, 1 for JPY).
 
 **Signature:**
 ```sql
@@ -463,7 +463,7 @@ anofox_tab_money (alias: money_from_cents(cents BIGINT, currency_code VARCHAR) â
 **Example:**
 ```sql
 SELECT anofox_tab_money (alias: money_from_cents(10050, 'USD');
--- Returns: {amount: 10050.0, currency: 'USD'}
+-- Returns: {amount: 100.5, currency: 'USD'}
 ```
 
 ---

--- a/python/src/anofox/money.py
+++ b/python/src/anofox/money.py
@@ -51,7 +51,9 @@ def money_from_cents(conn: Any, cents: int, currency: str) -> dict:
     Returns
     -------
     dict
-        ``{"amount": float, "currency": str}``
+        ``{"amount": float, "currency": str}`` where ``amount`` is in major
+        units (the cents value divided by the currency's ``subunit_to_unit``,
+        e.g. ``1000`` cents -> ``10.0`` USD).
     """
     result = conn.execute(
         f"SELECT anofox_tab_money_from_cents({cents}, '{currency}')"

--- a/python/tests/test_money.py
+++ b/python/tests/test_money.py
@@ -38,7 +38,13 @@ class TestMoneyFromCents:
     def test_converts_cents_to_dollars(self, conn):
         from anofox import money
         result = money.money_from_cents(conn, 1000, "USD")
-        # Extension stores the raw cents value as-is (no /100 conversion)
+        # 1000 cents = 10.00 USD (divided by the currency's subunit_to_unit)
+        assert abs(result["amount"] - 10.0) < 0.001
+
+    def test_zero_decimal_currency_unchanged(self, conn):
+        from anofox import money
+        result = money.money_from_cents(conn, 1000, "JPY")
+        # JPY has no subunit (subunit_to_unit = 1), value is unchanged
         assert abs(result["amount"] - 1000.0) < 0.001
 
 

--- a/src/anofox_money.cpp
+++ b/src/anofox_money.cpp
@@ -23,6 +23,15 @@ static LogicalType GetMoneyType() {
     return LogicalType::STRUCT(children);
 }
 
+//! Looks up a currency in the registry (case-insensitive) and throws for unknown codes.
+static const CurrencyInfo &LookupCurrencyOrThrow(const CurrencyRegistry &registry, const std::string &currency_code) {
+    auto currency = registry.GetCurrency(currency_code);
+    if (!currency) {
+        throw InvalidInputException("Invalid currency code: %s", currency_code);
+    }
+    return *currency;
+}
+
 //----------------------------------------------------------------------------------------------------------------------
 // Scalar Function: anofox_money(amount, currency_code) -> STRUCT
 //----------------------------------------------------------------------------------------------------------------------
@@ -48,17 +57,12 @@ static void AnofoxMoneyFunction(DataChunk &args, ExpressionState &state, Vector 
         auto currency_idx = currency_data.sel->get_index(i);
 
         if (!amount_data.validity.RowIsValid(amount_idx) || !currency_data.validity.RowIsValid(currency_idx)) {
-            builder.amount_validity.SetInvalid(i);
-            builder.currency_validity.SetInvalid(i);
+            SetMoneyResultNull(result, i);
         } else {
             auto currency_code = currency_values[currency_idx].GetString();
-
-            // Validate currency code
-            if (!registry.CurrencyExists(currency_code)) {
-                throw InvalidInputException("Invalid currency code: %s", currency_code);
-            }
-
-            SetMoneyResult(builder, i, amount_values[amount_idx], currency_code, result);
+            auto &currency = LookupCurrencyOrThrow(registry, currency_code);
+            // Store the canonical ISO code so that downstream comparisons work regardless of input case
+            SetMoneyResult(builder, i, amount_values[amount_idx], currency.iso_code, result);
         }
     }
 }
@@ -88,43 +92,42 @@ static void AnofoxMoneyFromCentsFunction(DataChunk &args, ExpressionState &state
         auto currency_idx = currency_data.sel->get_index(i);
 
         if (!cents_data.validity.RowIsValid(cents_idx) || !currency_data.validity.RowIsValid(currency_idx)) {
-            builder.amount_validity.SetInvalid(i);
-            builder.currency_validity.SetInvalid(i);
+            SetMoneyResultNull(result, i);
         } else {
             auto currency_code = currency_values[currency_idx].GetString();
+            auto &currency = LookupCurrencyOrThrow(registry, currency_code);
 
-            // Validate currency code
-            if (!registry.CurrencyExists(currency_code)) {
-                throw InvalidInputException("Invalid currency code: %s", currency_code);
+            const auto divisor = currency.subunit_to_unit;
+            if (divisor <= 0) {
+                throw InternalException("Invalid subunit_to_unit %d for currency: %s", divisor,
+                                        currency.iso_code.c_str());
             }
 
-            auto currency = registry.GetCurrency(currency_code);
-            if (!currency) {
-                throw InvalidInputException("Currency not found: %s", currency_code);
-            }
-
-            // Store amount as cents converted to decimal representation
-            // For now, just store the cents value as double
-            double amount = static_cast<double>(cents_values[cents_idx]);
-            SetMoneyResult(builder, i, amount, currency_code, result);
+            // Convert the smallest-unit amount to major units (e.g. 10050 cents -> 100.50 USD)
+            double amount = static_cast<double>(cents_values[cents_idx]) / static_cast<double>(divisor);
+            SetMoneyResult(builder, i, amount, currency.iso_code, result);
         }
     }
 }
 
 //----------------------------------------------------------------------------------------------------------------------
-// Scalar Function: anofox_money_amount(money) -> DECIMAL
+// Scalar Function: anofox_money_amount(money) -> DOUBLE
 //----------------------------------------------------------------------------------------------------------------------
 
 static void AnofoxMoneyAmountFunction(DataChunk &args, ExpressionState &state, Vector &result) {
     auto &money_vec = args.data[0];
-    auto &children = StructVector::GetEntries(money_vec);
+    idx_t count = args.size();
 
-    // Extract amount field (first child)
-    if (children.size() < 2) {
-        throw InvalidInputException("Money struct must have amount and currency fields");
+    auto data = ExtractMoneyStruct(money_vec, count);
+    auto result_data = FlatVector::GetData<double>(result);
+
+    for (idx_t i = 0; i < count; i++) {
+        if (!data.RowIsValid(i)) {
+            FlatVector::SetNull(result, i, true);
+        } else {
+            result_data[i] = data.Amount(i);
+        }
     }
-
-    result.Reference(*children[0]);
 }
 
 //----------------------------------------------------------------------------------------------------------------------
@@ -133,14 +136,18 @@ static void AnofoxMoneyAmountFunction(DataChunk &args, ExpressionState &state, V
 
 static void AnofoxMoneyCurrencyFunction(DataChunk &args, ExpressionState &state, Vector &result) {
     auto &money_vec = args.data[0];
-    auto &children = StructVector::GetEntries(money_vec);
+    idx_t count = args.size();
 
-    // Extract currency field (second child)
-    if (children.size() < 2) {
-        throw InvalidInputException("Money struct must have amount and currency fields");
+    auto data = ExtractMoneyStruct(money_vec, count);
+    auto result_data = FlatVector::GetData<string_t>(result);
+
+    for (idx_t i = 0; i < count; i++) {
+        if (!data.RowIsValid(i)) {
+            FlatVector::SetNull(result, i, true);
+        } else {
+            result_data[i] = StringVector::AddString(result, data.Currency(i));
+        }
     }
-
-    result.Reference(*children[1]);
 }
 
 //----------------------------------------------------------------------------------------------------------------------
@@ -162,12 +169,9 @@ static void AnofoxIsValidCurrencyFunction(DataChunk &args, ExpressionState &stat
 static void AnofoxCurrencySymbolFunction(DataChunk &args, ExpressionState &state, Vector &result) {
     auto &registry = CurrencyRegistry::GetInstance();
     IterateCurrencyCode(args, result, [&](const std::string& code, idx_t i) {
-        auto currency = registry.GetCurrency(code);
-        if (!currency) {
-            throw InvalidInputException("Currency not found: %s", code.c_str());
-        }
+        auto &currency = LookupCurrencyOrThrow(registry, code);
         auto result_data = FlatVector::GetData<string_t>(result);
-        result_data[i] = StringVector::AddString(result, currency->symbol);
+        result_data[i] = StringVector::AddString(result, currency.symbol);
     });
 }
 
@@ -184,43 +188,22 @@ static void AnofoxMoneyFormatFunction(DataChunk &args, ExpressionState &state, V
     style_vec.ToUnifiedFormat(count, style_data);
     auto style_values = reinterpret_cast<string_t *>(style_data.data);
 
-    // Get money struct entries
-    auto &children = StructVector::GetEntries(money_vec);
-    if (children.size() != 2) {
-        throw InvalidInputException("Money struct must have exactly 2 fields");
-    }
-
-    auto &amount_vec = *children[0];
-    auto &currency_vec = *children[1];
-
-    UnifiedVectorFormat amount_data;
-    UnifiedVectorFormat currency_data;
-    amount_vec.ToUnifiedFormat(count, amount_data);
-    currency_vec.ToUnifiedFormat(count, currency_data);
-
-    auto amount_values = reinterpret_cast<double *>(amount_data.data);
-    auto currency_values = reinterpret_cast<string_t *>(currency_data.data);
+    auto data = ExtractMoneyStruct(money_vec, count);
 
     auto &registry = CurrencyRegistry::GetInstance();
     auto result_data = FlatVector::GetData<string_t>(result);
 
     for (idx_t i = 0; i < count; i++) {
-        auto amount_idx = amount_data.sel->get_index(i);
-        auto currency_idx = currency_data.sel->get_index(i);
         auto style_idx = style_data.sel->get_index(i);
 
-        if (!amount_data.validity.RowIsValid(amount_idx) || !currency_data.validity.RowIsValid(currency_idx) ||
-            !style_data.validity.RowIsValid(style_idx)) {
+        if (!data.RowIsValid(i) || !style_data.validity.RowIsValid(style_idx)) {
             FlatVector::SetNull(result, i, true);
         } else {
-            double amount = amount_values[amount_idx];
-            auto currency_code = currency_values[currency_idx].GetString();
+            double amount = data.Amount(i);
+            auto currency_code = data.Currency(i);
             auto format_style = style_values[style_idx].GetString();
 
-            auto currency = registry.GetCurrency(currency_code);
-            if (!currency) {
-                throw InvalidInputException("Currency not found: %s", currency_code);
-            }
+            auto &currency = LookupCurrencyOrThrow(registry, currency_code);
 
             // Format based on style
             std::string formatted;
@@ -231,32 +214,27 @@ static void AnofoxMoneyFormatFunction(DataChunk &args, ExpressionState &state, V
                 std::string amount_str(buffer);
 
                 // Replace decimal mark if needed
-                if (currency->decimal_mark != ".") {
+                if (currency.decimal_mark != ".") {
                     size_t dot_pos = amount_str.find('.');
                     if (dot_pos != std::string::npos) {
-                        amount_str[dot_pos] = currency->decimal_mark[0];
+                        amount_str[dot_pos] = currency.decimal_mark[0];
                     }
                 }
 
-                if (currency->symbol_first) {
-                    formatted = currency->symbol + amount_str;
+                if (currency.symbol_first) {
+                    formatted = currency.symbol + amount_str;
                 } else {
-                    formatted = amount_str + " " + currency->symbol;
+                    formatted = amount_str + " " + currency.symbol;
                 }
-            } else if (format_style == "code") {
-                // Format: 100.50 USD
-                char buffer[256];
-                snprintf(buffer, sizeof(buffer), "%.2f %s", amount, currency_code.c_str());
-                formatted = buffer;
             } else if (format_style == "long") {
                 // Format: 100.50 United States Dollar
                 char buffer[512];
-                snprintf(buffer, sizeof(buffer), "%.2f %s", amount, currency->name.c_str());
+                snprintf(buffer, sizeof(buffer), "%.2f %s", amount, currency.name.c_str());
                 formatted = buffer;
             } else {
-                // Default: ISO format with code
+                // 'code' and default: ISO format with the canonical currency code
                 char buffer[256];
-                snprintf(buffer, sizeof(buffer), "%.2f %s", amount, currency_code.c_str());
+                snprintf(buffer, sizeof(buffer), "%.2f %s", amount, currency.iso_code.c_str());
                 formatted = buffer;
             }
 
@@ -301,54 +279,16 @@ static void AnofoxMoneyIsZeroFunction(DataChunk &args, ExpressionState &state, V
 
 static void AnofoxMoneyAbsFunction(DataChunk &args, ExpressionState &state, Vector &result) {
     auto &money_vec = args.data[0];
-    auto &children = StructVector::GetEntries(money_vec);
-
-    if (children.size() != 2) {
-        throw InvalidInputException("Money struct must have exactly 2 fields");
-    }
-
     idx_t count = args.size();
-    auto &amount_vec = *children[0];
-    auto &currency_vec = *children[1];
 
-    UnifiedVectorFormat amount_data;
-    UnifiedVectorFormat currency_data;
-    amount_vec.ToUnifiedFormat(count, amount_data);
-    currency_vec.ToUnifiedFormat(count, currency_data);
-
-    auto amount_values = reinterpret_cast<double *>(amount_data.data);
-    auto currency_values = reinterpret_cast<string_t *>(currency_data.data);
-
-    // Get result struct entries
-    auto &result_children = StructVector::GetEntries(result);
-    if (result_children.size() != 2) {
-        throw InvalidInputException("Money struct must have exactly 2 fields");
-    }
-
-    auto &result_amount = *result_children[0];
-    auto &result_currency = *result_children[1];
-
-    result_amount.SetVectorType(VectorType::FLAT_VECTOR);
-    result_currency.SetVectorType(VectorType::FLAT_VECTOR);
-
-    auto result_amount_ptr = FlatVector::GetData<double>(result_amount);
-    auto result_currency_ptr = FlatVector::GetData<string_t>(result_currency);
-    auto &result_amount_validity = FlatVector::Validity(result_amount);
-    auto &result_currency_validity = FlatVector::Validity(result_currency);
+    auto data = ExtractMoneyStruct(money_vec, count);
+    auto builder = PrepareMoneyResult(result);
 
     for (idx_t i = 0; i < count; i++) {
-        auto amount_idx = amount_data.sel->get_index(i);
-        auto currency_idx = currency_data.sel->get_index(i);
-
-        if (!amount_data.validity.RowIsValid(amount_idx) || !currency_data.validity.RowIsValid(currency_idx)) {
-            result_amount_validity.SetInvalid(i);
-            result_currency_validity.SetInvalid(i);
+        if (!data.RowIsValid(i)) {
+            SetMoneyResultNull(result, i);
         } else {
-            double amount = amount_values[amount_idx];
-            auto currency_code = currency_values[currency_idx].GetString();
-
-            result_amount_ptr[i] = std::fabs(amount);
-            result_currency_ptr[i] = StringVector::AddString(result_currency, currency_code);
+            SetMoneyResult(builder, i, std::fabs(data.Amount(i)), data.Currency(i), result);
         }
     }
 }
@@ -361,9 +301,7 @@ static void AnofoxMoneyAddFunction(DataChunk &args, ExpressionState &state, Vect
     IterateBinaryMoneyOp(args, result, true, [](MoneyResultBuilder& builder, idx_t i,
                                                 double amount1, double amount2,
                                                 const std::string& currency, Vector& result) {
-        builder.amount_ptr[i] = amount1 + amount2;
-        builder.currency_ptr[i] = StringVector::AddString(
-            *StructVector::GetEntries(result)[1], currency);
+        SetMoneyResult(builder, i, amount1 + amount2, currency, result);
     });
 }
 
@@ -375,9 +313,7 @@ static void AnofoxMoneySubtractFunction(DataChunk &args, ExpressionState &state,
     IterateBinaryMoneyOp(args, result, true, [](MoneyResultBuilder& builder, idx_t i,
                                                 double amount1, double amount2,
                                                 const std::string& currency, Vector& result) {
-        builder.amount_ptr[i] = amount1 - amount2;
-        builder.currency_ptr[i] = StringVector::AddString(
-            *StructVector::GetEntries(result)[1], currency);
+        SetMoneyResult(builder, i, amount1 - amount2, currency, result);
     });
 }
 
@@ -398,23 +334,12 @@ static void AnofoxMoneyMultiplyFunction(DataChunk &args, ExpressionState &state,
     auto factor_values = reinterpret_cast<double *>(factor_data.data);
 
     for (idx_t i = 0; i < count; i++) {
-        auto amount_idx = data.amount_data.sel->get_index(i);
-        auto currency_idx = data.currency_data.sel->get_index(i);
         auto factor_idx = factor_data.sel->get_index(i);
 
-        if (!data.amount_data.validity.RowIsValid(amount_idx) ||
-            !data.currency_data.validity.RowIsValid(currency_idx) ||
-            !factor_data.validity.RowIsValid(factor_idx)) {
-            builder.amount_validity.SetInvalid(i);
-            builder.currency_validity.SetInvalid(i);
+        if (!data.RowIsValid(i) || !factor_data.validity.RowIsValid(factor_idx)) {
+            SetMoneyResultNull(result, i);
         } else {
-            double amount = data.amount_values[amount_idx];
-            auto currency = data.currency_values[currency_idx].GetString();
-            double factor = factor_values[factor_idx];
-
-            builder.amount_ptr[i] = amount * factor;
-            auto& currency_vec = *StructVector::GetEntries(result)[1];
-            builder.currency_ptr[i] = StringVector::AddString(currency_vec, currency);
+            SetMoneyResult(builder, i, data.Amount(i) * factor_values[factor_idx], data.Currency(i), result);
         }
     }
 }
@@ -429,33 +354,25 @@ static void AnofoxMoneyInRangeFunction(DataChunk &args, ExpressionState &state, 
     auto &max_vec = args.data[2];
     idx_t count = args.size();
 
-    auto &children = StructVector::GetEntries(money_vec);
-    if (children.size() != 2) {
-        throw InvalidInputException("Money struct must have exactly 2 fields");
-    }
+    auto data = ExtractMoneyStruct(money_vec, count);
 
-    auto &amount_vec = *children[0];
-
-    UnifiedVectorFormat amount_data, min_data, max_data;
-    amount_vec.ToUnifiedFormat(count, amount_data);
+    UnifiedVectorFormat min_data, max_data;
     min_vec.ToUnifiedFormat(count, min_data);
     max_vec.ToUnifiedFormat(count, max_data);
 
-    auto amount_values = reinterpret_cast<double *>(amount_data.data);
     auto min_values = reinterpret_cast<double *>(min_data.data);
     auto max_values = reinterpret_cast<double *>(max_data.data);
     auto result_data = FlatVector::GetData<bool>(result);
 
     for (idx_t i = 0; i < count; i++) {
-        auto amount_idx = amount_data.sel->get_index(i);
         auto min_idx = min_data.sel->get_index(i);
         auto max_idx = max_data.sel->get_index(i);
 
-        if (!amount_data.validity.RowIsValid(amount_idx) || !min_data.validity.RowIsValid(min_idx) ||
+        if (!data.RowIsValid(i) || !min_data.validity.RowIsValid(min_idx) ||
             !max_data.validity.RowIsValid(max_idx)) {
             FlatVector::SetNull(result, i, true);
         } else {
-            double amount = amount_values[amount_idx];
+            double amount = data.Amount(i);
             double min_val = min_values[min_idx];
             double max_val = max_values[max_idx];
             result_data[i] = (amount >= min_val && amount <= max_val);
@@ -472,34 +389,17 @@ static void AnofoxMoneySameCurrencyFunction(DataChunk &args, ExpressionState &st
     auto &money2_vec = args.data[1];
     idx_t count = args.size();
 
-    auto &children1 = StructVector::GetEntries(money1_vec);
-    auto &children2 = StructVector::GetEntries(money2_vec);
-
-    if (children1.size() != 2 || children2.size() != 2) {
-        throw InvalidInputException("Money struct must have exactly 2 fields");
-    }
-
-    auto &currency1_vec = *children1[1];
-    auto &currency2_vec = *children2[1];
-
-    UnifiedVectorFormat currency1_data, currency2_data;
-    currency1_vec.ToUnifiedFormat(count, currency1_data);
-    currency2_vec.ToUnifiedFormat(count, currency2_data);
-
-    auto currency1_values = reinterpret_cast<string_t *>(currency1_data.data);
-    auto currency2_values = reinterpret_cast<string_t *>(currency2_data.data);
+    auto data1 = ExtractMoneyStruct(money1_vec, count);
+    auto data2 = ExtractMoneyStruct(money2_vec, count);
     auto result_data = FlatVector::GetData<bool>(result);
 
     for (idx_t i = 0; i < count; i++) {
-        auto currency1_idx = currency1_data.sel->get_index(i);
-        auto currency2_idx = currency2_data.sel->get_index(i);
-
-        if (!currency1_data.validity.RowIsValid(currency1_idx) || !currency2_data.validity.RowIsValid(currency2_idx)) {
+        if (!data1.RowIsValid(i) || !data2.RowIsValid(i)) {
             FlatVector::SetNull(result, i, true);
         } else {
-            auto c1 = currency1_values[currency1_idx].GetString();
-            auto c2 = currency2_values[currency2_idx].GetString();
-            result_data[i] = (c1 == c2);
+            // Canonical codes are stored at construction; compare case-insensitively so that
+            // manually constructed structs with mixed-case codes behave consistently
+            result_data[i] = StringUtil::CIEquals(data1.Currency(i), data2.Currency(i));
         }
     }
 }
@@ -511,12 +411,9 @@ static void AnofoxMoneySameCurrencyFunction(DataChunk &args, ExpressionState &st
 static void AnofoxCurrencyNameFunction(DataChunk &args, ExpressionState &state, Vector &result) {
     auto &registry = CurrencyRegistry::GetInstance();
     IterateCurrencyCode(args, result, [&](const std::string& code, idx_t i) {
-        auto currency = registry.GetCurrency(code);
-        if (!currency) {
-            throw InvalidInputException("Currency not found: %s", code.c_str());
-        }
+        auto &currency = LookupCurrencyOrThrow(registry, code);
         auto result_data = FlatVector::GetData<string_t>(result);
-        result_data[i] = StringVector::AddString(result, currency->name);
+        result_data[i] = StringVector::AddString(result, currency.name);
     });
 }
 
@@ -624,17 +521,19 @@ void RegisterMoneyFunctions(ExtensionLoader &loader) {
         desc.categories = {"money"};
         ScalarFunction money_func("anofox_tab_money", {LogicalTypeId::DOUBLE, LogicalTypeId::VARCHAR}, GetMoneyType(), AnofoxMoneyFunction);
         money_func.bind = MoneyBind;
+        money_func.SetFallible();
         RegisterScalarFunctionWithAlias(loader, money_func, "money", {std::move(desc)});
     }
     {
         FunctionDescription desc;
-        desc.description = "Creates a money value from an integer amount in cents and ISO 4217 currency code.";
+        desc.description = "Creates a money value from an integer amount in the smallest currency unit (e.g. cents) and ISO 4217 currency code.";
         desc.parameter_names = {"cents", "currency_code"};
         desc.parameter_types = {LogicalType::BIGINT, LogicalType::VARCHAR};
         desc.examples = {"SELECT money_from_cents(1999, 'USD');"};
         desc.categories = {"money"};
         ScalarFunction money_from_cents_func("anofox_tab_money_from_cents", {LogicalTypeId::BIGINT, LogicalTypeId::VARCHAR}, GetMoneyType(), AnofoxMoneyFromCentsFunction);
         money_from_cents_func.bind = MoneyFromCentsBind;
+        money_from_cents_func.SetFallible();
         RegisterScalarFunctionWithAlias(loader, money_from_cents_func, "money_from_cents", {std::move(desc)});
     }
     {
@@ -646,6 +545,7 @@ void RegisterMoneyFunctions(ExtensionLoader &loader) {
         desc.categories = {"money"};
         ScalarFunction money_amount_func("anofox_tab_money_amount", {GetMoneyType()}, LogicalTypeId::DOUBLE, AnofoxMoneyAmountFunction);
         money_amount_func.bind = MoneyAmountBind;
+        money_amount_func.SetFallible();
         RegisterScalarFunctionWithAlias(loader, money_amount_func, "money_amount", {std::move(desc)});
     }
     {
@@ -657,6 +557,7 @@ void RegisterMoneyFunctions(ExtensionLoader &loader) {
         desc.categories = {"money"};
         ScalarFunction money_currency_func("anofox_tab_money_currency", {GetMoneyType()}, LogicalTypeId::VARCHAR, AnofoxMoneyCurrencyFunction);
         money_currency_func.bind = MoneyCurrencyBind;
+        money_currency_func.SetFallible();
         RegisterScalarFunctionWithAlias(loader, money_currency_func, "money_currency", {std::move(desc)});
     }
     {
@@ -679,6 +580,7 @@ void RegisterMoneyFunctions(ExtensionLoader &loader) {
         desc.categories = {"money"};
         ScalarFunction currency_symbol_func("anofox_tab_currency_symbol", {LogicalTypeId::VARCHAR}, LogicalTypeId::VARCHAR, AnofoxCurrencySymbolFunction);
         currency_symbol_func.bind = CurrencySymbolBind;
+        currency_symbol_func.SetFallible();
         RegisterScalarFunctionWithAlias(loader, currency_symbol_func, "currency_symbol", {std::move(desc)});
     }
     {
@@ -690,6 +592,7 @@ void RegisterMoneyFunctions(ExtensionLoader &loader) {
         desc.categories = {"money"};
         ScalarFunction currency_name_func("anofox_tab_currency_name", {LogicalTypeId::VARCHAR}, LogicalTypeId::VARCHAR, AnofoxCurrencyNameFunction);
         currency_name_func.bind = CurrencyNameBind;
+        currency_name_func.SetFallible();
         RegisterScalarFunctionWithAlias(loader, currency_name_func, "currency_name", {std::move(desc)});
     }
     {
@@ -701,6 +604,7 @@ void RegisterMoneyFunctions(ExtensionLoader &loader) {
         desc.categories = {"money", "formatting"};
         ScalarFunction money_format_func("anofox_tab_money_format", {GetMoneyType(), LogicalTypeId::VARCHAR}, LogicalTypeId::VARCHAR, AnofoxMoneyFormatFunction);
         money_format_func.bind = MoneyFormatBind;
+        money_format_func.SetFallible();
         RegisterScalarFunctionWithAlias(loader, money_format_func, "money_format", {std::move(desc)});
     }
     {
@@ -712,6 +616,7 @@ void RegisterMoneyFunctions(ExtensionLoader &loader) {
         desc.categories = {"money", "validation"};
         ScalarFunction money_is_positive_func("anofox_tab_money_is_positive", {GetMoneyType()}, LogicalTypeId::BOOLEAN, AnofoxMoneyIsPositiveFunction);
         money_is_positive_func.bind = MoneyIsPositiveBind;
+        money_is_positive_func.SetFallible();
         RegisterScalarFunctionWithAlias(loader, money_is_positive_func, "money_is_positive", {std::move(desc)});
     }
     {
@@ -723,6 +628,7 @@ void RegisterMoneyFunctions(ExtensionLoader &loader) {
         desc.categories = {"money", "validation"};
         ScalarFunction money_is_negative_func("anofox_tab_money_is_negative", {GetMoneyType()}, LogicalTypeId::BOOLEAN, AnofoxMoneyIsNegativeFunction);
         money_is_negative_func.bind = MoneyIsNegativeBind;
+        money_is_negative_func.SetFallible();
         RegisterScalarFunctionWithAlias(loader, money_is_negative_func, "money_is_negative", {std::move(desc)});
     }
     {
@@ -734,6 +640,7 @@ void RegisterMoneyFunctions(ExtensionLoader &loader) {
         desc.categories = {"money", "validation"};
         ScalarFunction money_is_zero_func("anofox_tab_money_is_zero", {GetMoneyType()}, LogicalTypeId::BOOLEAN, AnofoxMoneyIsZeroFunction);
         money_is_zero_func.bind = MoneyIsZeroBind;
+        money_is_zero_func.SetFallible();
         RegisterScalarFunctionWithAlias(loader, money_is_zero_func, "money_is_zero", {std::move(desc)});
     }
     {
@@ -745,6 +652,7 @@ void RegisterMoneyFunctions(ExtensionLoader &loader) {
         desc.categories = {"money"};
         ScalarFunction money_abs_func("anofox_tab_money_abs", {GetMoneyType()}, GetMoneyType(), AnofoxMoneyAbsFunction);
         money_abs_func.bind = MoneyAbsBind;
+        money_abs_func.SetFallible();
         RegisterScalarFunctionWithAlias(loader, money_abs_func, "money_abs", {std::move(desc)});
     }
     {
@@ -756,6 +664,7 @@ void RegisterMoneyFunctions(ExtensionLoader &loader) {
         desc.categories = {"money", "arithmetic"};
         ScalarFunction money_add_func("anofox_tab_money_add", {GetMoneyType(), GetMoneyType()}, GetMoneyType(), AnofoxMoneyAddFunction);
         money_add_func.bind = MoneyAddBind;
+        money_add_func.SetFallible();
         RegisterScalarFunctionWithAlias(loader, money_add_func, "money_add", {std::move(desc)});
     }
     {
@@ -767,6 +676,7 @@ void RegisterMoneyFunctions(ExtensionLoader &loader) {
         desc.categories = {"money", "arithmetic"};
         ScalarFunction money_subtract_func("anofox_tab_money_subtract", {GetMoneyType(), GetMoneyType()}, GetMoneyType(), AnofoxMoneySubtractFunction);
         money_subtract_func.bind = MoneySubtractBind;
+        money_subtract_func.SetFallible();
         RegisterScalarFunctionWithAlias(loader, money_subtract_func, "money_subtract", {std::move(desc)});
     }
     {
@@ -778,6 +688,7 @@ void RegisterMoneyFunctions(ExtensionLoader &loader) {
         desc.categories = {"money", "arithmetic"};
         ScalarFunction money_multiply_func("anofox_tab_money_multiply", {GetMoneyType(), LogicalTypeId::DOUBLE}, GetMoneyType(), AnofoxMoneyMultiplyFunction);
         money_multiply_func.bind = MoneyMultiplyBind;
+        money_multiply_func.SetFallible();
         RegisterScalarFunctionWithAlias(loader, money_multiply_func, "money_multiply", {std::move(desc)});
     }
     {
@@ -789,6 +700,7 @@ void RegisterMoneyFunctions(ExtensionLoader &loader) {
         desc.categories = {"money", "validation"};
         ScalarFunction money_in_range_func("anofox_tab_money_in_range", {GetMoneyType(), LogicalTypeId::DOUBLE, LogicalTypeId::DOUBLE}, LogicalTypeId::BOOLEAN, AnofoxMoneyInRangeFunction);
         money_in_range_func.bind = MoneyInRangeBind;
+        money_in_range_func.SetFallible();
         RegisterScalarFunctionWithAlias(loader, money_in_range_func, "money_in_range", {std::move(desc)});
     }
     {
@@ -800,6 +712,7 @@ void RegisterMoneyFunctions(ExtensionLoader &loader) {
         desc.categories = {"money", "comparison"};
         ScalarFunction money_same_currency_func("anofox_tab_money_same_currency", {GetMoneyType(), GetMoneyType()}, LogicalTypeId::BOOLEAN, AnofoxMoneySameCurrencyFunction);
         money_same_currency_func.bind = MoneySameCurrencyBind;
+        money_same_currency_func.SetFallible();
         RegisterScalarFunctionWithAlias(loader, money_same_currency_func, "money_same_currency", {std::move(desc)});
     }
 

--- a/src/anofox_money_currency.cpp
+++ b/src/anofox_money_currency.cpp
@@ -4,17 +4,16 @@
 namespace duckdb {
 namespace anofox {
 
-CurrencyRegistry &CurrencyRegistry::GetInstance() {
-    static CurrencyRegistry instance;
-    if (!instance.initialized) {
-        instance.Initialize();
-    }
-    return instance;
+CurrencyRegistry::CurrencyRegistry() {
+    LoadCurrencies();
 }
 
-void CurrencyRegistry::Initialize() {
-    LoadCurrencies();
-    initialized = true;
+CurrencyRegistry &CurrencyRegistry::GetInstance() {
+    // Thread-safe under C++11 magic statics: the constructor fully populates the
+    // registry before the reference can escape to any thread, and the registry is
+    // immutable afterwards (issue #43).
+    static CurrencyRegistry instance;
+    return instance;
 }
 
 void CurrencyRegistry::LoadCurrencies() {

--- a/src/include/anofox_function_alias.hpp
+++ b/src/include/anofox_function_alias.hpp
@@ -13,13 +13,14 @@ namespace anofox {
 inline void RegisterScalarFunctionWithAlias(ExtensionLoader &loader, ScalarFunction func, const std::string &alias_name) {
 	// Register primary function
 	loader.RegisterFunction(func);
-	
+
 	// Register alias
 	ScalarFunction alias_func(alias_name, func.arguments, func.return_type, func.function);
 	alias_func.null_handling = func.null_handling;
 	alias_func.stability = func.stability;
 	alias_func.varargs = func.varargs;
 	alias_func.bind = func.bind;
+	alias_func.SetErrorMode(func.GetErrorMode());
 
 	CreateScalarFunctionInfo alias_info(alias_func);
 	alias_info.alias_of = func.name;
@@ -39,9 +40,10 @@ inline void RegisterScalarFunctionSetWithAlias(ExtensionLoader &loader, ScalarFu
 		alias_func.stability = func.stability;
 		alias_func.varargs = func.varargs;
 		alias_func.bind = func.bind;
+		alias_func.SetErrorMode(func.GetErrorMode());
 		alias_set.AddFunction(alias_func);
 	}
-	
+
 	CreateScalarFunctionInfo alias_info(alias_set);
 	alias_info.alias_of = func_set.name;
 	loader.RegisterFunction(alias_info);
@@ -100,6 +102,7 @@ inline void RegisterScalarFunctionWithAlias(ExtensionLoader &loader, ScalarFunct
     alias_func.stability = func.stability;
     alias_func.varargs = func.varargs;
     alias_func.bind = func.bind;
+    alias_func.SetErrorMode(func.GetErrorMode());
     CreateScalarFunctionInfo alias_info(alias_func);
     alias_info.alias_of = func.name;
     loader.RegisterFunction(alias_info);
@@ -122,6 +125,7 @@ inline void RegisterScalarFunctionSetWithAlias(ExtensionLoader &loader, ScalarFu
         alias_func.stability = func.stability;
         alias_func.varargs = func.varargs;
         alias_func.bind = func.bind;
+        alias_func.SetErrorMode(func.GetErrorMode());
         alias_set.AddFunction(alias_func);
     }
     CreateScalarFunctionInfo alias_info(alias_set);

--- a/src/include/anofox_money.hpp
+++ b/src/include/anofox_money.hpp
@@ -3,6 +3,7 @@
 #include "duckdb/main/extension/extension_loader.hpp"
 #include "duckdb/common/types/vector.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
+#include "duckdb/common/string_util.hpp"
 
 namespace duckdb {
 namespace anofox {
@@ -13,10 +14,32 @@ namespace anofox {
 struct MoneyStructData {
   Vector& amount_vec;
   Vector& currency_vec;
+  UnifiedVectorFormat struct_data;
   UnifiedVectorFormat amount_data;
   UnifiedVectorFormat currency_data;
   double* amount_values;
   string_t* currency_values;
+
+  //! A money row is only usable if the parent struct and both children are non-NULL.
+  //! A struct with NULL children is treated as a NULL money value (issue #43).
+  //! The children belong to the row space of the (possibly dictionary-wrapped)
+  //! struct vector, so they are indexed through the parent selection first.
+  bool RowIsValid(idx_t i) const {
+    auto row = struct_data.sel->get_index(i);
+    return struct_data.validity.RowIsValid(row) &&
+           amount_data.validity.RowIsValid(amount_data.sel->get_index(row)) &&
+           currency_data.validity.RowIsValid(currency_data.sel->get_index(row));
+  }
+
+  double Amount(idx_t i) const {
+    auto row = struct_data.sel->get_index(i);
+    return amount_values[amount_data.sel->get_index(row)];
+  }
+
+  std::string Currency(idx_t i) const {
+    auto row = struct_data.sel->get_index(i);
+    return currency_values[currency_data.sel->get_index(row)].GetString();
+  }
 };
 
 inline MoneyStructData ExtractMoneyStruct(Vector& money_vec, idx_t count) {
@@ -30,6 +53,7 @@ inline MoneyStructData ExtractMoneyStruct(Vector& money_vec, idx_t count) {
     *children[1],
   };
 
+  money_vec.ToUnifiedFormat(count, data.struct_data);
   data.amount_vec.ToUnifiedFormat(count, data.amount_data);
   data.currency_vec.ToUnifiedFormat(count, data.currency_data);
   data.amount_values = reinterpret_cast<double*>(data.amount_data.data);
@@ -76,6 +100,13 @@ inline void SetMoneyResult(MoneyResultBuilder& builder, idx_t i,
   builder.currency_ptr[i] = StringVector::AddString(*children[1], currency);
 }
 
+//! Marks a money result row as SQL NULL. FlatVector::SetNull on a STRUCT vector
+//! sets the parent validity and recursively invalidates the children, so the
+//! row satisfies the invariant `f(NULL) IS NULL`.
+inline void SetMoneyResultNull(Vector& result, idx_t i) {
+  FlatVector::SetNull(result, i, true);
+}
+
 // ============================================================================
 // Currency Input Iterator Template
 // ============================================================================
@@ -112,11 +143,10 @@ inline void IterateMoneyComparison(DataChunk& args, Vector& result,
   auto result_data = FlatVector::GetData<bool>(result);
 
   for (idx_t i = 0; i < count; i++) {
-    auto amount_idx = data.amount_data.sel->get_index(i);
-    if (!data.amount_data.validity.RowIsValid(amount_idx)) {
+    if (!data.RowIsValid(i)) {
       FlatVector::SetNull(result, i, true);
     } else {
-      result_data[i] = pred(data.amount_values[amount_idx]);
+      result_data[i] = pred(data.Amount(i));
     }
   }
 }
@@ -136,31 +166,21 @@ inline void IterateBinaryMoneyOp(DataChunk& args, Vector& result,
   auto builder = PrepareMoneyResult(result);
 
   for (idx_t i = 0; i < count; i++) {
-    auto amount1_idx = data1.amount_data.sel->get_index(i);
-    auto currency1_idx = data1.currency_data.sel->get_index(i);
-    auto amount2_idx = data2.amount_data.sel->get_index(i);
-    auto currency2_idx = data2.currency_data.sel->get_index(i);
-
-    if (!data1.amount_data.validity.RowIsValid(amount1_idx) ||
-        !data1.currency_data.validity.RowIsValid(currency1_idx) ||
-        !data2.amount_data.validity.RowIsValid(amount2_idx) ||
-        !data2.currency_data.validity.RowIsValid(currency2_idx)) {
-      builder.amount_validity.SetInvalid(i);
-      builder.currency_validity.SetInvalid(i);
+    if (!data1.RowIsValid(i) || !data2.RowIsValid(i)) {
+      SetMoneyResultNull(result, i);
     } else {
-      auto currency1 = data1.currency_values[currency1_idx].GetString();
-      auto currency2 = data2.currency_values[currency2_idx].GetString();
+      auto currency1 = data1.Currency(i);
+      auto currency2 = data2.Currency(i);
 
-      if (check_same_currency && currency1 != currency2) {
+      // Codes are canonicalized at construction; compare case-insensitively so
+      // manually constructed structs with mixed-case codes still work.
+      if (check_same_currency && !StringUtil::CIEquals(currency1, currency2)) {
         throw InvalidInputException(
             "Cannot operate on money with different currencies: %s and %s",
             currency1.c_str(), currency2.c_str());
       }
 
-      double amount1 = data1.amount_values[amount1_idx];
-      double amount2 = data2.amount_values[amount2_idx];
-
-      op(builder, i, amount1, amount2, currency1, result);
+      op(builder, i, data1.Amount(i), data2.Amount(i), currency1, result);
     }
   }
 }

--- a/src/include/anofox_money_currency.hpp
+++ b/src/include/anofox_money_currency.hpp
@@ -25,13 +25,11 @@ struct CurrencyInfo {
     ~CurrencyInfo() = default;
 };
 
-// Global currency registry
+// Global currency registry. Fully initialized by its constructor (thread-safe
+// via C++11 magic statics) and immutable afterwards.
 class CurrencyRegistry {
 public:
     static CurrencyRegistry &GetInstance();
-
-    // Initialize the registry from embedded JSON
-    void Initialize();
 
     // Look up currency by ISO code (case-insensitive)
     optional_ptr<const CurrencyInfo> GetCurrency(const string &iso_code) const;
@@ -46,10 +44,9 @@ public:
     idx_t GetCurrencyCount() const;
 
 private:
-    CurrencyRegistry() = default;
+    CurrencyRegistry();
 
     case_insensitive_map_t<unique_ptr<CurrencyInfo>> currencies;
-    bool initialized = false;
 
     // Load hardcoded currencies into registry
     void LoadCurrencies();

--- a/test/sql/anofox_money.test
+++ b/test/sql/anofox_money.test
@@ -17,16 +17,16 @@ SELECT anofox_tab_money(1000.0, 'JPY');
 ----
 {'amount': 1000.0, 'currency': JPY}
 
-# Test anofox_tab_money_from_cents
+# Test anofox_tab_money_from_cents (divides by the currency's subunit_to_unit)
 query T
 SELECT anofox_tab_money_from_cents(10050, 'USD');
 ----
-{'amount': 10050.0, 'currency': USD}
+{'amount': 100.5, 'currency': USD}
 
 query T
 SELECT anofox_tab_money_from_cents(5000, 'EUR');
 ----
-{'amount': 5000.0, 'currency': EUR}
+{'amount': 50.0, 'currency': EUR}
 
 # Test anofox_tab_money_amount extraction
 query I
@@ -256,11 +256,11 @@ SELECT anofox_tab_currency_symbol(anofox_tab_money_currency(anofox_tab_money(50.
 ----
 €
 
-# Test case insensitivity of currency codes in queries (depends on implementation)
+# Test case insensitivity of currency codes: stored as canonical ISO code
 query T
 SELECT anofox_tab_money(100.0, 'usd');
 ----
-{'amount': 100.0, 'currency': usd}
+{'amount': 100.0, 'currency': USD}
 
 # Test anofox_tab_money_format with 'symbol' style
 query T

--- a/test/sql/anofox_money_correctness.test
+++ b/test/sql/anofox_money_correctness.test
@@ -1,0 +1,195 @@
+# name: test/sql/anofox_money_correctness.test
+# description: Correctness tests for the money module (issue #43):
+#   - money_from_cents must divide by the currency's subunit_to_unit
+#   - currency codes must be canonicalized to the ISO code at construction
+#   - NULL/invalid rows must yield SQL NULL parent structs (f(NULL) IS NULL)
+#   - invalid currency codes must raise
+# group: [anofox_tabular]
+
+require anofox_tabular
+
+#----------------------------------------------------------------------------------------------------------------------
+# money_from_cents: subunit division
+#----------------------------------------------------------------------------------------------------------------------
+
+# USD has 100 subunits per unit -> 10050 cents = 100.50 USD
+query T
+SELECT anofox_tab_money_from_cents(10050, 'USD');
+----
+{'amount': 100.5, 'currency': USD}
+
+query R
+SELECT anofox_tab_money_amount(anofox_tab_money_from_cents(1999, 'EUR'));
+----
+19.99
+
+# JPY is a zero-decimal currency (subunit_to_unit = 1) -> 1000 stays 1000
+query T
+SELECT anofox_tab_money_from_cents(1000, 'JPY');
+----
+{'amount': 1000.0, 'currency': JPY}
+
+# Negative cents
+query T
+SELECT anofox_tab_money_from_cents(-500, 'USD');
+----
+{'amount': -5.0, 'currency': USD}
+
+# Large cent values
+query R
+SELECT anofox_tab_money_amount(anofox_tab_money_from_cents(922337203685477, 'USD'));
+----
+9223372036854.77
+
+#----------------------------------------------------------------------------------------------------------------------
+# Currency canonicalization: lower/mixed case input is stored as the canonical ISO code
+#----------------------------------------------------------------------------------------------------------------------
+
+query T
+SELECT anofox_tab_money(100.0, 'usd');
+----
+{'amount': 100.0, 'currency': USD}
+
+query T
+SELECT anofox_tab_money(50.0, 'eUr');
+----
+{'amount': 50.0, 'currency': EUR}
+
+query T
+SELECT anofox_tab_money_from_cents(1000, 'usd');
+----
+{'amount': 10.0, 'currency': USD}
+
+query T
+SELECT anofox_tab_money_currency(anofox_tab_money(1.0, 'gbp'));
+----
+GBP
+
+# Mixed-case arithmetic must work: same currency in different case
+query T
+SELECT anofox_tab_money_add(anofox_tab_money(1.0, 'usd'), anofox_tab_money(1.0, 'USD'));
+----
+{'amount': 2.0, 'currency': USD}
+
+query T
+SELECT anofox_tab_money_subtract(anofox_tab_money(5.0, 'Eur'), anofox_tab_money(2.0, 'EUR'));
+----
+{'amount': 3.0, 'currency': EUR}
+
+query I
+SELECT anofox_tab_money_same_currency(anofox_tab_money(1.0, 'usd'), anofox_tab_money(1.0, 'USD'));
+----
+true
+
+# Truly different currencies must still raise
+statement error
+SELECT anofox_tab_money_add(anofox_tab_money(1.0, 'USD'), anofox_tab_money(1.0, 'EUR'));
+----
+different currencies
+
+#----------------------------------------------------------------------------------------------------------------------
+# Invalid currency codes raise
+#----------------------------------------------------------------------------------------------------------------------
+
+statement error
+SELECT anofox_tab_money(1.0, 'ZZZ');
+----
+Invalid currency code
+
+statement error
+SELECT anofox_tab_money_from_cents(100, 'ZZZ');
+----
+Invalid currency code
+
+#----------------------------------------------------------------------------------------------------------------------
+# NULL propagation: parent struct must be SQL NULL (not a struct of NULL fields)
+# Use table-sourced NULLs so the binder cannot constant-fold the NULL away.
+#----------------------------------------------------------------------------------------------------------------------
+
+query I
+SELECT anofox_tab_money(a, c) IS NULL
+FROM (VALUES (NULL, 'USD'), (1.5, NULL), (1.5, 'USD')) t(a, c);
+----
+true
+true
+false
+
+query I
+SELECT anofox_tab_money_from_cents(cents, c) IS NULL
+FROM (VALUES (NULL, 'USD'), (150, 'USD')) t(cents, c);
+----
+true
+false
+
+statement ok
+CREATE TABLE money_null_tbl AS
+SELECT anofox_tab_money(1.0, 'USD') AS m
+UNION ALL
+SELECT NULL;
+
+query I
+SELECT anofox_tab_money_amount(m) IS NULL FROM money_null_tbl ORDER BY 1;
+----
+false
+true
+
+query I
+SELECT anofox_tab_money_currency(m) IS NULL FROM money_null_tbl ORDER BY 1;
+----
+false
+true
+
+query I
+SELECT anofox_tab_money_abs(m) IS NULL FROM money_null_tbl ORDER BY 1;
+----
+false
+true
+
+query I
+SELECT anofox_tab_money_add(m, anofox_tab_money(1.0, 'USD')) IS NULL FROM money_null_tbl ORDER BY 1;
+----
+false
+true
+
+query I
+SELECT anofox_tab_money_multiply(m, 2.0) IS NULL FROM money_null_tbl ORDER BY 1;
+----
+false
+true
+
+statement ok
+DROP TABLE money_null_tbl;
+
+# Manually constructed structs with NULL children are treated as NULL money values:
+# the parent struct of the result must be SQL NULL.
+query I
+SELECT anofox_tab_money_abs(s) IS NULL
+FROM (SELECT {'amount': NULL, 'currency': 'USD'}::STRUCT(amount DOUBLE, currency VARCHAR) AS s) t;
+----
+true
+
+query I
+SELECT anofox_tab_money_add(s, anofox_tab_money(1.0, 'USD')) IS NULL
+FROM (SELECT {'amount': 2.0, 'currency': NULL}::STRUCT(amount DOUBLE, currency VARCHAR) AS s) t;
+----
+true
+
+query I
+SELECT anofox_tab_money_amount(s) IS NULL
+FROM (SELECT {'amount': NULL, 'currency': 'USD'}::STRUCT(amount DOUBLE, currency VARCHAR) AS s) t;
+----
+true
+
+#----------------------------------------------------------------------------------------------------------------------
+# Sanity: results of constructors stay usable downstream after canonicalization
+#----------------------------------------------------------------------------------------------------------------------
+
+query T
+SELECT anofox_tab_money_format(anofox_tab_money_from_cents(10050, 'usd'), 'code');
+----
+100.50 USD
+
+query I
+SELECT anofox_tab_money_is_positive(anofox_tab_money_from_cents(1, 'USD'));
+----
+true


### PR DESCRIPTION
## Summary

Fixes the five money-module findings from the 2026-06 code review (section 2.7, Phase 1). All findings were re-verified against current `main` (post-UnifiedVectorFormat rewrite) and **all five were still present**; none had been fixed in the interim.

| Finding | Fix |
|---|---|
| `CurrencyRegistry::GetInstance()` did unsynchronized lazy `Initialize()` after the magic static | Registry is now fully populated in its constructor; the mutable `initialized` flag and public `Initialize()` are gone. Under the C++11 magic-static guarantee the constructor completes before the reference can escape to any thread, and the registry is immutable afterwards — provably race-free without locks. |
| `money_from_cents(10050,'USD')` returned `10050.0` (`subunit_to_unit` fetched but unused) | Divides by `subunit_to_unit` (10050 → 100.50 USD; JPY with `subunit_to_unit = 1` unchanged) and rejects invalid denominators (`<= 0`) with an `InternalException`. |
| `'usd'` accepted case-insensitively but stored verbatim; `money_add(money(1,'usd'), money(1,'USD'))` threw | Constructors store the canonical `CurrencyInfo::iso_code`; binary ops and `money_same_currency` compare case-insensitively (`StringUtil::CIEquals`) so manually built mixed-case structs work too. |
| Invalid/NULL rows produced a non-NULL parent struct with NULL children | Invariant defined and enforced: invalid row ⇒ parent struct SQL NULL (`FlatVector::SetNull` on the STRUCT result recursively invalidates children, so `f(NULL) IS NULL` holds). Consumers (`money_amount`, `money_currency`, predicates, arithmetic, `money_format`) treat structs with NULL children as NULL money values, checking parent validity through the struct's selection vector — which also makes the accessors correct for dictionary/constant struct inputs. |
| Throwing functions registered with default `CANNOT_ERROR` | `SetFallible()` on every money function that can throw (all except `is_valid_currency`); the alias-registration helpers in `anofox_function_alias.hpp` now propagate the error mode so aliases keep `CAN_THROW_RUNTIME_ERROR`. |

## Breaking change

`anofox_tab_money_from_cents` / `money_from_cents` previously stored the raw cents value as the amount. It now returns major units (`10050` cents → `100.50` USD). The Python package tests (`python/tests/test_money.py`), `README.md` and `docs/API_REFERENCE.md` are updated to the new semantics in this PR.

## Red/green evidence

First commit (`test: add failing tests for money correctness (#43)`) is tests-only. Against the unmodified implementation:

```
SELECT anofox_tab_money_from_cents(10050, 'USD');
Mismatch on row 1: {'amount': 10050.0, 'currency': USD} <> {'amount': 100.5, 'currency': USD}

SELECT anofox_tab_money(100.0, 'usd');
Mismatch on row 1: {'amount': 100.0, 'currency': usd} <> {'amount': 100.0, 'currency': USD}

SELECT anofox_tab_money(a, c) IS NULL FROM (VALUES (NULL, 'USD'), (1.5, 'USD')) t(a, c);
Actual result: 0 / 0   (expected: true / false)

SELECT anofox_tab_money_add(anofox_tab_money(1.0, 'usd'), anofox_tab_money(1.0, 'USD'));
Query unexpectedly failed: Invalid Input Error: Cannot operate on money with different currencies: usd and USD
```

Already-passing red tests kept as regression coverage: `money_from_cents(1000,'JPY') = 1000` (zero-decimal currency happens to be right because `subunit_to_unit = 1`) and the invalid-currency error tests.

## Registry race note

A deterministic red test for the initialization race is impossible. There is no `test/cpp/` Catch2 infrastructure in this repo, so no stress test was added; instead the race is removed structurally (constructor init under the C++11 magic-static guarantee, immutable afterwards), which is safe by construction rather than by observation.

## Out of scope (pre-existing)

The standalone `build/release/duckdb` shell segfaults on queries that trigger telemetry — the crash is in the PostHog telemetry background thread (`duckdb_httplib_openssl::Client` → `duckdb_re2::BitState::TrySearch`), reproducible on unmodified `main`, and unrelated to the money module.

## Test status

- `make test`: all green (1661 assertions in 17 test cases, 1 env-skip `OPENVINO_AVAILABLE`)
- New `test/sql/anofox_money_correctness.test`: 37 assertions green
- Python: `uv run pytest tests/ -v` → 243 passed

Closes #43
