### PR TITLE
fix: email network safety — no loopback fallback, poll-based I/O, null-MX, SMTP limits

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -286,6 +286,34 @@ if(UNIX AND NOT APPLE)
     target_link_options(${LOADABLE_EXTENSION_NAME} PRIVATE -Wl,--allow-multiple-definition)
 endif()
 
+# --- C++ unit tests (Catch2, linked into DuckDB's unittest runner) ---
+
+# The `unittest` target is created by duckdb/test, which is configured *after*
+# out-of-tree extensions, so the registration has to be deferred to the end of
+# the top-level configure pass. Deferred-call arguments are re-evaluated at
+# execution time (in the deferring directory's scope), so the paths are stashed
+# in cache variables instead of being passed as arguments.
+set(ANOFOX_TABULAR_CPP_TEST_SOURCES
+    "${CMAKE_CURRENT_SOURCE_DIR}/test/cpp/test_email_internal.cpp"
+    CACHE INTERNAL "anofox_tabular C++ unit test sources")
+set(ANOFOX_TABULAR_CPP_TEST_INCLUDE_DIR
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/include"
+    CACHE INTERNAL "anofox_tabular C++ unit test include dir")
+
+function(anofox_register_cpp_tests)
+    if(TARGET unittest AND TARGET anofox_tabular_extension)
+        target_sources(unittest PRIVATE ${ANOFOX_TABULAR_CPP_TEST_SOURCES})
+        target_include_directories(unittest PRIVATE ${ANOFOX_TABULAR_CPP_TEST_INCLUDE_DIR})
+    endif()
+endfunction()
+
+# Note: not gated on ENABLE_UNITTEST_CPP_TESTS — that option only controls
+# DuckDB's own C++ test subdirectories (extension-ci-tools disables it), while
+# these tests belong to this extension and should always ship with `unittest`.
+if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.19")
+    cmake_language(DEFER DIRECTORY ${CMAKE_SOURCE_DIR} CALL anofox_register_cpp_tests)
+endif()
+
 # --- Installation ---
 
 install(

--- a/README.md
+++ b/README.md
@@ -1104,7 +1104,7 @@ Set options via SQL or DuckDB's configuration file:
 SET anofox_tab_email_default_validation = 'regex';  -- Default: regex
 SET anofox_tab_email_regex_pattern = '<your-pattern>';  -- RFC 5322 inspired
 SET anofox_tab_email_dns_timeout_ms = 1000;  -- DNS timeout per try (1-5000ms)
-SET anofox_tab_email_dns_tries = 1;  -- DNS retry count
+SET anofox_tab_email_dns_tries = 1;  -- DNS retry count (1-10)
 SET anofox_tab_email_smtp_port = 25;  -- SMTP port
 SET anofox_tab_email_smtp_connect_timeout_ms = 5000;  -- TCP connect timeout
 SET anofox_tab_email_smtp_read_timeout_ms = 5000;  -- Read/write timeout

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1921,7 +1921,7 @@ Set options via SQL or DuckDB's configuration file.
 SET anofox_tab_email_default_validation = 'regex';  -- Default: regex
 SET anofox_tab_email_regex_pattern = '<your-pattern>';  -- RFC 5322 inspired
 SET anofox_tab_email_dns_timeout_ms = 1000;  -- DNS timeout per try (1-5000ms)
-SET anofox_tab_email_dns_tries = 1;  -- DNS retry count
+SET anofox_tab_email_dns_tries = 1;  -- DNS retry count (1-10)
 SET anofox_tab_email_smtp_port = 25;  -- SMTP port
 SET anofox_tab_email_smtp_connect_timeout_ms = 5000;  -- TCP connect timeout
 SET anofox_tab_email_smtp_read_timeout_ms = 5000;  -- Read/write timeout

--- a/src/anofox_email.cpp
+++ b/src/anofox_email.cpp
@@ -73,22 +73,6 @@ std::string ExtractDomain(const std::string &email) {
 	return email.substr(domain_offset);
 }
 
-std::vector<std::string> BuildFallbackHosts(const std::string &domain) {
-	std::vector<std::string> hosts;
-	auto add_unique = [&](const std::string &value) {
-		if (value.empty()) {
-			return;
-		}
-		if (std::find(hosts.begin(), hosts.end(), value) == hosts.end()) {
-			hosts.emplace_back(value);
-		}
-	};
-	add_unique(domain);
-	add_unique("localhost");
-	add_unique("127.0.0.1");
-	return hosts;
-}
-
 class EmailConfig {
 public:
 	static EmailConfig &Get() {
@@ -144,8 +128,10 @@ public:
 	}
 
 	void SetDnsTries(uint32_t tries) {
-		if (tries == 0) {
-			throw InvalidInputException("anofox_tab_email_dns_tries must be greater than 0");
+		if (tries < email::DnsOptions::MIN_TRIES || tries > email::DnsOptions::MAX_TRIES) {
+			throw InvalidInputException("anofox_tab_email_dns_tries must be between " +
+			                            std::to_string(email::DnsOptions::MIN_TRIES) + " and " +
+			                            std::to_string(email::DnsOptions::MAX_TRIES));
 		}
 		std::lock_guard<std::mutex> lock(config_mutex);
 		dns_options.tries = tries;
@@ -310,23 +296,21 @@ EmailValidationResult ValidateEmailAddress(const std::string &email, const std::
 	               (dns_lookup.reason.empty() ? std::string("<none>") : dns_lookup.reason) + " hosts=" +
 	               std::to_string(dns_lookup.mx_hosts.size()));
 
-	std::vector<std::string> smtp_hosts;
-	if (dns_lookup.success) {
-		dns_stage.valid = true;
-		smtp_hosts = dns_lookup.mx_hosts;
-	} else {
+	if (!dns_lookup.success) {
+		// DNS resolution failed: the address cannot be deliverable, so both DNS
+		// and SMTP modes fail here. No fallback SMTP probing of the raw domain or
+		// loopback addresses (issue #47).
 		dns_stage.valid = false;
 		dns_stage.reason = dns_lookup.reason.empty() ? EMAIL_REASON_DNS_FAIL : dns_lookup.reason;
-		smtp_hosts = BuildFallbackHosts(domain);
-		dns_stage.mx_hosts = smtp_hosts;
 		EmailTrace(AnofoxLogLevel::Warn,
-		           std::string("DNS failure, using fallback hosts count=") + std::to_string(smtp_hosts.size()));
-		if (smtp_hosts.empty()) {
-			return dns_stage;
-		}
+		           "DNS failure, validation fails without SMTP fallback reason=" + dns_stage.reason);
+		return dns_stage;
 	}
 
-	if (normalized_mode == EMAIL_STAGE_DNS) {
+	dns_stage.valid = true;
+	auto &smtp_hosts = dns_lookup.mx_hosts;
+
+	if (normalized_mode == EMAIL_STAGE_DNS || smtp_hosts.empty()) {
 		return dns_stage;
 	}
 
@@ -348,13 +332,7 @@ EmailValidationResult ValidateEmailAddress(const std::string &email, const std::
 	               std::string("SMTP verification failed reason=") +
 	                   (smtp_result.reason.empty() ? std::string("<none>") : smtp_result.reason));
 		smtp_stage.valid = false;
-		if (!smtp_result.reason.empty()) {
-			smtp_stage.reason = smtp_result.reason;
-		} else if (!dns_lookup.success && !dns_stage.reason.empty()) {
-			smtp_stage.reason = dns_stage.reason;
-		} else {
-			smtp_stage.reason = EMAIL_REASON_SMTP_FAIL;
-		}
+		smtp_stage.reason = smtp_result.reason.empty() ? EMAIL_REASON_SMTP_FAIL : smtp_result.reason;
 		return smtp_stage;
 	}
 
@@ -565,9 +543,11 @@ void SetDnsTriesOption(ClientContext &, SetScope, Value &parameter) {
 		throw InvalidInputException("anofox_tab_email_dns_tries cannot be NULL");
 	}
 	auto value = parameter.GetValue<int64_t>();
-	if (value <= 0 || value > std::numeric_limits<uint32_t>::max()) {
-		throw InvalidInputException("anofox_tab_email_dns_tries must be between 1 and " +
-		                            std::to_string(std::numeric_limits<uint32_t>::max()));
+	if (value < static_cast<int64_t>(email::DnsOptions::MIN_TRIES) ||
+	    value > static_cast<int64_t>(email::DnsOptions::MAX_TRIES)) {
+		throw InvalidInputException("anofox_tab_email_dns_tries must be between " +
+		                            std::to_string(email::DnsOptions::MIN_TRIES) + " and " +
+		                            std::to_string(email::DnsOptions::MAX_TRIES));
 	}
 	EmailConfig::Get().SetDnsTries(static_cast<uint32_t>(value));
 	parameter = Value::INTEGER(static_cast<int32_t>(EmailConfig::Get().GetDnsOptions().tries));
@@ -686,7 +666,7 @@ void RegisterEmailOptions(ExtensionLoader &loader) {
 	                          LogicalTypeId::BIGINT,
 	                          Value::BIGINT(static_cast<int64_t>(dns_options.timeout_ms)), SetDnsTimeoutOption);
 	config.AddExtensionOption("anofox_tab_email_dns_tries",
-	                          "Number of DNS queries to attempt before failing",
+	                          "Number of DNS queries to attempt before failing (1-10)",
 	                          LogicalTypeId::INTEGER,
 	                          Value::INTEGER(static_cast<int32_t>(dns_options.tries)), SetDnsTriesOption);
 	config.AddExtensionOption("anofox_tab_email_smtp_port",

--- a/src/anofox_email_dns.cpp
+++ b/src/anofox_email_dns.cpp
@@ -26,8 +26,8 @@
 #include <arpa/inet.h>
 #include <netdb.h>
 #include <netinet/in.h>
+#include <poll.h>
 #include <sys/socket.h>
-#include <sys/select.h>
 #include <sys/time.h>
 #include <unistd.h>
 #endif
@@ -47,7 +47,7 @@ struct MxQueryState {
 	int *pending = nullptr;
 	ares_status_t status = ARES_EDESTRUCTION;
 	std::string error;
-	std::vector<std::pair<uint16_t, std::string>> records;
+	std::vector<MxRecord> records;
 };
 
 struct AddrInfoState {
@@ -81,6 +81,16 @@ std::string MapAresStatus(int status) {
 	default:
 		return "dns_error_" + std::to_string(status);
 	}
+}
+
+//! poll()/WSAPoll() wrapper: unlike select(), it has no FD_SETSIZE limit, so
+//! arbitrary descriptor values are safe (issue #47).
+int PollSockets(struct pollfd *fds, size_t count, int timeout_ms) {
+#ifdef _WIN32
+	return WSAPoll(fds, static_cast<ULONG>(count), timeout_ms);
+#else
+	return poll(fds, static_cast<nfds_t>(count), timeout_ms);
+#endif
 }
 
 void OnSocketState(void *arg, ares_socket_t socket_fd, int readable, int writable) {
@@ -121,7 +131,7 @@ void OnMxQuery(void *arg, ares_status_t status, size_t timeouts, const ares_dns_
 				auto preference = ares_dns_rr_get_u16(rr, ARES_RR_MX_PREFERENCE);
 				auto exchange = ares_dns_rr_get_str(rr, ARES_RR_MX_EXCHANGE);
 				if (exchange) {
-					state.records.emplace_back(preference, exchange);
+					state.records.push_back(MxRecord {preference, exchange});
 				}
 			}
 		}
@@ -180,24 +190,23 @@ bool RunEventLoop(ares_channel_t *channel, SocketTracker &tracker, int &pending,
 			remaining = std::chrono::milliseconds(DnsOptions::MIN_TIMEOUT_MS);
 		}
 
-		fd_set read_fds;
-		fd_set write_fds;
-		FD_ZERO(&read_fds);
-		FD_ZERO(&write_fds);
-		ares_socket_t max_fd = ARES_SOCKET_BAD;
+		std::vector<struct pollfd> poll_fds;
+		poll_fds.reserve(tracker.sockets.size());
 		for (auto &entry : tracker.sockets) {
-			auto sock = entry.first;
 			const auto &state = entry.second;
+			short poll_events = 0;
 			if (state.readable) {
-				FD_SET(sock, &read_fds);
+				poll_events |= POLLIN;
 			}
 			if (state.writable) {
-				FD_SET(sock, &write_fds);
+				poll_events |= POLLOUT;
 			}
-			if (state.readable || state.writable) {
-				if (max_fd == ARES_SOCKET_BAD || sock > max_fd) {
-					max_fd = sock;
-				}
+			if (poll_events != 0) {
+				struct pollfd pfd;
+				pfd.fd = entry.first;
+				pfd.events = poll_events;
+				pfd.revents = 0;
+				poll_fds.push_back(pfd);
 			}
 		}
 
@@ -210,54 +219,53 @@ bool RunEventLoop(ares_channel_t *channel, SocketTracker &tracker, int &pending,
 		if (!tv_ptr) {
 			tv_ptr = &capped_timeout;
 		}
-
-		int select_result = 0;
-		if (max_fd != ARES_SOCKET_BAD) {
-			int nfds = static_cast<int>(max_fd) + 1;
-			select_result = select(nfds, &read_fds, &write_fds, nullptr, tv_ptr);
-		} else {
-			auto sleep_ms = static_cast<uint32_t>(tv_ptr->tv_sec * 1000 + static_cast<long>(tv_ptr->tv_usec / 1000));
-			auto capped_ms = static_cast<uint32_t>(remaining.count());
-			if (sleep_ms == 0) {
-				sleep_ms = capped_ms;
-			}
-			if (sleep_ms > capped_ms) {
-				sleep_ms = capped_ms;
-			}
-			if (sleep_ms == 0) {
-				sleep_ms = DnsOptions::MIN_TIMEOUT_MS;
-			}
-			std::this_thread::sleep_for(std::chrono::milliseconds(sleep_ms));
+		// Round up so a sub-millisecond budget does not busy-spin.
+		auto wait_ms = static_cast<uint32_t>(tv_ptr->tv_sec * 1000 + (tv_ptr->tv_usec + 999) / 1000);
+		auto capped_ms = static_cast<uint32_t>(remaining.count());
+		if (wait_ms > capped_ms) {
+			wait_ms = capped_ms;
 		}
-		if (select_result < 0) {
+		if (wait_ms == 0) {
+			wait_ms = DnsOptions::MIN_TIMEOUT_MS;
+		}
+
+		int poll_result = 0;
+		if (!poll_fds.empty()) {
+			poll_result = PollSockets(poll_fds.data(), poll_fds.size(), static_cast<int>(wait_ms));
+		} else {
+			std::this_thread::sleep_for(std::chrono::milliseconds(wait_ms));
+		}
+		if (poll_result < 0) {
 #ifdef _WIN32
 			int wsa_error = WSAGetLastError();
 			if (wsa_error == WSAEINTR) {
 				continue;
 			}
-			error_reason = "dns_select_failed_" + std::to_string(wsa_error);
+			error_reason = "dns_poll_failed_" + std::to_string(wsa_error);
 #else
 			if (errno == EINTR) {
 				continue;
 			}
-			error_reason = "dns_select_failed_" + std::to_string(errno);
+			error_reason = "dns_poll_failed_" + std::to_string(errno);
 #endif
 			return false;
 		}
 
 		std::vector<ares_fd_events_t> events;
-		if (select_result > 0) {
-			for (auto &entry : tracker.sockets) {
-				auto sock = entry.first;
+		if (poll_result > 0) {
+			for (auto &pfd : poll_fds) {
+				if (pfd.revents == 0) {
+					continue;
+				}
 				unsigned int event_mask = ARES_FD_EVENT_NONE;
-				if (FD_ISSET(sock, &read_fds)) {
+				if (pfd.revents & (POLLIN | POLLERR | POLLHUP | POLLNVAL)) {
 					event_mask |= ARES_FD_EVENT_READ;
 				}
-				if (FD_ISSET(sock, &write_fds)) {
+				if (pfd.revents & POLLOUT) {
 					event_mask |= ARES_FD_EVENT_WRITE;
 				}
 				if (event_mask != ARES_FD_EVENT_NONE) {
-					events.push_back({sock, event_mask});
+					events.push_back({pfd.fd, event_mask});
 				}
 			}
 		}
@@ -318,6 +326,11 @@ MxSelection SelectMxHosts(std::vector<MxRecord> records) {
 		return lhs.preference < rhs.preference;
 	});
 	for (auto &record : records) {
+		if (record.exchange.empty() || record.exchange == ".") {
+			// RFC 7505 Null MX: the domain explicitly does not accept mail.
+			selection.null_mx = true;
+			continue;
+		}
 		selection.hosts.emplace_back(std::move(record.exchange));
 	}
 	return selection;
@@ -344,6 +357,7 @@ DnsResolver::DnsResolver(const DnsOptions &options_p) : options(options_p) {
 	if (options.tries == 0) {
 		options.tries = DEFAULT_TRIES;
 	}
+	options.tries = std::min(std::max(options.tries, DnsOptions::MIN_TRIES), DnsOptions::MAX_TRIES);
 	options.timeout_ms = std::min(std::max(options.timeout_ms, DnsOptions::MIN_TIMEOUT_MS), DnsOptions::MAX_TIMEOUT_MS);
 }
 
@@ -438,21 +452,21 @@ DnsResult DnsResolver::Resolve(const std::string &domain) {
 	}
 
 	if (mx_state.status == ARES_SUCCESS && !mx_state.records.empty()) {
-		std::sort(mx_state.records.begin(), mx_state.records.end(),
-		          [](const std::pair<uint16_t, std::string> &lhs, const std::pair<uint16_t, std::string> &rhs) {
-			          if (lhs.first == rhs.first) {
-				          return lhs.second < rhs.second;
-			          }
-			          return lhs.first < rhs.first;
-		          });
-		result.success = true;
-		result.mx_hosts.reserve(mx_state.records.size());
-		for (auto &entry : mx_state.records) {
-			result.mx_hosts.emplace_back(entry.second);
+		auto selection = SelectMxHosts(std::move(mx_state.records));
+		if (!selection.hosts.empty()) {
+			result.success = true;
+			result.mx_hosts = std::move(selection.hosts);
+			EmailTrace(AnofoxLogLevel::Info,
+			           "DNS MX success records=" + std::to_string(result.mx_hosts.size()));
+			return result;
 		}
-		EmailTrace(AnofoxLogLevel::Info,
-		           "DNS MX success records=" + std::to_string(result.mx_hosts.size()));
-		return result;
+		if (selection.null_mx) {
+			// RFC 7505 Null MX: the domain explicitly refuses mail; do not fall
+			// back to direct host resolution.
+			result.reason = "dns_null_mx";
+			EmailTrace(AnofoxLogLevel::Warn, "DNS Null MX (RFC 7505) for domain=" + domain);
+			return result;
+		}
 	}
 
 	// MX lookup failed, attempt to fall back to direct host resolution.

--- a/src/anofox_email_dns.cpp
+++ b/src/anofox_email_dns.cpp
@@ -309,6 +309,20 @@ bool EnsureLibraryInitializedInternal(std::string &error_reason) {
 
 } // namespace
 
+MxSelection SelectMxHosts(std::vector<MxRecord> records) {
+	MxSelection selection;
+	std::sort(records.begin(), records.end(), [](const MxRecord &lhs, const MxRecord &rhs) {
+		if (lhs.preference == rhs.preference) {
+			return lhs.exchange < rhs.exchange;
+		}
+		return lhs.preference < rhs.preference;
+	});
+	for (auto &record : records) {
+		selection.hosts.emplace_back(std::move(record.exchange));
+	}
+	return selection;
+}
+
 std::string DnsStatusToReason(int status) {
 	return MapAresStatus(status);
 }

--- a/src/anofox_email_smtp.cpp
+++ b/src/anofox_email_smtp.cpp
@@ -909,6 +909,24 @@ SmtpResult AttemptHost(const std::string &email, const std::string &host, const 
 
 } // namespace
 
+bool SmtpResponseBudget::AcceptLine(size_t line_bytes) {
+	(void)line_bytes;
+	return true;
+}
+
+bool SmtpResponseBudget::AcceptPartialLine(size_t buffered_bytes) const {
+	(void)buffered_bytes;
+	return true;
+}
+
+std::chrono::milliseconds ClampToDeadline(std::chrono::milliseconds op_timeout,
+                                          std::chrono::steady_clock::time_point now,
+                                          std::chrono::steady_clock::time_point deadline) {
+	(void)now;
+	(void)deadline;
+	return op_timeout;
+}
+
 SmtpClient::SmtpClient(const SmtpOptions &options_p) : options(options_p) {
 	if (options.port == 0) {
 		options.port = 25;

--- a/src/anofox_email_smtp.cpp
+++ b/src/anofox_email_smtp.cpp
@@ -27,6 +27,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <netdb.h>
+#include <poll.h>
 #include <sys/socket.h>
 #include <sys/time.h>
 #include <unistd.h>
@@ -50,6 +51,16 @@ constexpr socket_handle INVALID_SOCKET_HANDLE = -1;
 #endif
 
 enum class WaitStatus { Success, Timeout, Error };
+
+//! poll()/WSAPoll() wrapper: unlike select(), it has no FD_SETSIZE limit, so
+//! arbitrary descriptor values are safe (issue #47).
+int PollSockets(struct pollfd *fds, size_t count, int timeout_ms) {
+#ifdef _WIN32
+	return WSAPoll(fds, static_cast<ULONG>(count), timeout_ms);
+#else
+	return poll(fds, static_cast<nfds_t>(count), timeout_ms);
+#endif
+}
 
 void DebugTrace(const std::string &message) {
     EmailTrace(AnofoxLogLevel::Debug, std::string("[SMTP] ") + message);
@@ -142,45 +153,39 @@ milliseconds ToDuration(uint32_t value_ms, uint32_t max_ms) {
 	return milliseconds(clamped);
 }
 
+//! Waits for the socket to become ready. The per-operation timeout is capped
+//! by the absolute overall deadline so a single host cannot exceed the total
+//! SMTP budget (issue #47).
 WaitStatus WaitForSocket(socket_handle sock, bool want_read, bool want_write, milliseconds timeout,
-                         SmtpResult *result, const char *context) {
-	auto deadline = Clock::now() + timeout;
-	while (true) {
-		if (context) {
-			DebugTrace(std::string(context) + " wait start (" + std::to_string(timeout.count()) + "ms)");
-			if (result) {
-				result->transcript.push_back({std::string("wait:start:") + context});
-			}
+                         Clock::time_point overall_deadline, SmtpResult *result, const char *context) {
+	auto start = Clock::now();
+	auto wait_deadline = start + ClampToDeadline(timeout, start, overall_deadline);
+	if (context) {
+		DebugTrace(std::string(context) + " wait start (" + std::to_string(timeout.count()) + "ms)");
+		if (result) {
+			result->transcript.push_back({std::string("wait:start:") + context});
 		}
-		fd_set readfds;
-		fd_set writefds;
-		fd_set exceptfds;
-		FD_ZERO(&readfds);
-		FD_ZERO(&writefds);
-		FD_ZERO(&exceptfds);
+	}
+	while (true) {
+		auto now = Clock::now();
+		auto remaining = (now < wait_deadline)
+		                    ? std::chrono::duration_cast<std::chrono::microseconds>(wait_deadline - now)
+		                    : std::chrono::microseconds(0);
+		// Round up so a sub-millisecond budget still polls once with a short wait.
+		auto remaining_ms = static_cast<int>((remaining.count() + 999) / 1000);
+
+		struct pollfd pfd;
+		pfd.fd = sock;
+		pfd.events = 0;
+		pfd.revents = 0;
 		if (want_read) {
-			FD_SET(sock, &readfds);
+			pfd.events |= POLLIN;
 		}
 		if (want_write) {
-			FD_SET(sock, &writefds);
+			pfd.events |= POLLOUT;
 		}
-		FD_SET(sock, &exceptfds);
 
-		auto now = Clock::now();
-		auto remaining = (now < deadline)
-		                    ? std::chrono::duration_cast<std::chrono::microseconds>(deadline - now)
-		                    : std::chrono::microseconds(0);
-		struct timeval tv;
-		tv.tv_sec = static_cast<long>(remaining.count() / 1000000);
-		tv.tv_usec = static_cast<long>(remaining.count() % 1000000);
-
-		int nfds =
-#ifdef _WIN32
-		    0;
-#else
-		    static_cast<int>(sock) + 1;
-#endif
-		int ret = select(nfds, want_read ? &readfds : nullptr, want_write ? &writefds : nullptr, &exceptfds, &tv);
+		int ret = PollSockets(&pfd, 1, remaining_ms);
 		if (ret == 0) {
 			if (context) {
 				DebugTrace(std::string(context) + " wait timeout");
@@ -209,7 +214,7 @@ WaitStatus WaitForSocket(socket_handle sock, bool want_read, bool want_write, mi
 			}
 			return WaitStatus::Error;
 		}
-		if (FD_ISSET(sock, &exceptfds)) {
+		if (pfd.revents & (POLLERR | POLLNVAL)) {
 			if (context) {
 				DebugTrace(std::string(context) + " wait exception");
 			}
@@ -342,22 +347,23 @@ bool RunResolverLoop(ares_channel_t *channel, ResolverSocketTracker &tracker, in
 			remaining = min_timeout;
 		}
 
-		fd_set read_fds;
-		fd_set write_fds;
-		FD_ZERO(&read_fds);
-		FD_ZERO(&write_fds);
-		ares_socket_t max_fd = ARES_SOCKET_BAD;
+		std::vector<struct pollfd> poll_fds;
+		poll_fds.reserve(tracker.sockets.size());
 		for (auto &entry : tracker.sockets) {
-			auto sock = entry.first;
 			const auto &state = entry.second;
+			short poll_events = 0;
 			if (state.readable) {
-				FD_SET(sock, &read_fds);
+				poll_events |= POLLIN;
 			}
 			if (state.writable) {
-				FD_SET(sock, &write_fds);
+				poll_events |= POLLOUT;
 			}
-			if ((state.readable || state.writable) && (max_fd == ARES_SOCKET_BAD || sock > max_fd)) {
-				max_fd = sock;
+			if (poll_events != 0) {
+				struct pollfd pfd;
+				pfd.fd = entry.first;
+				pfd.events = poll_events;
+				pfd.revents = 0;
+				poll_fds.push_back(pfd);
 			}
 		}
 
@@ -370,51 +376,53 @@ bool RunResolverLoop(ares_channel_t *channel, ResolverSocketTracker &tracker, in
 		if (!tv_ptr) {
 			tv_ptr = &capped_timeout;
 		}
-
-		int select_result = 0;
-		if (max_fd != ARES_SOCKET_BAD) {
-			int nfds = static_cast<int>(max_fd) + 1;
-			select_result = select(nfds, &read_fds, &write_fds, nullptr, tv_ptr);
-		} else {
-			auto sleep_ms = static_cast<uint32_t>(tv_ptr->tv_sec * 1000 + static_cast<long>(tv_ptr->tv_usec / 1000));
-			auto capped_ms = static_cast<uint32_t>(remaining.count());
-			if (sleep_ms == 0 || sleep_ms > capped_ms) {
-				sleep_ms = capped_ms;
-			}
-			if (sleep_ms == 0) {
-				sleep_ms = static_cast<uint32_t>(min_timeout.count());
-			}
-			std::this_thread::sleep_for(std::chrono::milliseconds(sleep_ms));
+		// Round up so a sub-millisecond budget does not busy-spin.
+		auto wait_ms = static_cast<uint32_t>(tv_ptr->tv_sec * 1000 + (tv_ptr->tv_usec + 999) / 1000);
+		auto capped_ms = static_cast<uint32_t>(remaining.count());
+		if (wait_ms > capped_ms) {
+			wait_ms = capped_ms;
 		}
-		if (select_result < 0) {
+		if (wait_ms == 0) {
+			wait_ms = static_cast<uint32_t>(min_timeout.count());
+		}
+
+		int poll_result = 0;
+		if (!poll_fds.empty()) {
+			poll_result = PollSockets(poll_fds.data(), poll_fds.size(), static_cast<int>(wait_ms));
+		} else {
+			std::this_thread::sleep_for(std::chrono::milliseconds(wait_ms));
+		}
+		if (poll_result < 0) {
 #ifdef _WIN32
 			int wsa_error = WSAGetLastError();
 			if (wsa_error == WSAEINTR) {
 				continue;
 			}
-			error_reason = "smtp_dns_select_failed_" + std::to_string(wsa_error);
+			error_reason = "smtp_dns_poll_failed_" + std::to_string(wsa_error);
 #else
 			if (errno == EINTR) {
 				continue;
 			}
-			error_reason = "smtp_dns_select_failed_" + std::to_string(errno);
+			error_reason = "smtp_dns_poll_failed_" + std::to_string(errno);
 #endif
 			return false;
 		}
 
 		std::vector<ares_fd_events_t> events;
-		if (select_result > 0) {
-			for (auto &entry : tracker.sockets) {
-				auto sock = entry.first;
+		if (poll_result > 0) {
+			for (auto &pfd : poll_fds) {
+				if (pfd.revents == 0) {
+					continue;
+				}
 				unsigned int event_mask = ARES_FD_EVENT_NONE;
-				if (FD_ISSET(sock, &read_fds)) {
+				if (pfd.revents & (POLLIN | POLLERR | POLLHUP | POLLNVAL)) {
 					event_mask |= ARES_FD_EVENT_READ;
 				}
-				if (FD_ISSET(sock, &write_fds)) {
+				if (pfd.revents & POLLOUT) {
 					event_mask |= ARES_FD_EVENT_WRITE;
 				}
 				if (event_mask != ARES_FD_EVENT_NONE) {
-					events.push_back({sock, event_mask});
+					events.push_back({pfd.fd, event_mask});
 				}
 			}
 		}
@@ -557,12 +565,13 @@ bool ResolveHostEndpoints(const std::string &host, uint16_t port, std::chrono::m
 	return true;
 }
 
-bool SendBuffer(socket_handle sock, const std::string &data, milliseconds timeout, SmtpResult &result) {
+bool SendBuffer(socket_handle sock, const std::string &data, milliseconds timeout, Clock::time_point deadline,
+                SmtpResult &result) {
 	size_t sent = 0;
 	while (sent < data.size()) {
-		auto status = WaitForSocket(sock, false, true, timeout, &result, "send");
+		auto status = WaitForSocket(sock, false, true, timeout, deadline, &result, "send");
 		if (status == WaitStatus::Timeout) {
-			result.reason = "smtp_write_timeout";
+			result.reason = Clock::now() >= deadline ? "smtp_overall_timeout" : "smtp_write_timeout";
 			return false;
 		}
 		if (status == WaitStatus::Error) {
@@ -595,16 +604,18 @@ bool SendBuffer(socket_handle sock, const std::string &data, milliseconds timeou
 	return true;
 }
 
-bool SendCommand(socket_handle sock, const std::string &command, milliseconds timeout, SmtpResult &result) {
+bool SendCommand(socket_handle sock, const std::string &command, milliseconds timeout, Clock::time_point deadline,
+                 SmtpResult &result) {
 	result.transcript.push_back({"C: " + command});
 	std::string wire = command;
 	if (wire.size() < 2 || wire.substr(wire.size() - 2) != "\r\n") {
 		wire += "\r\n";
 	}
-	return SendBuffer(sock, wire, timeout, result);
+	return SendBuffer(sock, wire, timeout, deadline, result);
 }
 
-bool ReadLine(socket_handle sock, std::string &buffer, std::string &line, milliseconds timeout, SmtpResult &result,
+bool ReadLine(socket_handle sock, std::string &buffer, std::string &line, milliseconds timeout,
+              Clock::time_point deadline, SmtpResponseBudget &budget, SmtpResult &result,
               const std::string &timeout_reason, const std::string &error_reason) {
 	char temp[512];
 	while (true) {
@@ -612,12 +623,22 @@ bool ReadLine(socket_handle sock, std::string &buffer, std::string &line, millis
 		if (pos != std::string::npos) {
 			line = buffer.substr(0, pos);
 			buffer.erase(0, pos + 2);
+			if (!budget.AcceptLine(line.size() + 2)) {
+				result.reason = "smtp_response_too_large";
+				result.transcript.push_back({"Response exceeds SMTP protocol limits"});
+				return false;
+			}
 			result.transcript.push_back({"S: " + line});
 			return true;
 		}
-		auto status = WaitForSocket(sock, true, false, timeout, &result, "read");
+		if (!budget.AcceptPartialLine(buffer.size())) {
+			result.reason = "smtp_response_too_large";
+			result.transcript.push_back({"Response line exceeds maximum length"});
+			return false;
+		}
+		auto status = WaitForSocket(sock, true, false, timeout, deadline, &result, "read");
 		if (status == WaitStatus::Timeout) {
-			result.reason = timeout_reason;
+			result.reason = Clock::now() >= deadline ? "smtp_overall_timeout" : timeout_reason;
 			return false;
 		}
 		if (status == WaitStatus::Error) {
@@ -656,10 +677,12 @@ int ParseSmtpCode(const std::string &response) {
 	return (response[0] - '0') * 100 + (response[1] - '0') * 10 + (response[2] - '0');
 }
 
-bool ReadResponse(socket_handle sock, std::string &buffer, milliseconds timeout, SmtpResult &result, int &code,
-                  const std::string &timeout_reason, const std::string &error_reason) {
+bool ReadResponse(socket_handle sock, std::string &buffer, milliseconds timeout, Clock::time_point deadline,
+                  SmtpResult &result, int &code, const std::string &timeout_reason,
+                  const std::string &error_reason) {
+	SmtpResponseBudget budget;
 	std::string line;
-	if (!ReadLine(sock, buffer, line, timeout, result, timeout_reason, error_reason)) {
+	if (!ReadLine(sock, buffer, line, timeout, deadline, budget, result, timeout_reason, error_reason)) {
 		return false;
 	}
 	code = ParseSmtpCode(line);
@@ -668,7 +691,7 @@ bool ReadResponse(socket_handle sock, std::string &buffer, milliseconds timeout,
 		return false;
 	}
 	while (line.size() > 3 && line[3] == '-') {
-		if (!ReadLine(sock, buffer, line, timeout, result, timeout_reason, error_reason)) {
+		if (!ReadLine(sock, buffer, line, timeout, deadline, budget, result, timeout_reason, error_reason)) {
 			return false;
 		}
 		int line_code = ParseSmtpCode(line);
@@ -681,7 +704,7 @@ bool ReadResponse(socket_handle sock, std::string &buffer, milliseconds timeout,
 }
 
 bool ConnectSocket(socket_handle sock, const sockaddr *addr, socklen_t length, milliseconds timeout,
-                   std::string &endpoint, SmtpResult &result) {
+                   Clock::time_point deadline, std::string &endpoint, SmtpResult &result) {
 	int rc = connect(sock, addr, length);
 	if (rc == 0) {
 		endpoint = EndpointToString(addr, length);
@@ -699,9 +722,9 @@ bool ConnectSocket(socket_handle sock, const sockaddr *addr, socklen_t length, m
 		result.transcript.push_back({"Connect error: " + SocketErrorMessage(err)});
 		return false;
 	}
-	auto status = WaitForSocket(sock, false, true, timeout, &result, "connect");
+	auto status = WaitForSocket(sock, false, true, timeout, deadline, &result, "connect");
 	if (status == WaitStatus::Timeout) {
-		result.reason = "smtp_connect_timeout";
+		result.reason = Clock::now() >= deadline ? "smtp_overall_timeout" : "smtp_connect_timeout";
 		return false;
 	}
 	if (status == WaitStatus::Error) {
@@ -731,7 +754,8 @@ bool ConnectSocket(socket_handle sock, const sockaddr *addr, socklen_t length, m
 	return true;
 }
 
-SmtpResult AttemptHost(const std::string &email, const std::string &host, const SmtpOptions &options) {
+SmtpResult AttemptHost(const std::string &email, const std::string &host, const SmtpOptions &options,
+                       Clock::time_point deadline) {
 	SmtpResult attempt;
 	attempt.transcript.push_back({"Attempt host: " + host});
     EmailTrace(AnofoxLogLevel::Info,
@@ -763,7 +787,13 @@ SmtpResult AttemptHost(const std::string &email, const std::string &host, const 
 			return attempt;
 		} else {
             EmailTrace(AnofoxLogLevel::Info, "SMTP resolving host via DNS: " + host);
-			if (!ResolveHostEndpoints(host, options.port, connect_timeout, endpoints, attempt)) {
+			auto resolve_timeout = ClampToDeadline(connect_timeout, Clock::now(), deadline);
+			if (resolve_timeout <= milliseconds::zero()) {
+				attempt.reason = "smtp_overall_timeout";
+				attempt.transcript.push_back({"Overall SMTP timeout reached before resolving host: " + host});
+				return attempt;
+			}
+			if (!ResolveHostEndpoints(host, options.port, resolve_timeout, endpoints, attempt)) {
                 EmailTrace(AnofoxLogLevel::Warn,
                            "SMTP DNS resolution failed reason=" + attempt.reason);
 				return attempt;
@@ -801,7 +831,7 @@ SmtpResult AttemptHost(const std::string &email, const std::string &host, const 
 
 		std::string endpoint_str;
 		if (!ConnectSocket(sock, reinterpret_cast<const sockaddr *>(&endpoint.address), endpoint.length, connect_timeout,
-		                   endpoint_str, attempt)) {
+		                   deadline, endpoint_str, attempt)) {
 			CloseSocketHandle(sock);
             EmailTrace(AnofoxLogLevel::Warn,
                        "SMTP connect failed endpoint=" + endpoint.description + " reason=" + attempt.reason);
@@ -816,7 +846,7 @@ SmtpResult AttemptHost(const std::string &email, const std::string &host, const 
 		read_buffer.clear();
 
 		int code = 0;
-		if (!ReadResponse(sock, read_buffer, io_timeout, attempt, code, "smtp_greeting_timeout",
+		if (!ReadResponse(sock, read_buffer, io_timeout, deadline, attempt, code, "smtp_greeting_timeout",
 		                  "smtp_greeting_error")) {
 			CloseSocketHandle(sock);
             EmailTrace(AnofoxLogLevel::Warn,
@@ -831,13 +861,13 @@ SmtpResult AttemptHost(const std::string &email, const std::string &host, const 
 			return attempt;
 		}
 
-		if (!SendCommand(sock, "EHLO " + options.helo_domain, io_timeout, attempt)) {
+		if (!SendCommand(sock, "EHLO " + options.helo_domain, io_timeout, deadline, attempt)) {
 			CloseSocketHandle(sock);
             EmailTrace(AnofoxLogLevel::Warn,
                        "SMTP EHLO send failed reason=" + attempt.reason);
 			return attempt;
 		}
-		if (!ReadResponse(sock, read_buffer, io_timeout, attempt, code, "smtp_read_timeout",
+		if (!ReadResponse(sock, read_buffer, io_timeout, deadline, attempt, code, "smtp_read_timeout",
 		                  "smtp_read_error")) {
 			CloseSocketHandle(sock);
             EmailTrace(AnofoxLogLevel::Warn,
@@ -852,13 +882,13 @@ SmtpResult AttemptHost(const std::string &email, const std::string &host, const 
 			return attempt;
 		}
 
-		if (!SendCommand(sock, "MAIL FROM:<" + options.mail_from + ">", io_timeout, attempt)) {
+		if (!SendCommand(sock, "MAIL FROM:<" + options.mail_from + ">", io_timeout, deadline, attempt)) {
 			CloseSocketHandle(sock);
             EmailTrace(AnofoxLogLevel::Warn,
                        "SMTP MAIL FROM send failed reason=" + attempt.reason);
 			return attempt;
 		}
-		if (!ReadResponse(sock, read_buffer, io_timeout, attempt, code, "smtp_read_timeout",
+		if (!ReadResponse(sock, read_buffer, io_timeout, deadline, attempt, code, "smtp_read_timeout",
 		                  "smtp_read_error")) {
 			CloseSocketHandle(sock);
             EmailTrace(AnofoxLogLevel::Warn,
@@ -873,13 +903,13 @@ SmtpResult AttemptHost(const std::string &email, const std::string &host, const 
 			return attempt;
 		}
 
-		if (!SendCommand(sock, "RCPT TO:<" + email + ">", io_timeout, attempt)) {
+		if (!SendCommand(sock, "RCPT TO:<" + email + ">", io_timeout, deadline, attempt)) {
 			CloseSocketHandle(sock);
             EmailTrace(AnofoxLogLevel::Warn,
                        "SMTP RCPT TO send failed reason=" + attempt.reason);
 			return attempt;
 		}
-		if (!ReadResponse(sock, read_buffer, io_timeout, attempt, code, "smtp_read_timeout",
+		if (!ReadResponse(sock, read_buffer, io_timeout, deadline, attempt, code, "smtp_read_timeout",
 		                  "smtp_read_error")) {
 			CloseSocketHandle(sock);
             EmailTrace(AnofoxLogLevel::Warn,
@@ -896,7 +926,7 @@ SmtpResult AttemptHost(const std::string &email, const std::string &host, const 
 
 		attempt.success = true;
 		attempt.reason.clear();
-		SendCommand(sock, "QUIT", io_timeout, attempt);
+		SendCommand(sock, "QUIT", io_timeout, deadline, attempt);
 		CloseSocketHandle(sock);
         EmailTrace(AnofoxLogLevel::Info, "SMTP verification success host=" + host);
 		return attempt;
@@ -910,21 +940,32 @@ SmtpResult AttemptHost(const std::string &email, const std::string &host, const 
 } // namespace
 
 bool SmtpResponseBudget::AcceptLine(size_t line_bytes) {
-	(void)line_bytes;
-	return true;
+	if (line_bytes > SmtpLimits::MAX_LINE_BYTES) {
+		return false;
+	}
+	line_count++;
+	if (line_count > SmtpLimits::MAX_RESPONSE_LINES) {
+		return false;
+	}
+	total_bytes += line_bytes;
+	return total_bytes <= SmtpLimits::MAX_RESPONSE_BYTES;
 }
 
 bool SmtpResponseBudget::AcceptPartialLine(size_t buffered_bytes) const {
-	(void)buffered_bytes;
-	return true;
+	return buffered_bytes <= SmtpLimits::MAX_LINE_BYTES;
 }
 
 std::chrono::milliseconds ClampToDeadline(std::chrono::milliseconds op_timeout,
                                           std::chrono::steady_clock::time_point now,
                                           std::chrono::steady_clock::time_point deadline) {
-	(void)now;
-	(void)deadline;
-	return op_timeout;
+	if (op_timeout < std::chrono::milliseconds::zero()) {
+		op_timeout = std::chrono::milliseconds::zero();
+	}
+	if (now >= deadline) {
+		return std::chrono::milliseconds::zero();
+	}
+	auto remaining = std::chrono::duration_cast<std::chrono::milliseconds>(deadline - now);
+	return std::min(op_timeout, remaining);
 }
 
 SmtpClient::SmtpClient(const SmtpOptions &options_p) : options(options_p) {
@@ -970,7 +1011,7 @@ SmtpResult SmtpClient::Verify(const std::string &email, const std::vector<std::s
 			aggregated.transcript.push_back({"Overall SMTP timeout reached before trying host: " + host});
 			return aggregated;
 		}
-		SmtpResult attempt = AttemptHost(email, host, options);
+		SmtpResult attempt = AttemptHost(email, host, options, overall_deadline);
 		aggregated.transcript.insert(aggregated.transcript.end(), attempt.transcript.begin(), attempt.transcript.end());
 		if (attempt.success) {
 			aggregated.success = true;

--- a/src/include/anofox_email_dns.hpp
+++ b/src/include/anofox_email_dns.hpp
@@ -14,6 +14,8 @@ namespace email {
 struct DnsOptions {
 	static constexpr uint32_t MIN_TIMEOUT_MS = 1;
 	static constexpr uint32_t MAX_TIMEOUT_MS = 5000;
+	static constexpr uint32_t MIN_TRIES = 1;
+	static constexpr uint32_t MAX_TRIES = 10;
 	uint32_t timeout_ms = 1000;
 	uint32_t tries = 1;
 };
@@ -23,6 +25,24 @@ struct DnsResult {
 	std::string reason;
 	std::vector<std::string> mx_hosts;
 };
+
+//! A single MX record as returned by the DNS lookup.
+struct MxRecord {
+	uint16_t preference;
+	std::string exchange;
+};
+
+//! Result of filtering/ordering MX records. `null_mx` is set when an RFC 7505
+//! Null MX record (exchange ".") was present, signalling the domain does not
+//! accept mail.
+struct MxSelection {
+	bool null_mx = false;
+	std::vector<std::string> hosts;
+};
+
+//! Orders MX records by preference and filters out RFC 7505 Null MX entries.
+//! Exposed as a free function so the logic is unit-testable without sockets.
+MxSelection SelectMxHosts(std::vector<MxRecord> records);
 
 class DnsResolver {
 public:

--- a/src/include/anofox_email_smtp.hpp
+++ b/src/include/anofox_email_smtp.hpp
@@ -3,6 +3,8 @@
 #include "duckdb/common/vector.hpp"
 #include "duckdb/common/types/string_type.hpp"
 
+#include <chrono>
+#include <cstddef>
 #include <string>
 #include <vector>
 
@@ -21,6 +23,38 @@ struct SmtpOptions {
 	std::string helo_domain = "duckdb.local";
 	std::string mail_from = "validator@duckdb.local";
 };
+
+//! Protocol limits applied to SMTP server responses so a hostile peer cannot
+//! grow memory without bound.
+struct SmtpLimits {
+	static constexpr size_t MAX_LINE_BYTES = 8 * 1024;
+	static constexpr size_t MAX_RESPONSE_BYTES = 64 * 1024;
+	static constexpr size_t MAX_RESPONSE_LINES = 64;
+};
+
+//! Tracks byte/line consumption of a single (possibly multi-line) SMTP
+//! response. Exposed so the limit enforcement is unit-testable without sockets.
+class SmtpResponseBudget {
+public:
+	//! Account for one complete received line (including the CRLF terminator).
+	//! Returns false once the line length, total response size, or line count
+	//! exceeds the protocol limits.
+	bool AcceptLine(size_t line_bytes);
+	//! Check an unterminated partial line accumulated in the receive buffer.
+	//! Returns false when it already exceeds the maximum line length.
+	bool AcceptPartialLine(size_t buffered_bytes) const;
+
+private:
+	size_t total_bytes = 0;
+	size_t line_count = 0;
+};
+
+//! Returns the effective wait duration for a single socket operation:
+//! min(op_timeout, time remaining until the absolute deadline), never
+//! negative. Exposed so the deadline math is unit-testable without sockets.
+std::chrono::milliseconds ClampToDeadline(std::chrono::milliseconds op_timeout,
+                                          std::chrono::steady_clock::time_point now,
+                                          std::chrono::steady_clock::time_point deadline);
 
 struct SmtpDebugEntry {
 	std::string message;

--- a/test/cpp/test_email_internal.cpp
+++ b/test/cpp/test_email_internal.cpp
@@ -1,0 +1,110 @@
+// Unit tests for the network-free internals of the email validation module
+// (issue #47: network safety and protocol limits).
+//
+// These tests are linked into DuckDB's Catch2 `unittest` runner; test names
+// start with "test/cpp/" so the default "test/*" filter picks them up.
+
+#include "catch.hpp"
+
+#include "anofox_email_dns.hpp"
+#include "anofox_email_smtp.hpp"
+
+#include <string>
+#include <vector>
+
+using namespace duckdb::anofox::email;
+using std::chrono::milliseconds;
+using std::chrono::seconds;
+using std::chrono::steady_clock;
+
+TEST_CASE("test/cpp/anofox_email_mx_selection", "[anofox_email]") {
+	SECTION("regular records are ordered by preference") {
+		auto selection = SelectMxHosts({{20, "mx2.example.com"}, {10, "mx1.example.com"}});
+		REQUIRE_FALSE(selection.null_mx);
+		REQUIRE(selection.hosts == std::vector<std::string>({"mx1.example.com", "mx2.example.com"}));
+	}
+
+	SECTION("RFC 7505 Null MX yields no deliverable hosts") {
+		auto selection = SelectMxHosts({{0, "."}});
+		REQUIRE(selection.null_mx);
+		REQUIRE(selection.hosts.empty());
+	}
+
+	SECTION("empty exchange is treated like Null MX") {
+		auto selection = SelectMxHosts({{0, ""}});
+		REQUIRE(selection.null_mx);
+		REQUIRE(selection.hosts.empty());
+	}
+
+	SECTION("Null MX mixed with real records keeps only real hosts") {
+		auto selection = SelectMxHosts({{0, "."}, {10, "mx.example.com"}});
+		REQUIRE(selection.null_mx);
+		REQUIRE(selection.hosts == std::vector<std::string>({"mx.example.com"}));
+	}
+
+	SECTION("no records yields no hosts and no Null MX") {
+		auto selection = SelectMxHosts({});
+		REQUIRE_FALSE(selection.null_mx);
+		REQUIRE(selection.hosts.empty());
+	}
+}
+
+TEST_CASE("test/cpp/anofox_email_smtp_response_budget", "[anofox_email]") {
+	SECTION("lines within limits are accepted") {
+		SmtpResponseBudget budget;
+		REQUIRE(budget.AcceptLine(512));
+		REQUIRE(budget.AcceptLine(SmtpLimits::MAX_LINE_BYTES));
+	}
+
+	SECTION("a single line above the maximum length is rejected") {
+		SmtpResponseBudget budget;
+		REQUIRE_FALSE(budget.AcceptLine(SmtpLimits::MAX_LINE_BYTES + 1));
+	}
+
+	SECTION("an unterminated partial line above the maximum length is rejected") {
+		SmtpResponseBudget budget;
+		REQUIRE(budget.AcceptPartialLine(SmtpLimits::MAX_LINE_BYTES));
+		REQUIRE_FALSE(budget.AcceptPartialLine(SmtpLimits::MAX_LINE_BYTES + 1));
+	}
+
+	SECTION("total response size is bounded") {
+		SmtpResponseBudget budget;
+		// 4 KiB lines: the first 16 fill the 64 KiB response budget exactly.
+		bool accepted = true;
+		for (size_t i = 0; i < SmtpLimits::MAX_RESPONSE_BYTES / 4096; i++) {
+			accepted = budget.AcceptLine(4096);
+			REQUIRE(accepted);
+		}
+		REQUIRE_FALSE(budget.AcceptLine(4096));
+	}
+
+	SECTION("multi-line count is bounded") {
+		SmtpResponseBudget budget;
+		for (size_t i = 0; i < SmtpLimits::MAX_RESPONSE_LINES; i++) {
+			REQUIRE(budget.AcceptLine(16));
+		}
+		REQUIRE_FALSE(budget.AcceptLine(16));
+	}
+}
+
+TEST_CASE("test/cpp/anofox_email_smtp_deadline_clamp", "[anofox_email]") {
+	auto now = steady_clock::now();
+
+	SECTION("op timeout within the remaining budget is unchanged") {
+		REQUIRE(ClampToDeadline(milliseconds(100), now, now + seconds(10)) == milliseconds(100));
+	}
+
+	SECTION("op timeout is capped by the remaining budget") {
+		auto clamped = ClampToDeadline(seconds(5), now, now + milliseconds(200));
+		REQUIRE(clamped <= milliseconds(200));
+	}
+
+	SECTION("an expired deadline yields a zero wait") {
+		REQUIRE(ClampToDeadline(milliseconds(100), now, now - milliseconds(1)) == milliseconds(0));
+		REQUIRE(ClampToDeadline(milliseconds(100), now, now) == milliseconds(0));
+	}
+
+	SECTION("negative op timeouts are floored at zero") {
+		REQUIRE(ClampToDeadline(milliseconds(-5), now, now + seconds(1)) == milliseconds(0));
+	}
+}

--- a/test/sql/anofox_email_network_safety.test
+++ b/test/sql/anofox_email_network_safety.test
@@ -1,0 +1,66 @@
+# name: test/sql/anofox_email_network_safety.test
+# description: Email network safety (issue #47) — no loopback fallback after
+#              DNS failure, bounded DNS tries. Uses the reserved .invalid TLD
+#              (RFC 2606) so DNS resolution fails deterministically without
+#              requiring a working network.
+# group: [anofox_tabular]
+
+require anofox_tabular
+
+statement ok
+LOAD anofox_tabular;
+
+# Keep the DNS/SMTP stages fast even when no network is available.
+statement ok
+SET anofox_tab_email_dns_timeout_ms=500;
+
+statement ok
+SET anofox_tab_email_smtp_connect_timeout_ms=100;
+
+statement ok
+SET anofox_tab_email_smtp_read_timeout_ms=100;
+
+# SMTP-mode validation of an unresolvable domain must fail at the DNS stage:
+# no fallback SMTP probing of the raw domain, localhost, or 127.0.0.1.
+query TTTT
+SELECT (result).valid, (result).stage, COALESCE((result).reason, '') <> '',
+       list_has_any((result).mx_hosts, ['localhost', '127.0.0.1'])
+FROM (SELECT anofox_tab_email_validate('user@nonexistent-domain-zzz.invalid', 'smtp') AS result);
+----
+false	dns	true	false
+
+# DNS-mode validation must not report loopback hosts as MX candidates either.
+query TTT
+SELECT (result).valid, (result).stage,
+       list_has_any((result).mx_hosts, ['localhost', '127.0.0.1'])
+FROM (SELECT anofox_tab_email_validate('user@nonexistent-domain-zzz.invalid', 'dns') AS result);
+----
+false	dns	false
+
+# The DNS tries option is bounded to a documented small range (1..10).
+statement ok
+SET anofox_tab_email_dns_tries=10;
+
+statement error
+SET anofox_tab_email_dns_tries=11;
+----
+anofox_tab_email_dns_tries must be between 1 and 10
+
+statement error
+SET anofox_tab_email_dns_tries=0;
+----
+anofox_tab_email_dns_tries must be between 1 and 10
+
+# Restore defaults; the email configuration singleton is process-wide and
+# would otherwise leak into other test files.
+statement ok
+SET anofox_tab_email_dns_tries=1;
+
+statement ok
+SET anofox_tab_email_dns_timeout_ms=1000;
+
+statement ok
+SET anofox_tab_email_smtp_connect_timeout_ms=5000;
+
+statement ok
+SET anofox_tab_email_smtp_read_timeout_ms=5000;


### PR DESCRIPTION
Closes #47.

## Summary

Fixes the six findings from the email module review (all re-verified against current `main` before fixing — none were already fixed):

| Sev | Finding | Fix |
|-----|---------|-----|
| HIGH | After DNS failure, SMTP fallback hosts included the raw domain, `localhost`, and `127.0.0.1` | `BuildFallbackHosts` removed; DNS failure now fails validation for both `dns` and `smtp` modes at the DNS stage |
| HIGH | `FD_SET` with fd >= `FD_SETSIZE` is UB in DNS and SMTP `select()` loops | All three loops (DNS event loop, SMTP resolver loop, SMTP socket waits) rewritten on `poll()`/`WSAPoll()` |
| MED | Null MX (`"."`, RFC 7505) treated as deliverable | `SelectMxHosts` filters Null MX exchanges; an effective Null MX fails with reason `dns_null_mx` and skips the direct-host fallback |
| MED | `ReadLine`/`ReadResponse` unbounded | `SmtpResponseBudget` enforces 8 KiB/line, 64 KiB/response, 64 lines/response; violations fail with `smtp_response_too_large` |
| MED | Overall SMTP timeout only checked between hosts | Absolute deadline threaded through `AttemptHost`/`ConnectSocket`/`ReadResponse`/`SendCommand`; every wait capped via `ClampToDeadline`; exhausted budget reports `smtp_overall_timeout` |
| LOW | `dns_tries` accepted up to `uint32_t` max then cast to `int` for c-ares | Capped to documented `1..10` (`DnsOptions::MIN_TRIES`/`MAX_TRIES`), enforced in the SET callback, config setter, and resolver |

## TDD red/green

The first commit (`test: add failing tests for email network safety (#47)`) contains only the tests plus the exposure-only refactor (`SelectMxHosts`, `SmtpResponseBudget`, `ClampToDeadline` declared with the current, unfixed behavior so the tests compile). Red run output at that commit:

**Catch2 (`./build/release/test/unittest "test/cpp/*"`):**
```
test/cpp/anofox_email_mx_selection:        REQUIRE( selection.null_mx ) FAILED (3 sections)
test/cpp/anofox_email_smtp_response_budget: REQUIRE_FALSE( budget.AcceptLine(...) ) FAILED (4 sections)
test/cpp/anofox_email_smtp_deadline_clamp:  REQUIRE( clamped <= milliseconds(200) ) FAILED (3 sections)
test cases:  3 |  0 passed |  3 failed
assertions: 98 | 88 passed | 10 failed
```

**sqllogictest (`test/sql/anofox_email_network_safety.test`):**
```
Mismatch on row 1, column (result).stage(index 2)
smtp <> dns
Actual result: 0  smtp  1  1     -- stage=smtp via fallback probing, mx_hosts contained localhost/127.0.0.1
```
`SET anofox_tab_email_dns_tries=11` was accepted before the fix.

Since no `test/cpp` infrastructure existed, the Catch2 tests are linked into DuckDB's `unittest` runner via a deferred CMake registration (`cmake_language(DEFER)`); test names start with `test/cpp/` so the standard `make test` filter (`test/*`) picks them up.

## Test status

- `./build/release/test/unittest "test/*"`: **All tests passed** (21 test cases — 18 sqllogictests + 3 new Catch2 cases; 1 skipped: `require-env OPENVINO_AVAILABLE`), 1744 assertions.
- New sqllogictest uses only the reserved `.invalid` TLD (RFC 2606) and needs no working network.
- Docs updated: `anofox_tab_email_dns_tries` range documented in README and API reference.