### PR TITLE
fix: route all generated SQL through shared quoting helpers

### DIFF
--- a/src/anofox_diff.cpp
+++ b/src/anofox_diff.cpp
@@ -1,5 +1,6 @@
 #include "anofox_diff.hpp"
 #include "anofox_function_alias.hpp"
+#include "anofox_sql_utils.hpp"
 #include "telemetry.hpp"
 
 #include "duckdb/common/string_util.hpp"
@@ -225,7 +226,7 @@ static string GenerateJoinDiffSQL(const string &source_table, const string &targ
 		if (i > 0) {
 			pk_join_condition += " AND ";
 		}
-		pk_join_condition += "s." + primary_keys[i] + " = t." + primary_keys[i];
+		pk_join_condition += "s." + QuoteSqlIdentifier(primary_keys[i]) + " = t." + QuoteSqlIdentifier(primary_keys[i]);
 	}
 
 	// Build the COALESCE expressions for primary keys
@@ -234,25 +235,15 @@ static string GenerateJoinDiffSQL(const string &source_table, const string &targ
 		if (i > 0) {
 			pk_select += ", ";
 		}
-		pk_select += "COALESCE(s." + primary_keys[i] + ", t." + primary_keys[i] + ") AS " + primary_keys[i];
-	}
-
-	// Build column list for comparison
-	string compare_list;
-	if (!compare_columns.empty()) {
-		for (size_t i = 0; i < compare_columns.size(); i++) {
-			if (i > 0) {
-				compare_list += ", ";
-			}
-			compare_list += compare_columns[i];
-		}
+		pk_select += "COALESCE(s." + QuoteSqlIdentifier(primary_keys[i]) + ", t." + QuoteSqlIdentifier(primary_keys[i]) +
+		             ") AS " + QuoteSqlIdentifier(primary_keys[i]);
 	}
 
 	// Generate the diff query
 	string sql = "SELECT ";
 	sql += "CASE ";
-	sql += "WHEN s." + primary_keys[0] + " IS NULL THEN 'added' ";
-	sql += "WHEN t." + primary_keys[0] + " IS NULL THEN 'removed' ";
+	sql += "WHEN s." + QuoteSqlIdentifier(primary_keys[0]) + " IS NULL THEN 'added' ";
+	sql += "WHEN t." + QuoteSqlIdentifier(primary_keys[0]) + " IS NULL THEN 'removed' ";
 
 	// For comparison, we need to check if any non-PK columns differ
 	// Simplified: use a hash-based comparison
@@ -266,7 +257,7 @@ static string GenerateJoinDiffSQL(const string &source_table, const string &targ
 			if (i > 0) {
 				sql += " OR ";
 			}
-			sql += "s." + compare_columns[i] + " IS DISTINCT FROM t." + compare_columns[i];
+			sql += "s." + QuoteSqlIdentifier(compare_columns[i]) + " IS DISTINCT FROM t." + QuoteSqlIdentifier(compare_columns[i]);
 		}
 		sql += ") THEN 'changed' ";
 	}
@@ -280,16 +271,14 @@ static string GenerateJoinDiffSQL(const string &source_table, const string &targ
 		if (i > 0) {
 			sql += ", ";
 		}
-		sql += primary_keys[i];
+		sql += QuoteSqlIdentifier(primary_keys[i]);
 	}
 	sql += ")";
 
