### PR TITLE
fix: outlier_tree row ids, categorical negation, duplicates, JSON escaping, param validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -570,6 +570,11 @@ FROM outlier_tree('employees', 'job_title,salary,years_exp', 'outliers');
 - `'summary'`: Single row with pass/fail status and outlier count
 - `'outliers'`: Per-outlier rows with z-scores, bounds, and explanations
 
+**Semantics:**
+- Rows containing NULL in any selected column are excluded from the analysis
+- `row_id` is the 1-based position of the row in the source table (NULL rows still count toward the position)
+- `total_rows` (summary mode) is the number of analyzed rows, i.e. rows that are non-NULL in every selected column
+
 ---
 
 ### 🔄 Data Diffing

--- a/src/anofox_outlier_tree.cpp
+++ b/src/anofox_outlier_tree.cpp
@@ -31,6 +31,7 @@ std::vector<OutlierExplanation> OutlierTree::FitPredict(
     std::vector<OutlierExplanation> outliers;
     clusters_evaluated_ = 0;
     max_depth_reached_ = 0;
+    outlier_slots_.clear();
 
     if (data.empty() || column_info.empty()) {
         return outliers;
@@ -156,8 +157,9 @@ void OutlierTree::BuildTreeForColumn(
     if (right_condition.column_type == FeatureType::NUMERIC) {
         right_condition.is_less_than = false;  // Invert for right branch
     } else {
-        // For categorical, right branch gets complement of left categories
-        // (handled implicitly by not being in left_categories)
+        // For categorical, the right branch is the complement of the left
+        // categories — mark the condition as negated (NOT IN left_categories)
+        right_condition.is_negated = true;
     }
     std::vector<SplitCondition> right_conditions = current_conditions;
     right_conditions.push_back(right_condition);
@@ -236,11 +238,6 @@ void OutlierTree::FindOutliersInNumericCluster(
 
         double score = NumericClusterStats::ChebyshevBound(z_score);
 
-        // Check if we should skip (better outlier already exists)
-        if (ShouldSkipDuplicateOutlier(outliers, row_idx, target_col, score)) {
-            continue;
-        }
-
         OutlierExplanation outlier;
         outlier.row_idx = row_idx;
         outlier.target_column_idx = target_col;
@@ -257,8 +254,9 @@ void OutlierTree::FindOutliersInNumericCluster(
         outlier.outlier_score = score;
 
         GenerateExplanation(outlier, column_info);
-        outliers.push_back(std::move(outlier));
-        outlier_count++;
+        if (AddOrReplaceOutlier(outliers, std::move(outlier))) {
+            outlier_count++;
+        }
     }
 }
 
@@ -312,10 +310,6 @@ void OutlierTree::FindOutliersInCategoricalCluster(
             if (data[target_col].category_indices[idx] == cat_idx) {
                 double score = prop;  // Lower proportion = rarer = lower score
 
-                if (ShouldSkipDuplicateOutlier(outliers, idx, target_col, score)) {
-                    continue;
-                }
-
                 OutlierExplanation outlier;
                 outlier.row_idx = idx;
                 outlier.target_column_idx = target_col;
@@ -329,8 +323,9 @@ void OutlierTree::FindOutliersInCategoricalCluster(
                 outlier.z_score = 1.0 / std::sqrt(prop);
 
                 GenerateExplanation(outlier, column_info);
-                outliers.push_back(std::move(outlier));
-                outlier_count++;
+                if (AddOrReplaceOutlier(outliers, std::move(outlier))) {
+                    outlier_count++;
+                }
             }
         }
     }
@@ -724,6 +719,9 @@ void OutlierTree::PartitionRows(
                 continue;  // Skip invalid categories
             }
             goes_left = split.left_categories.count(cat) > 0;
+            if (split.is_negated) {
+                goes_left = !goes_left;
+            }
         }
 
         if (goes_left) {
@@ -734,19 +732,23 @@ void OutlierTree::PartitionRows(
     }
 }
 
-bool OutlierTree::ShouldSkipDuplicateOutlier(
-    const std::vector<OutlierExplanation>& outliers,
-    size_t row_idx,
-    size_t col_idx,
-    double new_score
+bool OutlierTree::AddOrReplaceOutlier(
+    std::vector<OutlierExplanation>& outliers,
+    OutlierExplanation&& outlier
 ) {
-    for (const auto& existing : outliers) {
-        if (existing.row_idx == row_idx && existing.target_column_idx == col_idx) {
-            // Keep the one with lower (more extreme) score
-            return existing.outlier_score <= new_score;
-        }
+    auto key = std::make_pair(outlier.row_idx, outlier.target_column_idx);
+    auto it = outlier_slots_.find(key);
+    if (it == outlier_slots_.end()) {
+        outlier_slots_.emplace(key, outliers.size());
+        outliers.push_back(std::move(outlier));
+        return true;
     }
-    return false;
+    // Keep the finding with the lower (more extreme) score
+    if (outliers[it->second].outlier_score <= outlier.outlier_score) {
+        return false;
+    }
+    outliers[it->second] = std::move(outlier);
+    return true;
 }
 
 //===--------------------------------------------------------------------===//
@@ -773,6 +775,9 @@ struct OutlierTreeGlobalState : public GlobalTableFunctionState {
 
     // Results
     std::vector<OutlierExplanation> outliers;
+    // Maps a compacted (NULL-filtered) row index back to its 1-based
+    // position in the source table, so reported row ids match the source.
+    std::vector<int64_t> source_row_ids;
     int64_t total_rows = 0;
     int64_t columns_analyzed = 0;
     int64_t clusters_evaluated = 0;
@@ -819,18 +824,26 @@ static unique_ptr<FunctionData> OutlierTreeBind(ClientContext &context, TableFun
         throw BinderException("columns parameter must contain at least one column name");
     }
 
-    // Parse optional parameters
+    // Parse optional parameters (read integral values as signed so that
+    // negative inputs can be rejected before any cast to size_t)
     std::string output_mode = input.inputs.size() > 2 ? input.inputs[2].ToString() : "summary";
-    size_t max_depth = input.inputs.size() > 3 ? input.inputs[3].GetValue<int64_t>() : 4;
+    int64_t max_depth_raw = input.inputs.size() > 3 ? input.inputs[3].GetValue<int64_t>() : 4;
     double max_perc_outliers = input.inputs.size() > 4 ? input.inputs[4].GetValue<double>() : 0.01;
-    size_t min_size_numeric = input.inputs.size() > 5 ? input.inputs[5].GetValue<int64_t>() : 25;
-    size_t min_size_categ = input.inputs.size() > 6 ? input.inputs[6].GetValue<int64_t>() : 75;
+    int64_t min_size_numeric_raw = input.inputs.size() > 5 ? input.inputs[5].GetValue<int64_t>() : 25;
+    int64_t min_size_categ_raw = input.inputs.size() > 6 ? input.inputs[6].GetValue<int64_t>() : 75;
     double z_norm = input.inputs.size() > 7 ? input.inputs[7].GetValue<double>() : 2.67;
     double z_outlier = input.inputs.size() > 8 ? input.inputs[8].GetValue<double>() : 8.0;
 
-    // Validate parameters
-    if (max_depth < 1) {
-        throw BinderException("max_depth must be >= 1");
+    // Validate parameters while still signed
+    static constexpr int64_t MAX_TREE_DEPTH = 1024;
+    if (max_depth_raw < 1 || max_depth_raw > MAX_TREE_DEPTH) {
+        throw BinderException("max_depth must be >= 1 and <= %lld", MAX_TREE_DEPTH);
+    }
+    if (min_size_numeric_raw < 1) {
+        throw BinderException("min_size_numeric must be >= 1");
+    }
+    if (min_size_categ_raw < 1) {
+        throw BinderException("min_size_categ must be >= 1");
     }
     if (max_perc_outliers <= 0 || max_perc_outliers > 1) {
         throw BinderException("max_perc_outliers must be between 0 and 1");
@@ -842,8 +855,9 @@ static unique_ptr<FunctionData> OutlierTreeBind(ClientContext &context, TableFun
         throw BinderException("z_norm must be positive");
     }
 
-    OutlierTreeParams params(max_depth, max_perc_outliers, min_size_numeric,
-                             min_size_categ, z_norm, z_outlier);
+    OutlierTreeParams params(static_cast<size_t>(max_depth_raw), max_perc_outliers,
+                             static_cast<size_t>(min_size_numeric_raw),
+                             static_cast<size_t>(min_size_categ_raw), z_norm, z_outlier);
 
     // Define output schema based on mode
     if (output_mode == "outliers") {
@@ -933,12 +947,15 @@ static void OutlierTreeExecute(ClientContext &context, TableFunctionInput &data_
             column_info[i].name = bind_data.column_names[i];
         }
 
-        // Read data
+        // Read data; rows containing NULL in any selected column are skipped,
+        // but their source positions are preserved for row id reporting.
+        int64_t source_row = 0;
         while (true) {
             auto chunk = result->Fetch();
             if (!chunk || chunk->size() == 0) break;
 
             for (idx_t row = 0; row < chunk->size(); ++row) {
+                source_row++;
                 bool valid_row = true;
 
                 // Check for NULLs
@@ -951,6 +968,8 @@ static void OutlierTreeExecute(ClientContext &context, TableFunctionInput &data_
                 }
 
                 if (!valid_row) continue;
+
+                state.source_row_ids.push_back(source_row);
 
                 // Add values to data structures
                 for (idx_t col = 0; col < chunk->ColumnCount(); ++col) {
@@ -967,6 +986,8 @@ static void OutlierTreeExecute(ClientContext &context, TableFunctionInput &data_
             }
         }
 
+        // total_rows counts the analyzed rows, i.e. rows that are non-NULL in
+        // every selected column (NULL-containing rows are excluded above)
         state.total_rows = data.empty() ? 0 : static_cast<int64_t>(data[0].size());
         state.columns_analyzed = static_cast<int64_t>(data.size());
 
@@ -987,7 +1008,9 @@ static void OutlierTreeExecute(ClientContext &context, TableFunctionInput &data_
         while (state.current_row < state.outliers.size() && count < max_count) {
             auto &outlier = state.outliers[state.current_row];
 
-            output.SetValue(0, count, Value::BIGINT(static_cast<int64_t>(outlier.row_idx + 1)));  // 1-indexed
+            // Report the 1-based source table position, not the index in the
+            // NULL-compacted working dataset
+            output.SetValue(0, count, Value::BIGINT(state.source_row_ids[outlier.row_idx]));
             output.SetValue(1, count, Value(outlier.target_column_name));
             output.SetValue(2, count, Value(outlier.GetOutlierValueString()));
             output.SetValue(3, count, Value::DOUBLE(outlier.cluster_mean));

--- a/src/include/anofox_outlier_tree.hpp
+++ b/src/include/anofox_outlier_tree.hpp
@@ -10,12 +10,41 @@
 #include <optional>
 #include <unordered_set>
 #include <algorithm>
+#include <iomanip>
+#include <map>
 #include <numeric>
 #include <limits>
 #include <sstream>
 
 namespace duckdb {
 namespace anofox {
+
+/**
+ * Escape a string for safe embedding inside a JSON string literal.
+ * Handles quotes, backslashes, and control characters.
+ */
+inline std::string EscapeJSONString(const std::string& input) {
+    std::ostringstream oss;
+    for (char c : input) {
+        switch (c) {
+        case '"':  oss << "\\\""; break;
+        case '\\': oss << "\\\\"; break;
+        case '\b': oss << "\\b"; break;
+        case '\f': oss << "\\f"; break;
+        case '\n': oss << "\\n"; break;
+        case '\r': oss << "\\r"; break;
+        case '\t': oss << "\\t"; break;
+        default:
+            if (static_cast<unsigned char>(c) < 0x20) {
+                oss << "\\u" << std::hex << std::setw(4) << std::setfill('0')
+                    << static_cast<int>(static_cast<unsigned char>(c)) << std::dec;
+            } else {
+                oss << c;
+            }
+        }
+    }
+    return oss.str();
+}
 
 /**
  * Split condition for tree nodes
@@ -33,6 +62,7 @@ struct SplitCondition {
     // For categorical splits
     std::unordered_set<int> left_categories;
     std::vector<std::string> left_category_names;  // Human-readable names
+    bool is_negated = false;  // true = right branch: column NOT IN (left_categories)
 
     SplitCondition() : column_idx(0), column_type(FeatureType::NUMERIC) {}
 
@@ -42,7 +72,7 @@ struct SplitCondition {
         if (column_type == FeatureType::NUMERIC) {
             oss << column_name << (is_less_than ? " <= " : " > ") << split_value;
         } else {
-            oss << column_name << " IN (";
+            oss << column_name << (is_negated ? " NOT IN (" : " IN (");
             for (size_t i = 0; i < left_category_names.size(); ++i) {
                 if (i > 0) oss << ", ";
                 oss << "'" << left_category_names[i] << "'";
@@ -55,15 +85,16 @@ struct SplitCondition {
     // Convert to JSON representation
     std::string ToJSON() const {
         std::ostringstream oss;
-        oss << "{\"column\":\"" << column_name << "\",";
+        oss << "{\"column\":\"" << EscapeJSONString(column_name) << "\",";
         if (column_type == FeatureType::NUMERIC) {
             oss << "\"type\":\"numeric\",\"operator\":\""
                 << (is_less_than ? "<=" : ">") << "\",\"value\":" << split_value;
         } else {
-            oss << "\"type\":\"categorical\",\"values\":[";
+            oss << "\"type\":\"categorical\",\"operator\":\""
+                << (is_negated ? "not_in" : "in") << "\",\"values\":[";
             for (size_t i = 0; i < left_category_names.size(); ++i) {
                 if (i > 0) oss << ",";
-                oss << "\"" << left_category_names[i] << "\"";
+                oss << "\"" << EscapeJSONString(left_category_names[i]) << "\"";
             }
             oss << "]";
         }
@@ -77,7 +108,8 @@ struct SplitCondition {
  * Contains all information about a detected outlier
  */
 struct OutlierExplanation {
-    size_t row_idx;                          // Original row index (0-indexed)
+    size_t row_idx;                          // Index into the NULL-filtered working dataset
+                                             // (0-indexed; mapped to source row ids at output)
     size_t target_column_idx;                // Column where outlier was detected
     std::string target_column_name;          // Name of the column
 
@@ -256,6 +288,9 @@ private:
     OutlierTreeParams params_;
     size_t clusters_evaluated_ = 0;
     size_t max_depth_reached_ = 0;
+    // Maps (row_idx, target_column_idx) to the slot of the current best
+    // finding in the outliers vector, so duplicates replace the worse entry.
+    std::map<std::pair<size_t, size_t>, size_t> outlier_slots_;
 
     /**
      * Build tree for predicting target_col using other columns
@@ -446,18 +481,15 @@ private:
     );
 
     /**
-     * Check if an outlier with same row and column already exists
+     * Insert an outlier, replacing any existing finding for the same
+     * (row, column) pair when the new score is more extreme (lower).
      * @param outliers: Existing outliers
-     * @param row_idx: Row index
-     * @param col_idx: Column index
-     * @param new_score: Score of potential new outlier
-     * @return true if should skip (better outlier already exists)
+     * @param outlier: New outlier candidate
+     * @return true if the outlier was inserted or replaced an existing one
      */
-    bool ShouldSkipDuplicateOutlier(
-        const std::vector<OutlierExplanation>& outliers,
-        size_t row_idx,
-        size_t col_idx,
-        double new_score
+    bool AddOrReplaceOutlier(
+        std::vector<OutlierExplanation>& outliers,
+        OutlierExplanation&& outlier
     );
 };
 

--- a/test/sql/anofox_outlier_tree_issue45.test
+++ b/test/sql/anofox_outlier_tree_issue45.test
@@ -1,0 +1,206 @@
+# name: test/sql/anofox_outlier_tree_issue45.test
+# description: Regression tests for issue #45 — outlier_tree output correctness and parameter validation
+# group: [anofox_tabular]
+
+require anofox_tabular
+
+require json
+
+statement ok
+LOAD anofox_tabular
+
+statement ok
+SET anofox_tab_trace_enabled = false
+
+# ===--------------------------------------------------------------------===
+# Finding 1 (HIGH): negative size parameters must be rejected, not wrap
+# around to huge size_t values that silently pass the "< 1" checks.
+# ===--------------------------------------------------------------------===
+
+statement ok
+CREATE TABLE ot45_simple (v DOUBLE)
+
+statement ok
+INSERT INTO ot45_simple VALUES
+    (10.0), (11.0), (10.0), (11.0), (10.0),
+    (11.0), (10.0), (11.0), (10.0), (11.0),
+    (100.0)
+
+# Negative max_depth must produce a binder error (previously wrapped and passed)
+statement error
+SELECT * FROM outlier_tree('ot45_simple', 'v', 'summary', -1, 0.1::DOUBLE, 3, 3, 2.67, 8.0)
+----
+max_depth
+
+# Negative min_size_numeric must produce a binder error
+statement error
+SELECT * FROM outlier_tree('ot45_simple', 'v', 'summary', 4, 0.1::DOUBLE, -5, 3, 2.67, 8.0)
+----
+min_size_numeric
+
+# Negative min_size_categ must produce a binder error
+statement error
+SELECT * FROM outlier_tree('ot45_simple', 'v', 'summary', 4, 0.1::DOUBLE, 3, -5, 2.67, 8.0)
+----
+min_size_categ
+
+# Unreasonably large max_depth must produce a binder error
+statement error
+SELECT * FROM outlier_tree('ot45_simple', 'v', 'summary', 2000, 0.1::DOUBLE, 3, 3, 2.67, 8.0)
+----
+max_depth
+
+# ===--------------------------------------------------------------------===
+# Finding 2 (MED): reported row_id must refer to the SOURCE table row
+# position, not the position in the NULL-compacted working dataset.
+# Rows 4 and 5 are NULL; the outlier is source row 13.
+# ===--------------------------------------------------------------------===
+
+statement ok
+CREATE TABLE ot45_nulls (v DOUBLE)
+
+statement ok
+INSERT INTO ot45_nulls VALUES
+    (10.0), (11.0), (10.0),
+    (NULL), (NULL),
+    (11.0), (10.0), (11.0), (10.0), (11.0), (10.0), (11.0),
+    (100.0)
+
+query IT
+SELECT row_id, outlier_value
+FROM outlier_tree('ot45_nulls', 'v', 'outliers', 4, 0.1::DOUBLE, 3, 3, 2.67, 8.0)
+----
+13	100
+
+# total_rows in summary mode counts only the analyzed (fully non-NULL) rows
+query I
+SELECT total_rows FROM outlier_tree('ot45_nulls', 'v', 'summary', 4, 0.1::DOUBLE, 3, 3, 2.67, 8.0)
+----
+11
+
+# ===--------------------------------------------------------------------===
+# Finding 3 (MED): a categorical right branch means the row is NOT in the
+# left categories — explanations and conditions JSON must carry negation.
+# Fixture: outlier 1500 is normal globally (root MAD is large) but extreme
+# inside the g <> 'a' branch, so its only conditioning is the right branch.
+# ===--------------------------------------------------------------------===
+
+statement ok
+CREATE TABLE ot45_categ (g VARCHAR, v DOUBLE)
+
+statement ok
+INSERT INTO ot45_categ VALUES
+    ('a', 0), ('a', 20), ('a', 40), ('a', 60), ('a', 80), ('a', 100),
+    ('a', 120), ('a', 140), ('a', 160), ('a', 180), ('a', 200), ('a', 220),
+    ('b', 1000), ('b', 1001), ('b', 1000), ('b', 1001), ('b', 1000),
+    ('b', 1001), ('b', 1000), ('b', 1001), ('b', 1000), ('b', 1001),
+    ('b', 1500)
+
+# Exactly one outlier is found, in the right (g <> 'a') branch
+query I
+SELECT COUNT(*)
+FROM outlier_tree('ot45_categ', 'g,v', 'outliers', 2, 0.1::DOUBLE, 3, 3, 2.67, 8.0)
+----
+1
+
+# The explanation must express negation (NOT IN), and the conditions JSON
+# must carry a negated operator for the categorical right branch.
+query TT
+SELECT
+    CASE WHEN explanation LIKE '%g NOT IN (''a'')%' THEN 'negated' ELSE explanation END,
+    json_extract_string(conditions, '$[0].operator')
+FROM outlier_tree('ot45_categ', 'g,v', 'outliers', 2, 0.1::DOUBLE, 3, 3, 2.67, 8.0)
+----
+negated	not_in
+
+# ===--------------------------------------------------------------------===
+# Finding 4 (MED): the same (row, column) outlier found in several clusters
+# must yield a single finding (the most extreme one), not duplicates.
+# Fixture: outlier 5000 is flagged both at the root cluster and inside the
+# g <> 'a' branch (where its score is more extreme).
+# ===--------------------------------------------------------------------===
+
+statement ok
+CREATE TABLE ot45_dup (g VARCHAR, v DOUBLE)
+
+statement ok
+INSERT INTO ot45_dup VALUES
+    ('a', 0), ('a', 20), ('a', 40), ('a', 60), ('a', 80), ('a', 100),
+    ('a', 120), ('a', 140), ('a', 160), ('a', 180), ('a', 200), ('a', 220),
+    ('b', 1000), ('b', 1001), ('b', 1000), ('b', 1001), ('b', 1000),
+    ('b', 1001), ('b', 1000), ('b', 1001), ('b', 1000), ('b', 1001),
+    ('b', 5000)
+
+# No (row_id, column_name) pair may appear more than once
+query I
+SELECT COUNT(*) FROM (
+    SELECT row_id, column_name
+    FROM outlier_tree('ot45_dup', 'g,v', 'outliers', 2, 0.1::DOUBLE, 3, 3, 2.67, 8.0)
+    GROUP BY row_id, column_name
+    HAVING COUNT(*) > 1
+)
+----
+0
+
+# The single finding kept is the most specific/extreme one (branch cluster)
+query I
+SELECT COUNT(*)
+FROM outlier_tree('ot45_dup', 'g,v', 'outliers', 2, 0.1::DOUBLE, 3, 3, 2.67, 8.0)
+----
+1
+
+# Summary outlier_count must match (no inflated counts)
+query I
+SELECT outlier_count
+FROM outlier_tree('ot45_dup', 'g,v', 'summary', 2, 0.1::DOUBLE, 3, 3, 2.67, 8.0)
+----
+1
+
+# ===--------------------------------------------------------------------===
+# Finding 5 (MED): conditions JSON must stay valid when category values
+# contain quotes or backslashes.
+# ===--------------------------------------------------------------------===
+
+statement ok
+CREATE TABLE ot45_json (g VARCHAR, v DOUBLE)
+
+statement ok
+INSERT INTO ot45_json VALUES
+    ('a"x\', 0), ('a"x\', 20), ('a"x\', 40), ('a"x\', 60), ('a"x\', 80), ('a"x\', 100),
+    ('a"x\', 120), ('a"x\', 140), ('a"x\', 160), ('a"x\', 180), ('a"x\', 200), ('a"x\', 220),
+    ('b', 1000), ('b', 1001), ('b', 1000), ('b', 1001), ('b', 1000),
+    ('b', 1001), ('b', 1000), ('b', 1001), ('b', 1000), ('b', 1001),
+    ('b', 1500)
+
+query I
+SELECT CASE WHEN json_valid(conditions) THEN 1 ELSE 0 END
+FROM outlier_tree('ot45_json', 'g,v', 'outliers', 2, 0.1::DOUBLE, 3, 3, 2.67, 8.0)
+----
+1
+
+# The escaped category value round-trips through json extraction
+query T
+SELECT json_extract_string(conditions, '$[0].values[0]')
+FROM outlier_tree('ot45_json', 'g,v', 'outliers', 2, 0.1::DOUBLE, 3, 3, 2.67, 8.0)
+----
+a"x\
+
+# ===--------------------------------------------------------------------===
+# Cleanup
+# ===--------------------------------------------------------------------===
+
+statement ok
+DROP TABLE ot45_simple
+
+statement ok
+DROP TABLE ot45_nulls
+
+statement ok
+DROP TABLE ot45_categ
+
+statement ok
+DROP TABLE ot45_dup
+
+statement ok
+DROP TABLE ot45_json
+


### PR DESCRIPTION
## Summary

Fixes all five findings of #45 in `src/anofox_outlier_tree.cpp` / `src/include/anofox_outlier_tree.hpp`. Every finding was re-verified against current `main` before fixing — all five were still present.

- **HIGH — signed→unsigned wrap:** `max_depth`, `min_size_numeric`, `min_size_categ` are now read into `int64_t` temporaries and validated *before* casting to `size_t`. `max_depth` is bounded to 1..1024; the min sizes must be >= 1. Negative values previously wrapped to huge `size_t` values and passed the `< 1` checks.
- **MED — wrong row ids after NULL filtering:** the 1-based source position of each analyzed row is preserved through NULL filtering (`source_row_ids` in the global state) and reported as `row_id`. Previously the id indexed the NULL-compacted working dataset.
- **MED — categorical right branch rendered as IN:** `SplitCondition` gained an `is_negated` flag set on the right branch of a categorical split. `ToString` renders `col NOT IN (...)`, `ToJSON` carries `"operator":"in"|"not_in"`, and `PartitionRows` honors the flag for consistency.
- **MED — duplicate (row, column) findings:** the append-only `ShouldSkipDuplicateOutlier` was replaced by `AddOrReplaceOutlier` backed by a `(row, column) → slot` map; a more extreme finding replaces the worse one in place instead of duplicating it.
- **MED — invalid JSON for hostile strings:** a small `EscapeJSONString` helper escapes quotes, backslashes and control characters for every string value written into the conditions JSON.

Also documents NULL-filtering, `row_id` and `total_rows` semantics in the README (`total_rows` counts rows non-NULL in every selected column; unchanged behavior, now documented).

## Red/green TDD

First commit (9fd4201) contains only the new tests (`test/sql/anofox_outlier_tree_issue45.test`); second commit (df76781) the fix.

Red evidence against unmodified main (DuckDB v1.5.3 build):

1. Negative `max_depth` accepted:
```
Query unexpectedly succeeded!
SELECT * FROM outlier_tree('ot45_simple', 'v', 'summary', -1, 0.1::DOUBLE, 3, 3, 2.67, 8.0);
fail	11	1	1	1	0	1 outlier(s) detected
```
2. `row_id` off after NULL filtering (outlier is source row 13; two NULL rows precede it):
```
│ row_id │ outlier_value │
│     11 │ 100           │
```
3. Right branch (row has g='b') explained with IN:
```
... when g IN ('a')        -- row 23 has g = 'b'
conditions: [{"column":"g","type":"categorical","values":["a"]}]
```
4. Duplicate (row, column) findings:
```
│ 23 │ v │ 0.0046562636151327875 │ []                                                   │
│ 23 │ v │ 1.374501389788557e-07 │ [{"column":"g","type":"categorical","values":["a"]}] │
```
5. Invalid JSON for category values containing quotes/backslashes:
```
[{"column":"g","type":"categorical","values":["a"x\"]}]   json_valid = false
```

The new test file also asserts (as regressions, already passing before the fix): `total_rows` counts analyzed rows only, and exactly one outlier is produced by the right-branch fixture.

Note: the issue suggested optional Catch2 unit tests; the repository has no `test/cpp` harness wired up, so the JSON/negation behavior is covered end-to-end through sqllogictests (`json_valid`, `json_extract_string`) instead.

## Test status

- `./build/release/test/unittest test/sql/anofox_outlier_tree_issue45.test` — all 32 assertions pass
- `./build/release/test/unittest test/sql/anofox_outlier_tree.test` — all 83 assertions pass
- `make test` — all tests pass (1656 assertions in 17 test cases, 1 env-skipped OpenVINO test)

Closes #45