-	// Parse table names
-	auto source_qname = QualifiedName::Parse(source_table);
-	auto target_qname = QualifiedName::Parse(target_table);
-
-	sql += " FROM " + source_qname.ToString() + " s ";
-	sql += "FULL OUTER JOIN " + target_qname.ToString() + " t ";
+	// Reference both tables via query_table() so hostile and schema-qualified
+	// names are handled by the shared quoting helpers
+	sql += " FROM " + BuildQueryTableRef(source_table) + " s ";
+	sql += "FULL OUTER JOIN " + BuildQueryTableRef(target_table) + " t ";
 	sql += "ON " + pk_join_condition;
 
 	if (!include_all) {

--- a/src/anofox_metric.cpp
+++ b/src/anofox_metric.cpp
@@ -238,8 +238,10 @@ static string GenerateSchemaSQL(const string &table_name, const vector<string> &
 
 // Helper: Generate SQL for freshness metrics
 static string GenerateFreshnessSQL(const string &table_ref, const string &timestamp_column, const Value &max_age, const Value &reference_time) {
-	string max_age_interval = max_age.IsNull() ? "INTERVAL '1 day'" : "'" + max_age.ToString() + "'::INTERVAL";
-	string ref_time = reference_time.IsNull() ? "now()" : "'" + reference_time.ToString() + "'::TIMESTAMP";
+	string max_age_interval =
+	    max_age.IsNull() ? "INTERVAL '1 day'" : "'" + EscapeSqlStringLiteral(max_age.ToString()) + "'::INTERVAL";
+	string ref_time =
+	    reference_time.IsNull() ? "now()" : "'" + EscapeSqlStringLiteral(reference_time.ToString()) + "'::TIMESTAMP";
 	string col_id = QuoteSqlIdentifier(timestamp_column);
 
 	return "SELECT "
@@ -680,9 +682,9 @@ static void IsolationForestExecute(ClientContext &context, TableFunctionInput &d
 			string type_query = "SELECT ";
 			for (size_t i = 0; i < bind_data.column_names.size(); ++i) {
 				if (i > 0) type_query += ", ";
-				type_query += "\"" + bind_data.column_names[i] + "\"";
+				type_query += QuoteSqlIdentifier(bind_data.column_names[i]);
 			}
-			type_query += " FROM query_table('" + bind_data.table_name + "') LIMIT 0";
+			type_query += " FROM " + BuildQueryTableRef(bind_data.table_name) + " LIMIT 0";
 
 			auto type_result = con.Query(type_query);
 			if (type_result->HasError()) {
@@ -707,28 +709,28 @@ static void IsolationForestExecute(ClientContext &context, TableFunctionInput &d
 		for (size_t i = 0; i < bind_data.column_names.size(); ++i) {
 			if (i > 0) column_list += ", ";
 			if (is_categorical[i]) {
-				column_list += "CAST(\"" + bind_data.column_names[i] + "\" AS VARCHAR)";
+				column_list += "CAST(" + QuoteSqlIdentifier(bind_data.column_names[i]) + " AS VARCHAR)";
 			} else {
-				column_list += "CAST(\"" + bind_data.column_names[i] + "\" AS DOUBLE)";
+				column_list += "CAST(" + QuoteSqlIdentifier(bind_data.column_names[i]) + " AS DOUBLE)";
 			}
 		}
 		// Append weight column to query if provided (will be last column in result)
 		idx_t weight_col_idx = bind_data.column_names.size();  // Index of weight column in result
 		if (bind_data.has_weight_column) {
-			column_list += ", CAST(\"" + bind_data.weight_column + "\" AS DOUBLE)";
+			column_list += ", CAST(" + QuoteSqlIdentifier(bind_data.weight_column) + " AS DOUBLE)";
 		}
 
 		string null_checks;
 		for (size_t i = 0; i < bind_data.column_names.size(); ++i) {
 			if (i > 0) null_checks += " AND ";
-			null_checks += "\"" + bind_data.column_names[i] + "\" IS NOT NULL";
+			null_checks += QuoteSqlIdentifier(bind_data.column_names[i]) + " IS NOT NULL";
 		}
 		// Include weight column in null checks if provided (ensures data and weight queries return same rows)
 		if (bind_data.has_weight_column) {
-			null_checks += " AND \"" + bind_data.weight_column + "\" IS NOT NULL";
+			null_checks += " AND " + QuoteSqlIdentifier(bind_data.weight_column) + " IS NOT NULL";
 		}
 
-		string query = "SELECT " + column_list + " FROM query_table('" + bind_data.table_name + "') WHERE " + null_checks;
+		string query = "SELECT " + column_list + " FROM " + BuildQueryTableRef(bind_data.table_name) + " WHERE " + null_checks;
 
 		auto result = con.Query(query);
 		if (result->HasError()) {
@@ -990,8 +992,8 @@ static string GenerateIsolationForestSummarySQL(
 	string contamination_str = std::to_string(contamination);
 
 	return "WITH data_sample AS ("
-		"SELECT ROW_NUMBER() OVER () as row_id, CAST(\"" + column_name + "\" AS DOUBLE) as value "
-		"FROM (SELECT * FROM " + table_ref + ") WHERE \"" + column_name + "\" IS NOT NULL"
+		"SELECT ROW_NUMBER() OVER () as row_id, CAST(" + QuoteSqlIdentifier(column_name) + " AS DOUBLE) as value "
+		"FROM (SELECT * FROM " + table_ref + ") WHERE " + QuoteSqlIdentifier(column_name) + " IS NOT NULL"
 		"), "
 		"summary AS ("
 		"SELECT "
@@ -1028,8 +1030,8 @@ static string GenerateIsolationForestScoresSQL(
 	string contamination_str = std::to_string(contamination);
 
 	return "WITH data_sample AS ("
-		"SELECT ROW_NUMBER() OVER () as row_id, CAST(\"" + column_name + "\" AS DOUBLE) as value "
-		"FROM (SELECT * FROM " + table_ref + ") WHERE \"" + column_name + "\" IS NOT NULL"
+		"SELECT ROW_NUMBER() OVER () as row_id, CAST(" + QuoteSqlIdentifier(column_name) + " AS DOUBLE) as value "
+		"FROM (SELECT * FROM " + table_ref + ") WHERE " + QuoteSqlIdentifier(column_name) + " IS NOT NULL"
 		"), "
 		"computed_scores AS ("
 		"SELECT "
@@ -1071,8 +1073,8 @@ static string GenerateIsolationForestMultivariateSummarySQL(
 			column_list += ", ";
 			null_checks += " AND ";
 		}
-		column_list += "CAST(\"" + column_names[i] + "\" AS DOUBLE) as col_" + std::to_string(i);
-		null_checks += "\"" + column_names[i] + "\" IS NOT NULL";
+		column_list += "CAST(" + QuoteSqlIdentifier(column_names[i]) + " AS DOUBLE) as col_" + std::to_string(i);
+		null_checks += QuoteSqlIdentifier(column_names[i]) + " IS NOT NULL";
 	}
 
 	// Build anomaly detection condition based on number of columns
@@ -1134,8 +1136,8 @@ static string GenerateIsolationForestMultivariateScoresSQL(
 			column_list += ", ";
 			null_checks += " AND ";
 		}
-		column_list += "CAST(\"" + column_names[i] + "\" AS DOUBLE) as col_" + std::to_string(i);
-		null_checks += "\"" + column_names[i] + "\" IS NOT NULL";
+		column_list += "CAST(" + QuoteSqlIdentifier(column_names[i]) + " AS DOUBLE) as col_" + std::to_string(i);
+		null_checks += QuoteSqlIdentifier(column_names[i]) + " IS NOT NULL";
 	}
 
 	// Build anomaly detection condition based on number of columns
@@ -1201,7 +1203,7 @@ static unique_ptr<TableRef> MetricIsolationForestBindReplace(ClientContext &cont
 		throw BinderException("contamination must be between 0.0 and 0.5");
 	}
 
-	string table_ref = "query_table('" + table_name + "')";
+	string table_ref = BuildQueryTableRef(table_name);
 	string sql = (output_mode == "scores") ?
 		GenerateIsolationForestScoresSQL(table_ref, column_name, n_trees, sample_size, contamination) :
 		GenerateIsolationForestSummarySQL(table_ref, column_name, n_trees, sample_size, contamination);
@@ -1263,7 +1265,7 @@ static unique_ptr<TableRef> MetricIsolationForestMultivariateBindReplace(ClientC
 		throw BinderException("contamination must be between 0.0 and 0.5");
 	}
 
-	string table_ref = "query_table('" + table_name + "')";
+	string table_ref = BuildQueryTableRef(table_name);
 	string sql = (output_mode == "scores") ?
 		GenerateIsolationForestMultivariateScoresSQL(table_ref, column_names, n_trees, sample_size, contamination) :
 		GenerateIsolationForestMultivariateSummarySQL(table_ref, column_names, n_trees, sample_size, contamination);
@@ -1294,20 +1296,20 @@ static unique_ptr<TableRef> MetricDBSCANBindReplace(ClientContext &context, Tabl
 		throw BinderException("min_pts must be >= 1");
 	}
 
-	string table_ref = "query_table('" + table_name + "')";
+	string table_ref = BuildQueryTableRef(table_name);
 
 	// For now, use simple placeholder SQL (distance > eps detection)
 	string sql = (output_mode == "clusters") ?
 		"WITH data_sample AS ("
-		"SELECT ROW_NUMBER() OVER () as row_id, CAST(\"" + column_name + "\" AS DOUBLE) as value "
-		"FROM (SELECT * FROM " + table_ref + ") WHERE \"" + column_name + "\" IS NOT NULL"
+		"SELECT ROW_NUMBER() OVER () as row_id, CAST(" + QuoteSqlIdentifier(column_name) + " AS DOUBLE) as value "
+		"FROM (SELECT * FROM " + table_ref + ") WHERE " + QuoteSqlIdentifier(column_name) + " IS NOT NULL"
 		") "
 		"SELECT row_id, value, 0 as cluster_id, CAST('CORE' AS VARCHAR) as point_type, 5 as neighbor_count, 0.5 as anomaly_score, false as is_anomaly "
 		"FROM data_sample ORDER BY row_id" :
 		"WITH data_sample AS ("
-		"SELECT COUNT(*) as total_count, COUNT(DISTINCT CAST(\"" + column_name + "\" AS DOUBLE)) as cluster_count, "
-		"COUNT(CASE WHEN CAST(\"" + column_name + "\" AS DOUBLE) > 1000 THEN 1 END) as noise_count "
-		"FROM (SELECT * FROM " + table_ref + ") WHERE \"" + column_name + "\" IS NOT NULL"
+		"SELECT COUNT(*) as total_count, COUNT(DISTINCT CAST(" + QuoteSqlIdentifier(column_name) + " AS DOUBLE)) as cluster_count, "
+		"COUNT(CASE WHEN CAST(" + QuoteSqlIdentifier(column_name) + " AS DOUBLE) > 1000 THEN 1 END) as noise_count "
+		"FROM (SELECT * FROM " + table_ref + ") WHERE " + QuoteSqlIdentifier(column_name) + " IS NOT NULL"
 		") "
 		"SELECT 'pass' as status, cluster_count, noise_count, total_count, "
 		"CAST(noise_count AS DOUBLE) / CAST(total_count AS DOUBLE) as noise_rate, "
@@ -1364,7 +1366,7 @@ static unique_ptr<TableRef> MetricDBSCANMultivariateBindReplace(ClientContext &c
 		throw BinderException("min_pts must be >= 1");
 	}
 
-	string table_ref = "query_table('" + table_name + "')";
+	string table_ref = BuildQueryTableRef(table_name);
 
 	// Placeholder SQL for multivariate DBSCAN
 	string sql = (output_mode == "clusters") ?

--- a/src/anofox_pii.cpp
+++ b/src/anofox_pii.cpp
@@ -1,5 +1,6 @@
 #include "anofox_pii.hpp"
 #include "anofox_ner.hpp"
+#include "anofox_sql_utils.hpp"
 #include "anofox_trace.hpp"
 #include "anofox_function_alias.hpp"
 #include "anofox_phonenumber.hpp"
@@ -2692,8 +2693,8 @@ void PIIAuditTableFunction(ClientContext &context, TableFunctionInput &input, Da
             // For each column, query values and detect PII (row-level)
             for (const auto &col_name : columns_to_scan) {
                 // Build query to get column values with row numbers
-                std::string query = "SELECT row_number() OVER () as _row_id, \"" + col_name + "\" FROM " +
-                                   bind_data.table_name;
+                std::string query = "SELECT row_number() OVER () as _row_id, " + QuoteSqlIdentifier(col_name) +
+                                    " FROM " + BuildQueryTableRef(bind_data.table_name);
 
                 // Execute query using a new connection
                 Connection con(*context.db);
@@ -2926,8 +2927,9 @@ void PIIScanTableFunction(ClientContext &context, TableFunctionInput &input, Dat
 
             for (const auto &col_name : columns_to_scan) {
                 // Build query to get column values
-                std::string query = "SELECT \"" + col_name + "\" FROM " + bind_data.table_name +
-                                   " WHERE \"" + col_name + "\" IS NOT NULL";
+                std::string query = "SELECT " + QuoteSqlIdentifier(col_name) + " FROM " +
+                                   BuildQueryTableRef(bind_data.table_name) +
+                                   " WHERE " + QuoteSqlIdentifier(col_name) + " IS NOT NULL";
 
                 // Execute query using a new connection
                 Connection con(*context.db);

--- a/test/sql/anofox_sql_quoting.test
+++ b/test/sql/anofox_sql_quoting.test
@@ -1,0 +1,207 @@
+# name: test/sql/anofox_sql_quoting.test
+# description: Hostile identifier and literal quoting tests for generated SQL (issue #42)
+# group: [anofox_tabular]
+
+require anofox_tabular
+
+statement ok
+LOAD anofox_tabular
+
+statement ok
+SET anofox_tab_trace_enabled = false
+
+# ===----------------------------------------------------------------------===
+# Setup: tables and columns containing quotes, spaces, unicode and reserved
+# keywords. Real (non-TEMP) tables are required: several functions read the
+# data through a nested Connection that cannot see TEMP tables.
+# ===----------------------------------------------------------------------===
+
+statement ok
+CREATE TABLE "quoting it's tbl" (
+    "va""l" DOUBLE,
+    "select" DOUBLE,
+    "my col" VARCHAR,
+    "päi'vä""ys" TIMESTAMP
+)
+
+statement ok
+INSERT INTO "quoting it's tbl" VALUES
+    (100.0, 1.0, 'a', TIMESTAMP '2026-01-01 10:00:00'),
+    (101.0, 2.0, 'b', TIMESTAMP '2026-01-02 10:00:00'),
+    (102.0, 3.0, NULL, TIMESTAMP '2026-01-03 10:00:00'),
+    (103.0, 4.0, 'c', TIMESTAMP '2026-01-04 10:00:00'),
+    (250.0, 5.0, 'd', TIMESTAMP '2026-01-05 10:00:00'),
+    (99.0, 6.0, 'e', TIMESTAMP '2026-01-06 10:00:00'),
+    (98.5, 7.0, 'f', TIMESTAMP '2026-01-07 10:00:00'),
+    (101.5, 8.0, 'g', TIMESTAMP '2026-01-08 10:00:00')
+
+# ===----------------------------------------------------------------------===
+# Metric functions already routed through the shared helpers (regression)
+# ===----------------------------------------------------------------------===
+
+query I
+SELECT status FROM anofox_tab_volume('quoting it''s tbl', 1, 100);
+----
+pass
+
+query I
+SELECT status FROM anofox_tab_null_rate('quoting it''s tbl', 'my col', 0.5);
+----
+pass
+
+query I
+SELECT status FROM anofox_tab_distinct_count('quoting it''s tbl', 'select', 1, 10);
+----
+pass
+
+statement ok
+SELECT * FROM anofox_tab_zscore('quoting it''s tbl', 'va"l', 3.0);
+
+statement ok
+SELECT * FROM anofox_tab_iqr('quoting it''s tbl', 'va"l', 1.5);
+
+query I
+SELECT status FROM anofox_tab_schema_check('quoting it''s tbl', ['va"l', 'select', 'my col']);
+----
+pass
+
+query I
+SELECT status FROM anofox_tab_schema_check('quoting it''s tbl', ['no''such "col']);
+----
+fail
+
+query I
+SELECT status FROM anofox_tab_freshness('quoting it''s tbl', 'päi''vä"ys', INTERVAL '1 day', TIMESTAMP '2026-01-08 12:00:00');
+----
+pass
+
+# ===----------------------------------------------------------------------===
+# outlier_tree: already routed through the shared helpers (regression)
+# ===----------------------------------------------------------------------===
+
+statement ok
+SELECT * FROM anofox_tab_outlier_tree('quoting it''s tbl', 'va"l,select', 'summary');
+
+# ===----------------------------------------------------------------------===
+# isolation_forest: executes generated SQL on a nested Connection
+# ===----------------------------------------------------------------------===
+
+query I
+SELECT status IS NOT NULL FROM anofox_tab_isolation_forest('quoting it''s tbl', 'va"l', 10, 8, 0.1, 'summary');
+----
+true
+
+# ===----------------------------------------------------------------------===
+# dbscan / dbscan_mv: generated SQL via bind_replace
+# ===----------------------------------------------------------------------===
+
+query I
+SELECT status FROM anofox_tab_dbscan('quoting it''s tbl', 'va"l', 0.5, 2, 'summary');
+----
+pass
+
+query I
+SELECT count(*) >= 0 FROM anofox_tab_dbscan_mv('quoting it''s tbl', 'va"l,select', 0.5, 2, 'clusters');
+----
+true
+
+# ===----------------------------------------------------------------------===
+# pii_scan_table / pii_audit_table: SQL rebuilt from raw table name.
+# NOTE: SQL errors in the per-column queries are swallowed (the column is
+# skipped), so a broken table reference silently yields zero rows.
+# ===----------------------------------------------------------------------===
+
+statement ok
+CREATE TABLE "pii sc'an tbl" ("e""mail" VARCHAR, "from" VARCHAR)
+
+statement ok
+INSERT INTO "pii sc'an tbl" VALUES
+    ('john.doe@example.com', 'clean text'),
+    ('reach jane@test.org today', 'nothing here')
+
+query I
+SELECT count(*) > 0 FROM anofox_tab_pii_scan_table('pii sc''an tbl');
+----
+true
+
+query III
+SELECT column_name, pii_type, match_count
+FROM anofox_tab_pii_scan_table('pii sc''an tbl', 'e"mail')
+WHERE pii_type = 'EMAIL';
+----
+e"mail	EMAIL	2
+
+query I
+SELECT count(*) > 0 FROM anofox_tab_pii_audit_table('pii sc''an tbl');
+----
+true
+
+query I
+SELECT count(DISTINCT column_name) FROM anofox_tab_pii_audit_table('pii sc''an tbl', 'e"mail');
+----
+1
+
+# ===----------------------------------------------------------------------===
+# diff_joindiff / diff_hashdiff: PK and compare column identifiers
+# ===----------------------------------------------------------------------===
+
+statement ok
+CREATE TABLE "diff s'rc" ("or der" INTEGER, "va""l" VARCHAR, "select" VARCHAR)
+
+statement ok
+CREATE TABLE "diff t'gt" ("or der" INTEGER, "va""l" VARCHAR, "select" VARCHAR)
+
+statement ok
+INSERT INTO "diff s'rc" VALUES (1, 'a', 'x'), (2, 'b', 'y')
+
+statement ok
+INSERT INTO "diff t'gt" VALUES (1, 'a', 'x'), (2, 'B', 'y'), (3, 'c', 'z')
+
+# single hostile primary key (space in identifier)
+query I
+SELECT count(*) FROM anofox_tab_diff_joindiff('diff s''rc', 'diff t''gt', 'or der');
+----
+2
+
+# hostile compare column (embedded double quote)
+query I
+SELECT count(*) FROM anofox_tab_diff_joindiff('diff s''rc', 'diff t''gt', 'or der', ['va"l']);
+----
+2
+
+# multiple primary keys including a reserved keyword
+query I
+SELECT count(*) FROM anofox_tab_diff_joindiff('diff s''rc', 'diff t''gt', ['or der', 'select']);
+----
+2
+
+# hashdiff shares the joindiff SQL generator
+query I
+SELECT count(*) FROM anofox_tab_diff_hashdiff('diff s''rc', 'diff t''gt', 'or der');
+----
+2
+
+# diff_type classification stays correct with hostile identifiers
+query II
+SELECT diff_type, count(*)
+FROM anofox_tab_diff_joindiff('diff s''rc', 'diff t''gt', 'or der')
+GROUP BY diff_type ORDER BY diff_type;
+----
+added	1
+changed	1
+
+# ===----------------------------------------------------------------------===
+# Cleanup
+# ===----------------------------------------------------------------------===
+
+statement ok
+DROP TABLE "quoting it's tbl"
+
+statement ok
+DROP TABLE "pii sc'an tbl"
+
+statement ok
+DROP TABLE "diff s'rc"
+
+statement ok
+DROP TABLE "diff t'gt"


### PR DESCRIPTION
# Summary

Completes the quoting sweep for issue #42: every place that builds SQL from table names, column names, or string literals in the metric, isolation-forest, dbscan, pii and diff paths now goes through the shared helpers in `src/anofox_sql_utils.{hpp,cpp}` (`QuoteSqlIdentifier` — `""`-doubling, `EscapeSqlStringLiteral` — `''`-doubling, `BuildQueryTableRef` — `query_table('...')` with an escaped literal).

## Findings re-verified against current main

**Already fixed on main before this PR** (kept as regression coverage in the new test):

- Shared helpers `src/anofox_sql_utils.{hpp,cpp}` already exist with correct `""`/`''` doubling (audited).
- `anofox_metric.cpp` pass/fail metrics (`volume`, `null_rate`, `distinct_count`, `zscore`, `iqr`, `schema_check`, `freshness` table ref + timestamp column) already use the helpers.
- `anofox_outlier_tree.cpp` already routes its column list and table ref through `QuoteSqlIdentifier` / `BuildQueryTableRef`.
- `anofox_profile.cpp` already routes everything through the helpers.
- diff *table names* were already safe (`QualifiedName::Parse` + keyword-quoting `ToString`).

**Still broken on main, fixed by this PR:**

- `src/anofox_metric.cpp`: `IsolationForestExecute` (hand-built `"col"` quoting, raw `query_table('<name>')` refs), the four `table_ref = "query_table('" + table_name + "')"` builders, the isolation-forest/dbscan SQL generators, and the freshness `INTERVAL`/`TIMESTAMP` literals (escaped belt-and-braces; they come from typed values).
- `src/anofox_pii.cpp`: `pii_scan_table` / `pii_audit_table` per-column queries interpolated the raw table name (not even via `query_table`) and hand-built column quoting; because per-column query errors are swallowed, hostile table/column names silently produced **zero rows** instead of an error.
- `src/anofox_diff.cpp`: `GenerateJoinDiffSQL` concatenated PK and compare-column identifiers unquoted into the join condition, COALESCE select list, `IS DISTINCT FROM` comparisons and the `EXCLUDE` list. Table refs now also go through `BuildQueryTableRef`, and a dead `compare_list` buildup was removed.

## Red/green evidence

The first commit contains only `test/sql/anofox_sql_quoting.test` (tables/columns with embedded `"`, `'`, spaces, unicode and reserved keywords). Against unfixed main:

```
test/sql/anofox_sql_quoting.test:89: FAILED:
Invalid Input Error: Failed to query source table: Parser Error: unterminated quoted identifier
LINE 1: SELECT "va"l" FROM query_table('quoting it's tbl') LIMIT 0
```

CLI probes of the other affected functions on the unfixed build:

```
anofox_tab_dbscan('quoting it''s tbl', 'va"l', ...)            -> Parser Error: syntax error at or near "l"
anofox_tab_diff_joindiff('diff s''rc', 'diff t''gt', 'or der') -> Parser Error: syntax error at or near "der"
anofox_tab_pii_scan_table('pii sc''an tbl')                    -> [anofox] pii_scan_table: Error querying column e"mail (silently 0 rows)
```

After the fix commit: the new test passes (40 assertions) and the full suite is green — `All tests passed (1 skipped test, 1664 assertions in 17 test cases)`; the single skip is the pre-existing `require-env OPENVINO_AVAILABLE` NER test, identical to the baseline run on main.

There is no `test/cpp` Catch2 wiring in this repo's CMake, so helper edge cases (embedded quotes, unicode, keywords, spaces) are covered through the SQL tests instead of C++ unit tests.

Closes #42
