### PR TITLE
fix: NER thread safety — per-call inference, by-value tokenization, LRU cache races

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -286,6 +286,35 @@ if(UNIX AND NOT APPLE)
     target_link_options(${LOADABLE_EXTENSION_NAME} PRIVATE -Wl,--allow-multiple-definition)
 endif()
 
+# --- C++ unit tests ---
+
+# Standalone Catch2 unit test binary for extension-internal data structures
+# (e.g. the NER LRU cache). Uses the Catch2 header bundled with DuckDB.
+# Run: ./build/<config>/extension/anofox_tabular/anofox_tabular_cpp_tests
+set(DUCKDB_CATCH_DIR "${CMAKE_CURRENT_SOURCE_DIR}/duckdb/third_party/catch")
+if(NOT EXISTS "${DUCKDB_CATCH_DIR}/catch.hpp")
+    # Built from within the DuckDB build tree (extension template): the top-level
+    # CMake project is DuckDB itself
+    set(DUCKDB_CATCH_DIR "${CMAKE_SOURCE_DIR}/third_party/catch")
+endif()
+if(EXISTS "${DUCKDB_CATCH_DIR}/catch.hpp")
+    add_executable(anofox_tabular_cpp_tests
+        test/cpp/test_ner_lru_cache.cpp
+    )
+    target_include_directories(anofox_tabular_cpp_tests PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/include
+        ${DUCKDB_CATCH_DIR}
+    )
+    find_package(Threads REQUIRED)
+    target_link_libraries(anofox_tabular_cpp_tests PRIVATE Threads::Threads)
+    # anofox_ner.hpp includes OpenVINO headers when HAVE_OPENVINO=1
+    if(OPENVINO_FOUND)
+        target_link_libraries(anofox_tabular_cpp_tests PRIVATE openvino::runtime)
+    endif()
+else()
+    message(STATUS "Catch2 header not found - skipping anofox_tabular_cpp_tests")
+endif()
+
 # --- Installation ---
 
 install(

--- a/src/anofox_ner.cpp
+++ b/src/anofox_ner.cpp
@@ -246,18 +246,19 @@ int WordPieceTokenizer::TokenToId(const std::string &token) const {
     return UNK_TOKEN_ID;
 }
 
-std::vector<int64_t> WordPieceTokenizer::Encode(const std::string &text) {
-    offsets_.clear();
-    std::vector<int64_t> input_ids;
+TokenizedInput WordPieceTokenizer::Encode(const std::string &text) const {
+    // All per-call state lives in `result`; this method only reads the shared
+    // vocabulary, so concurrent Encode() calls are safe (issue #50)
+    TokenizedInput result;
 
     if (vocab_.empty()) {
         AnofoxTrace(AnofoxLogLevel::Warn, "[anofox] ner: Vocabulary not loaded, cannot encode");
-        return {};
+        return result;
     }
 
     // Add [CLS] token
-    input_ids.push_back(CLS_TOKEN_ID);
-    offsets_.push_back({0, 0});  // CLS has no text position
+    result.ids.push_back(CLS_TOKEN_ID);
+    result.offsets.push_back({0, 0});  // CLS has no text position
 
     // Tokenize text into words
     std::vector<std::string> words = Tokenize(text);
@@ -285,12 +286,13 @@ std::vector<int64_t> WordPieceTokenizer::Encode(const std::string &text) {
             // Try to find longest matching subword in vocabulary
             while (end > start) {
                 std::string subword = prefix + word.substr(start, end - start);
-                if (vocab_.find(subword) != vocab_.end()) {
-                    input_ids.push_back(vocab_.at(subword));
+                auto it = vocab_.find(subword);
+                if (it != vocab_.end()) {
+                    result.ids.push_back(it->second);
                     // Calculate byte offsets for this subword
                     size_t byte_start = word_start + start;
                     size_t byte_end = word_start + end;
-                    offsets_.push_back({byte_start, byte_end});
+                    result.offsets.push_back({byte_start, byte_end});
                     start = end;
                     found = true;
                     break;
@@ -300,8 +302,8 @@ std::vector<int64_t> WordPieceTokenizer::Encode(const std::string &text) {
 
             if (!found) {
                 // No matching subword found, use [UNK]
-                input_ids.push_back(UNK_TOKEN_ID);
-                offsets_.push_back({word_start + start, word_start + start + 1});
+                result.ids.push_back(UNK_TOKEN_ID);
+                result.offsets.push_back({word_start + start, word_start + start + 1});
                 ++start;
             }
 
@@ -310,10 +312,10 @@ std::vector<int64_t> WordPieceTokenizer::Encode(const std::string &text) {
     }
 
     // Add [SEP] token
-    input_ids.push_back(SEP_TOKEN_ID);
-    offsets_.push_back({text.size(), text.size()});  // SEP has no text position
+    result.ids.push_back(SEP_TOKEN_ID);
+    result.offsets.push_back({text.size(), text.size()});  // SEP has no text position
 
-    return input_ids;
+    return result;
 }
 
 // ============================================================================
@@ -348,11 +350,13 @@ bool SentencePieceTokenizer::IsLoaded() const {
     return processor_ && processor_->GetPieceSize() > 0;
 }
 
-std::vector<int64_t> SentencePieceTokenizer::Encode(const std::string &text) {
-    offsets_.clear();
+TokenizedInput SentencePieceTokenizer::Encode(const std::string &text) const {
+    // All per-call state lives in `result`; the SentencePiece processor is
+    // only read, so concurrent Encode() calls are safe (issue #50)
+    TokenizedInput result;
 
     if (!IsLoaded() || text.empty()) {
-        return {};
+        return result;
     }
 
     // Tokenize using SentencePiece
@@ -361,17 +365,17 @@ std::vector<int64_t> SentencePieceTokenizer::Encode(const std::string &text) {
     if (!status.ok()) {
         AnofoxTrace(AnofoxLogLevel::Error,
                     "[anofox] ner: SentencePiece encoding error: " + std::string(status.message()));
-        return {};
+        return result;
     }
 
     // Convert to int64_t and add special tokens
     // XLM-RoBERTa format: <s> tokens </s>
-    std::vector<int64_t> input_ids;
-    input_ids.reserve(piece_ids.size() + 2);
+    result.ids.reserve(piece_ids.size() + 2);
+    result.offsets.reserve(piece_ids.size() + 2);
 
     // Add <s> (BOS) token
-    input_ids.push_back(BOS_TOKEN_ID);
-    offsets_.push_back(std::make_pair(size_t(0), size_t(0)));  // BOS has no text position
+    result.ids.push_back(BOS_TOKEN_ID);
+    result.offsets.push_back(std::make_pair(size_t(0), size_t(0)));  // BOS has no text position
 
     // Get pieces with their byte offsets
     ::sentencepiece::SentencePieceText spt;
@@ -379,24 +383,24 @@ std::vector<int64_t> SentencePieceTokenizer::Encode(const std::string &text) {
     if (!status.ok()) {
         // Fallback: use the piece_ids without offsets
         for (int pid : piece_ids) {
-            input_ids.push_back(static_cast<int64_t>(pid));
-            offsets_.push_back(std::make_pair(size_t(0), size_t(0)));  // No offset info available
+            result.ids.push_back(static_cast<int64_t>(pid));
+            result.offsets.push_back(std::make_pair(size_t(0), size_t(0)));  // No offset info available
         }
     } else {
         // Use proper offsets from SentencePieceText
         for (int i = 0; i < spt.pieces_size(); ++i) {
             const auto &piece = spt.pieces(i);
-            input_ids.push_back(static_cast<int64_t>(piece.id()));
-            offsets_.push_back(std::make_pair(static_cast<size_t>(piece.begin()),
-                                              static_cast<size_t>(piece.end())));
+            result.ids.push_back(static_cast<int64_t>(piece.id()));
+            result.offsets.push_back(std::make_pair(static_cast<size_t>(piece.begin()),
+                                                    static_cast<size_t>(piece.end())));
         }
     }
 
     // Add </s> (EOS) token
-    input_ids.push_back(EOS_TOKEN_ID);
-    offsets_.push_back(std::make_pair(text.size(), text.size()));  // EOS has no text position
+    result.ids.push_back(EOS_TOKEN_ID);
+    result.offsets.push_back(std::make_pair(text.size(), text.size()));  // EOS has no text position
 
-    return input_ids;
+    return result;
 }
 
 #endif  // HAVE_SENTENCEPIECE
@@ -430,31 +434,60 @@ bool NERModelManager::IsAvailable() const {
 #endif
 }
 
+NERStatusSnapshot NERModelManager::GetStatusSnapshot() const {
+    NERStatusSnapshot snapshot;
+    {
+        std::lock_guard<std::mutex> lock(state_mutex_);
+        snapshot.status = status_.load();
+        snapshot.message = status_message_;
+        snapshot.model_path = model_path_;
+        snapshot.model_name = current_model_name_;
+        snapshot.device = device_name_;
+    }
+    if (snapshot.model_path.empty()) {
+        snapshot.model_path = DefaultModelPath();
+    }
+    return snapshot;
+}
+
+void NERModelManager::SetStatusMessage(const std::string &message) {
+    std::lock_guard<std::mutex> lock(state_mutex_);
+    status_message_ = message;
+}
+
 std::string NERModelManager::GetStatusMessage() const {
+    std::lock_guard<std::mutex> lock(state_mutex_);
     return status_message_;
 }
 
-std::string NERModelManager::GetModelPath() const {
-    if (model_path_.empty()) {
-        // Default path: ~/.duckdb/extensions/anofox/ner/
+std::string NERModelManager::DefaultModelPath() {
+    // Default path: ~/.duckdb/extensions/anofox/ner/
 #ifdef _WIN32
-        // Windows: use USERPROFILE environment variable
-        const char* userprofile = std::getenv("USERPROFILE");
-        if (userprofile) {
-            auto path = std::filesystem::path(userprofile) / ".duckdb" / "extensions" / "anofox" / "ner" / "model_quantized.onnx";
-            return path.string();
-        }
-#else
-        // Unix-like: use HOME environment variable
-        const char* home = std::getenv("HOME");
-        if (home) {
-            auto path = std::filesystem::path(home) / ".duckdb" / "extensions" / "anofox" / "ner" / "model_quantized.onnx";
-            return path.string();
-        }
-#endif
-        return "";
+    // Windows: use USERPROFILE environment variable
+    const char* userprofile = std::getenv("USERPROFILE");
+    if (userprofile) {
+        auto path = std::filesystem::path(userprofile) / ".duckdb" / "extensions" / "anofox" / "ner" / "model_quantized.onnx";
+        return path.string();
     }
-    return model_path_;
+#else
+    // Unix-like: use HOME environment variable
+    const char* home = std::getenv("HOME");
+    if (home) {
+        auto path = std::filesystem::path(home) / ".duckdb" / "extensions" / "anofox" / "ner" / "model_quantized.onnx";
+        return path.string();
+    }
+#endif
+    return "";
+}
+
+std::string NERModelManager::GetModelPath() const {
+    {
+        std::lock_guard<std::mutex> lock(state_mutex_);
+        if (!model_path_.empty()) {
+            return model_path_;
+        }
+    }
+    return DefaultModelPath();
 }
 
 double NERModelManager::GetModelSizeMB() const {
@@ -489,7 +522,7 @@ void NERModelManager::EnsureInitialized() {
     LoadModel();
 #else
     status_.store(NERStatus::NOT_AVAILABLE);
-    status_message_ = "OpenVINO not compiled in";
+    SetStatusMessage("OpenVINO not compiled in");
 #endif
 }
 
@@ -497,21 +530,26 @@ void NERModelManager::LoadModel() {
 #if HAVE_OPENVINO
     AnofoxTrace(AnofoxLogLevel::Info, "[anofox] ner: Loading NER model...");
 
-    model_path_ = GetModelPath();
+    const std::string model_path = GetModelPath();
+    const std::string device_name = GetDevice();
+    {
+        std::lock_guard<std::mutex> lock(state_mutex_);
+        model_path_ = model_path;
+    }
 
     // Check if model file exists
-    if (!std::filesystem::exists(model_path_)) {
+    if (!std::filesystem::exists(model_path)) {
         AnofoxTrace(AnofoxLogLevel::Info, "[anofox] ner: Model not found, attempting download...");
         status_.store(NERStatus::DOWNLOADING);
-        status_message_ = "Downloading model from HuggingFace...";
+        SetStatusMessage("Downloading model from HuggingFace...");
 
         // Create directory if it doesn't exist
-        std::filesystem::path dir_path = std::filesystem::path(model_path_).parent_path();
+        std::filesystem::path dir_path = std::filesystem::path(model_path).parent_path();
         std::filesystem::create_directories(dir_path);
 
-        if (!DownloadModel(model_path_)) {
+        if (!DownloadModel(model_path)) {
             status_.store(NERStatus::FAILED);
-            status_message_ = "Failed to download model";
+            SetStatusMessage("Failed to download model");
             AnofoxTrace(AnofoxLogLevel::Error, "[anofox] ner: Model download failed");
             return;
         }
@@ -520,7 +558,7 @@ void NERModelManager::LoadModel() {
     try {
         // Read model (supports .onnx directly via ONNX frontend)
         AnofoxTrace(AnofoxLogLevel::Info, "[anofox] ner: Reading ONNX model with OpenVINO...");
-        std::shared_ptr<ov::Model> model = core_->read_model(model_path_);
+        std::shared_ptr<ov::Model> model = core_->read_model(model_path);
 
         // Reshape model to accept dynamic batch and sequence length
         // The ONNX model has dynamic shapes, but OpenVINO needs explicit configuration
@@ -538,9 +576,9 @@ void NERModelManager::LoadModel() {
         AnofoxTrace(AnofoxLogLevel::Info, "[anofox] ner: Available OpenVINO devices: " + dev_list);
 
         // Compile model for configured device (default AUTO: selects GPU if available, falls back to CPU)
-        AnofoxTrace(AnofoxLogLevel::Info, "[anofox] ner: Compiling model for device: " + device_name_);
+        AnofoxTrace(AnofoxLogLevel::Info, "[anofox] ner: Compiling model for device: " + device_name);
         compiled_model_ = std::make_shared<ov::CompiledModel>(
-            core_->compile_model(model, device_name_)
+            core_->compile_model(model, device_name)
         );
 
         // Log the actual execution device(s) chosen by AUTO or by explicit selection
@@ -552,10 +590,9 @@ void NERModelManager::LoadModel() {
         }
         AnofoxTrace(AnofoxLogLevel::Info, "[anofox] ner: Executing on: " + exec_dev_str);
 
-        // Create inference request
-        infer_request_ = std::make_shared<ov::InferRequest>(
-            compiled_model_->create_infer_request()
-        );
+        // Note: inference requests are created per ExtractEntities call;
+        // a single ov::InferRequest is stateful and must not be shared
+        // across DuckDB worker threads (issue #50)
 
         // Create and load tokenizer based on model type
         std::string model_name = GetCurrentModelName();
@@ -588,23 +625,28 @@ void NERModelManager::LoadModel() {
             }
         }
 
-        current_model_name_ = model_name;
+        {
+            std::lock_guard<std::mutex> lock(state_mutex_);
+            current_model_name_ = model_name;
+            status_message_ = "Model loaded successfully (" + model_name + ", device: " + exec_dev_str + ")";
+        }
+        // Publish LOADED last: readers that observe LOADED are guaranteed to
+        // see the fully constructed compiled_model_ and tokenizer_
         status_.store(NERStatus::LOADED);
-        status_message_ = "Model loaded successfully (" + model_name + ", device: " + exec_dev_str + ")";
-        AnofoxTrace(AnofoxLogLevel::Info, "[anofox] ner: NER model loaded from: " + model_path_);
+        AnofoxTrace(AnofoxLogLevel::Info, "[anofox] ner: NER model loaded from: " + model_path);
 
     } catch (const ov::Exception &e) {
         status_.store(NERStatus::FAILED);
-        status_message_ = std::string("OpenVINO error: ") + e.what();
+        SetStatusMessage(std::string("OpenVINO error: ") + e.what());
         AnofoxTrace(AnofoxLogLevel::Error, "[anofox] ner: Failed to load model: " + std::string(e.what()));
     } catch (const std::exception &e) {
         status_.store(NERStatus::FAILED);
-        status_message_ = std::string("Error: ") + e.what();
+        SetStatusMessage(std::string("Error: ") + e.what());
         AnofoxTrace(AnofoxLogLevel::Error, "[anofox] ner: Failed to load model: " + std::string(e.what()));
     }
 #else
     status_.store(NERStatus::NOT_AVAILABLE);
-    status_message_ = "OpenVINO not compiled in";
+    SetStatusMessage("OpenVINO not compiled in");
 #endif
 }
 
@@ -643,7 +685,7 @@ bool NERModelManager::DownloadModel(const std::string &dest_path) {
                 AnofoxTrace(AnofoxLogLevel::Info, "[anofox] ner: Downloading " + file.name + " from HuggingFace...");
             }
 
-            status_message_ = "Downloading " + file.name + "...";
+            SetStatusMessage("Downloading " + file.name + "...");
 
             // Open file for writing
             FILE *fp = fopen(file.dest.c_str(), "wb");
@@ -704,23 +746,21 @@ bool NERModelManager::DownloadModel(const std::string &dest_path) {
         if (!download_success) {
             AnofoxTrace(AnofoxLogLevel::Error,
                 "[anofox] ner: Failed to download " + file.name + " after " + std::to_string(max_retries) + " attempts");
-            status_message_ = "Failed to download " + file.name;
+            SetStatusMessage("Failed to download " + file.name);
             return false;
         }
     }
 
-    status_message_ = "Download complete";
+    SetStatusMessage("Download complete");
     return true;
 }
 
-std::vector<NEREntity> NERModelManager::ExtractEntities(const std::string &text) {
+std::vector<NEREntity> NERModelManager::RunSingleInference(const std::string &text) {
 #if HAVE_OPENVINO
-    if (!IsAvailable()) {
-        return {};
-    }
-
-    // Check cache first
-    if (result_cache_ && result_cache_->Capacity() > 0) {
+    // Check cache first. Get/Put are fully synchronized internally and Put is
+    // a safe no-op when the capacity is 0, so no unsynchronized
+    // Capacity() pre-check is needed (issue #50)
+    if (result_cache_) {
         auto cached = result_cache_->Get(text);
         if (cached) {
             AnofoxTrace(AnofoxLogLevel::Debug, "[anofox] ner: Cache hit");
@@ -729,18 +769,21 @@ std::vector<NEREntity> NERModelManager::ExtractEntities(const std::string &text)
     }
 
     try {
-        // Tokenize input
+        // tokenizer_ and compiled_model_ are immutable once status_ is
+        // LOADED (checked by the callers), so reading them here is safe
         if (!tokenizer_ || !tokenizer_->IsLoaded()) {
             AnofoxTrace(AnofoxLogLevel::Error, "[anofox] ner: Tokenizer not loaded");
             return {};
         }
-        auto input_ids = tokenizer_->Encode(text);
-        if (input_ids.empty()) {
+
+        // Tokenize input; ids and offsets are returned by value so no
+        // tokenizer state is shared between concurrent calls (issue #50)
+        TokenizedInput tokenized = tokenizer_->Encode(text);
+        if (tokenized.ids.empty()) {
             return {};
         }
 
-        auto offsets = tokenizer_->GetOffsets();
-        size_t actual_length = input_ids.size();
+        size_t actual_length = tokenized.ids.size();
 
         // Pad to minimum length to avoid OpenVINO shape inference issues
         // with very short sequences in the quantized model
@@ -754,7 +797,7 @@ std::vector<NEREntity> NERModelManager::ExtractEntities(const std::string &text)
         }
 
         // Pad input_ids with 0 (PAD token)
-        input_ids.resize(seq_length, 0);
+        tokenized.ids.resize(seq_length, 0);
 
         // Create input tensors
         ov::Shape input_shape = {1, seq_length};
@@ -765,26 +808,31 @@ std::vector<NEREntity> NERModelManager::ExtractEntities(const std::string &text)
         // Copy data to tensors
         int64_t* input_ids_data = input_ids_tensor.data<int64_t>();
         int64_t* attention_data = attention_mask_tensor.data<int64_t>();
-        std::memcpy(input_ids_data, input_ids.data(), input_ids.size() * sizeof(int64_t));
+        std::memcpy(input_ids_data, tokenized.ids.data(), tokenized.ids.size() * sizeof(int64_t));
         std::memcpy(attention_data, attention_mask.data(), attention_mask.size() * sizeof(int64_t));
 
+        // Create a per-call inference request: ov::CompiledModel is
+        // thread-safe for creating requests, while a single ov::InferRequest
+        // is stateful and must not be shared across threads (issue #50)
+        ov::InferRequest infer_request = compiled_model_->create_infer_request();
+
         // Set input tensors
-        infer_request_->set_tensor("input_ids", input_ids_tensor);
-        infer_request_->set_tensor("attention_mask", attention_mask_tensor);
+        infer_request.set_tensor("input_ids", input_ids_tensor);
+        infer_request.set_tensor("attention_mask", attention_mask_tensor);
 
         // Run inference
-        infer_request_->infer();
+        infer_request.infer();
 
         // Get output tensor
-        ov::Tensor output_tensor = infer_request_->get_output_tensor(0);
-        float* logits_data = output_tensor.data<float>();
+        ov::Tensor output_tensor = infer_request.get_output_tensor(0);
+        const float* logits_data = output_tensor.data<float>();
 
         std::vector<float> logits(logits_data, logits_data + seq_length * NUM_LABELS);
 
-        auto entities = PostProcess(logits, seq_length, text, offsets);
+        auto entities = PostProcess(logits, seq_length, text, tokenized.offsets);
 
-        // Store in cache
-        if (result_cache_ && result_cache_->Capacity() > 0) {
+        // Store in cache (no-op when the cache is disabled)
+        if (result_cache_) {
             result_cache_->Put(text, entities);
         }
 
@@ -797,6 +845,17 @@ std::vector<NEREntity> NERModelManager::ExtractEntities(const std::string &text)
         AnofoxTrace(AnofoxLogLevel::Error, "[anofox] ner: Inference error: " + std::string(e.what()));
         return {};
     }
+#else
+    return {};
+#endif
+}
+
+std::vector<NEREntity> NERModelManager::ExtractEntities(const std::string &text) {
+#if HAVE_OPENVINO
+    if (!IsAvailable() || text.empty()) {
+        return {};
+    }
+    return RunSingleInference(text);
 #else
     return {};
 #endif
@@ -999,12 +1058,16 @@ void NERModelManager::ClearCache() {
 }
 
 void NERModelManager::SetDevice(const std::string &device_name) {
-    device_name_ = device_name;
+    {
+        std::lock_guard<std::mutex> lock(state_mutex_);
+        device_name_ = device_name;
+    }
     AnofoxTrace(AnofoxLogLevel::Info,
                 "[anofox] ner: Device set to '" + device_name + "' (reload required for changes to take effect)");
 }
 
 std::string NERModelManager::GetDevice() const {
+    std::lock_guard<std::mutex> lock(state_mutex_);
     return device_name_;
 }
 
@@ -1021,138 +1084,39 @@ std::vector<std::string> NERModelManager::GetAvailableDevices() const {
 // ============================================================================
 
 std::vector<std::vector<NEREntity>> NERModelManager::ExtractEntitiesBatch(
-    const std::vector<std::string> &texts,
-    size_t max_batch_size
+    const std::vector<std::string> &texts
 ) {
-#if HAVE_OPENVINO
     std::vector<std::vector<NEREntity>> all_results(texts.size());
 
+#if HAVE_OPENVINO
     if (!IsAvailable() || texts.empty()) {
         return all_results;
     }
 
-    // Phase 1: Check cache for all texts and identify cache misses
-    std::vector<size_t> cache_miss_indices;
+    // Deduplicate inputs; RunSingleInference consults the result cache
+    // itself, so duplicate texts (and previously cached texts) only run
+    // inference once
     std::unordered_map<std::string, std::vector<size_t>> text_to_indices;
-
     for (size_t i = 0; i < texts.size(); ++i) {
-        const auto &text = texts[i];
-        if (text.empty()) {
-            // Empty text gets empty result
-            continue;
+        if (!texts[i].empty()) {
+            // Empty texts keep their default empty result
+            text_to_indices[texts[i]].push_back(i);
         }
-
-        // Check cache first
-        if (result_cache_ && result_cache_->Capacity() > 0) {
-            auto cached = result_cache_->Get(text);
-            if (cached) {
-                all_results[i] = *cached;
-                AnofoxTrace(AnofoxLogLevel::Debug, "[anofox] ner: Batch cache hit");
-                continue;
-            }
-        }
-
-        // Track which indices need this text (deduplication)
-        auto it = text_to_indices.find(text);
-        if (it == text_to_indices.end()) {
-            cache_miss_indices.push_back(i);
-            text_to_indices[text] = {i};
-        } else {
-            it->second.push_back(i);
-        }
-    }
-
-    if (cache_miss_indices.empty()) {
-        // All texts were in cache
-        return all_results;
     }
 
     AnofoxTrace(AnofoxLogLevel::Debug,
-                "[anofox] ner: Batch processing " + std::to_string(cache_miss_indices.size()) +
+                "[anofox] ner: Batch processing " + std::to_string(text_to_indices.size()) +
                 " unique texts (" + std::to_string(texts.size()) + " total)");
 
-    // Phase 2: Process cache misses sequentially (true batching would require dynamic model)
-    // Note: We still get cache benefit for duplicate texts within the batch
-    for (size_t idx : cache_miss_indices) {
-        const auto &text = texts[idx];
-
-        try {
-            // Tokenize input
-            if (!tokenizer_ || !tokenizer_->IsLoaded()) {
-                continue;
-            }
-            auto input_ids = tokenizer_->Encode(text);
-            if (input_ids.empty()) {
-                continue;
-            }
-
-            auto offsets = tokenizer_->GetOffsets();
-            size_t actual_length = input_ids.size();
-
-            // Pad to minimum length to avoid OpenVINO shape inference issues
-            static const size_t MIN_SEQ_LENGTH = 16;
-            size_t seq_length = std::max(actual_length, MIN_SEQ_LENGTH);
-
-            // Create attention mask (1 for real tokens, 0 for padding)
-            std::vector<int64_t> attention_mask(seq_length, 0);
-            for (size_t i = 0; i < actual_length; ++i) {
-                attention_mask[i] = 1;
-            }
-
-            // Pad input_ids with 0 (PAD token)
-            input_ids.resize(seq_length, 0);
-
-            // Create input tensors
-            ov::Shape input_shape = {1, seq_length};
-
-            ov::Tensor input_ids_tensor(ov::element::i64, input_shape);
-            ov::Tensor attention_mask_tensor(ov::element::i64, input_shape);
-
-            // Copy data to tensors
-            int64_t* input_ids_data = input_ids_tensor.data<int64_t>();
-            int64_t* attention_data = attention_mask_tensor.data<int64_t>();
-            std::memcpy(input_ids_data, input_ids.data(), input_ids.size() * sizeof(int64_t));
-            std::memcpy(attention_data, attention_mask.data(), attention_mask.size() * sizeof(int64_t));
-
-            // Set input tensors
-            infer_request_->set_tensor("input_ids", input_ids_tensor);
-            infer_request_->set_tensor("attention_mask", attention_mask_tensor);
-
-            // Run inference
-            infer_request_->infer();
-
-            // Get output tensor
-            ov::Tensor output_tensor = infer_request_->get_output_tensor(0);
-            float* logits_data = output_tensor.data<float>();
-
-            std::vector<float> logits(logits_data, logits_data + seq_length * NUM_LABELS);
-
-            auto entities = PostProcess(logits, seq_length, text, offsets);
-
-            // Store in cache
-            if (result_cache_ && result_cache_->Capacity() > 0) {
-                result_cache_->Put(text, entities);
-            }
-
-            // Assign result to all indices that have this text
-            auto &indices = text_to_indices[text];
-            for (size_t i : indices) {
-                all_results[i] = entities;
-            }
-
-        } catch (const ov::Exception &e) {
-            AnofoxTrace(AnofoxLogLevel::Error,
-                        "[anofox] ner: OpenVINO batch inference error: " + std::string(e.what()));
-        } catch (const std::exception &e) {
-            AnofoxTrace(AnofoxLogLevel::Error,
-                        "[anofox] ner: Batch inference error: " + std::string(e.what()));
+    for (const auto &entry : text_to_indices) {
+        auto entities = RunSingleInference(entry.first);
+        for (size_t i : entry.second) {
+            all_results[i] = entities;
         }
     }
+#endif
 
     return all_results;
-#else
-    return {};
-#endif
 }
 
 // ============================================================================

--- a/src/anofox_pii.cpp
+++ b/src/anofox_pii.cpp
@@ -2519,14 +2519,16 @@ void NERStatusFunction(ClientContext &, TableFunctionInput &input, DataChunk &ou
 
 #if HAVE_OPENVINO
     auto &ner = NERModelManager::Instance();
-    auto status = ner.GetStatus();
+    // Single consistent snapshot: status, message and paths are read under
+    // one lock so a concurrently loading model cannot produce torn strings
+    auto snapshot = ner.GetStatusSnapshot();
 
     // onnx_available (keep column name for backward compatibility)
     output.data[0].SetValue(0, Value::BOOLEAN(true));
 
     // model_status
     std::string status_str;
-    switch (status) {
+    switch (snapshot.status) {
         case NERStatus::NOT_LOADED: status_str = "NOT_LOADED"; break;
         case NERStatus::DOWNLOADING: status_str = "DOWNLOADING"; break;
         case NERStatus::LOADED: status_str = "LOADED"; break;
@@ -2537,13 +2539,13 @@ void NERStatusFunction(ClientContext &, TableFunctionInput &input, DataChunk &ou
     output.data[1].SetValue(0, Value(status_str));
 
     // model_path
-    output.data[2].SetValue(0, Value(ner.GetModelPath()));
+    output.data[2].SetValue(0, Value(snapshot.model_path));
 
     // model_size_mb
     output.data[3].SetValue(0, Value::DOUBLE(ner.GetModelSizeMB()));
 
     // status_message
-    output.data[4].SetValue(0, Value(ner.GetStatusMessage()));
+    output.data[4].SetValue(0, Value(snapshot.message));
 #else
     // OpenVINO not compiled in
     output.data[0].SetValue(0, Value::BOOLEAN(false));

--- a/src/include/anofox_ner.hpp
+++ b/src/include/anofox_ner.hpp
@@ -56,10 +56,19 @@ public:
     }
 
     /**
-     * Insert or update value in cache
+     * Insert or update value in cache.
+     * With capacity 0 the cache is disabled and Put is a safe no-op.
      */
     void Put(const Key& key, const Value& value) {
         std::lock_guard<std::mutex> lock(mutex_);
+
+        if (capacity_ == 0) {
+            // Cache disabled (e.g. SET anofox_ner_cache_size = 0). This must
+            // be checked under the lock: callers cannot rely on a Capacity()
+            // pre-check because another thread may shrink the capacity in
+            // between (issue #50).
+            return;
+        }
 
         auto it = cache_.find(key);
         if (it != cache_.end()) {
@@ -70,7 +79,7 @@ public:
         }
 
         // Evict if at capacity
-        if (cache_.size() >= capacity_) {
+        while (cache_.size() >= capacity_ && !lru_list_.empty()) {
             const Key& lru_key = lru_list_.back();
             cache_.erase(lru_key);
             lru_list_.pop_back();
@@ -101,7 +110,10 @@ public:
     /**
      * Get cache capacity
      */
-    size_t Capacity() const { return capacity_; }
+    size_t Capacity() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return capacity_;
+    }
 
     /**
      * Set new capacity (may evict entries)
@@ -154,14 +166,25 @@ enum class NERStatus {
 };
 
 /**
- * Abstract base class for tokenizers
+ * Result of tokenizing a text: token ids plus the byte offsets of each token
+ * in the original text. Returned by value so that concurrent Encode() calls
+ * never share mutable tokenizer state (issue #50).
+ */
+struct TokenizedInput {
+    std::vector<int64_t> ids;
+    std::vector<std::pair<size_t, size_t>> offsets;
+};
+
+/**
+ * Abstract base class for tokenizers.
+ * Encode() is const and returns all per-call state by value, so a loaded
+ * tokenizer can be shared across DuckDB worker threads.
  */
 class ITokenizer {
 public:
     virtual ~ITokenizer() = default;
     virtual bool Load(const std::string &model_path) = 0;
-    virtual std::vector<int64_t> Encode(const std::string &text) = 0;
-    virtual const std::vector<std::pair<size_t, size_t>>& GetOffsets() const = 0;
+    virtual TokenizedInput Encode(const std::string &text) const = 0;
     virtual bool IsLoaded() const = 0;
 };
 
@@ -180,14 +203,9 @@ public:
     bool LoadVocab(const std::string &vocab_path) { return Load(vocab_path); }
 
     /**
-     * Encode text to token IDs
+     * Encode text to token IDs and byte offsets (returned by value)
      */
-    std::vector<int64_t> Encode(const std::string &text) override;
-
-    /**
-     * Get byte offsets for each token (for mapping back to original text)
-     */
-    const std::vector<std::pair<size_t, size_t>>& GetOffsets() const override { return offsets_; }
+    TokenizedInput Encode(const std::string &text) const override;
 
     /**
      * Check if vocabulary is loaded
@@ -196,9 +214,8 @@ public:
 
 private:
     std::unordered_map<std::string, int> vocab_;
-    std::vector<std::pair<size_t, size_t>> offsets_;
 
-    std::vector<std::string> Tokenize(const std::string &text);
+    static std::vector<std::string> Tokenize(const std::string &text);
     int TokenToId(const std::string &token) const;
 };
 
@@ -217,14 +234,9 @@ public:
     bool Load(const std::string &model_path) override;
 
     /**
-     * Encode text to token IDs
+     * Encode text to token IDs and byte offsets (returned by value)
      */
-    std::vector<int64_t> Encode(const std::string &text) override;
-
-    /**
-     * Get byte offsets for each token (for mapping back to original text)
-     */
-    const std::vector<std::pair<size_t, size_t>>& GetOffsets() const override { return offsets_; }
+    TokenizedInput Encode(const std::string &text) const override;
 
     /**
      * Check if model is loaded
@@ -233,7 +245,6 @@ public:
 
 private:
     std::unique_ptr<::sentencepiece::SentencePieceProcessor> processor_;
-    std::vector<std::pair<size_t, size_t>> offsets_;
 
     // XLM-RoBERTa special tokens
     static constexpr int BOS_TOKEN_ID = 0;  // <s>
@@ -243,6 +254,19 @@ private:
 #endif
 
 /**
+ * Immutable snapshot of the NER model manager status.
+ * Returned by value under a mutex so status table functions never observe
+ * torn strings while a loader thread updates the fields (issue #50).
+ */
+struct NERStatusSnapshot {
+    NERStatus status = NERStatus::NOT_LOADED;
+    std::string message;
+    std::string model_path;
+    std::string model_name;
+    std::string device;
+};
+
+/**
  * Singleton OpenVINO NER Model Manager
  *
  * Responsibilities:
@@ -250,6 +274,12 @@ private:
  * - Download model from HuggingFace if not cached locally
  * - Thread-safe initialization
  * - Provide entity extraction interface using OpenVINO
+ *
+ * Thread safety: after LoadModel() publishes NERStatus::LOADED, tokenizer_
+ * and compiled_model_ are treated as immutable. Each inference call creates
+ * its own ov::InferRequest (compiled models are thread-safe for creating
+ * requests), and tokenization returns its state by value, so ExtractEntities
+ * can be called concurrently from DuckDB worker threads.
  */
 class NERModelManager {
 public:
@@ -270,15 +300,14 @@ public:
     std::vector<NEREntity> ExtractEntities(const std::string &text);
 
     /**
-     * Extract entities from multiple texts (batch processing)
-     * More efficient than calling ExtractEntities for each text
+     * Extract entities from multiple texts.
+     * Deduplicates the inputs and shares the result cache with
+     * ExtractEntities; inference itself runs one text at a time.
      * @param texts Vector of input texts
-     * @param max_batch_size Maximum texts to process in single inference
      * @return Vector of entity vectors (one per input text)
      */
     std::vector<std::vector<NEREntity>> ExtractEntitiesBatch(
-        const std::vector<std::string> &texts,
-        size_t max_batch_size = 32
+        const std::vector<std::string> &texts
     );
 
     /**
@@ -324,6 +353,11 @@ public:
     NERStatus GetStatus() const { return status_.load(); }
 
     /**
+     * Get a consistent snapshot of status, message, model path/name and device
+     */
+    NERStatusSnapshot GetStatusSnapshot() const;
+
+    /**
      * Get status message for display
      */
     std::string GetStatusMessage() const;
@@ -353,21 +387,47 @@ private:
         const std::vector<std::pair<size_t, size_t>> &offsets
     );
 
+    /**
+     * Run cache lookup, tokenization, inference and post-processing for one
+     * text. Shared by ExtractEntities and ExtractEntitiesBatch so the
+     * thread-safety guarantees live in exactly one place.
+     * Precondition: IsAvailable() returned true.
+     */
+    std::vector<NEREntity> RunSingleInference(const std::string &text);
+
+    /**
+     * Update status_message_ under state_mutex_
+     */
+    void SetStatusMessage(const std::string &message);
+
+    /**
+     * Compute the default on-disk model path (no member state accessed)
+     */
+    static std::string DefaultModelPath();
+
     std::atomic<NERStatus> status_{NERStatus::NOT_LOADED};
     std::mutex init_lock_;
+
+    // Guards status_message_, model_path_, current_model_name_ and
+    // device_name_ against torn reads from status table functions while a
+    // loader thread updates them (issue #50)
+    mutable std::mutex state_mutex_;
     std::string status_message_;
     std::string model_path_;
     std::string device_name_ = "AUTO";
 
 #if HAVE_OPENVINO
     std::shared_ptr<ov::Core> core_;
+    // Immutable after LoadModel() publishes NERStatus::LOADED; inference
+    // requests are created per call (ov::InferRequest is stateful and must
+    // not be shared across threads)
     std::shared_ptr<ov::CompiledModel> compiled_model_;
-    std::shared_ptr<ov::InferRequest> infer_request_;
 #endif
 
-    // Tokenizer (WordPiece for DistilBERT, SentencePiece for XLM-RoBERTa)
+    // Tokenizer (WordPiece for DistilBERT, SentencePiece for XLM-RoBERTa);
+    // immutable after LoadModel() publishes NERStatus::LOADED
     std::unique_ptr<ITokenizer> tokenizer_;
-    std::string current_model_name_;  // Track which model is loaded
+    std::string current_model_name_;  // Track which model is loaded (guarded by state_mutex_)
 
     // Result cache for repeated texts
     std::unique_ptr<LRUCache<std::string, std::vector<NEREntity>>> result_cache_;

--- a/test/cpp/test_ner_lru_cache.cpp
+++ b/test/cpp/test_ner_lru_cache.cpp
@@ -1,0 +1,130 @@
+//===----------------------------------------------------------------------===//
+// Catch2 unit tests for the NER LRUCache (issue #50).
+//
+// Built as a standalone test binary (anofox_tabular_cpp_tests) using the
+// Catch2 header bundled with DuckDB (duckdb/third_party/catch/catch.hpp).
+//
+// Run: ./build/release/extension/anofox_tabular/anofox_tabular_cpp_tests
+//===----------------------------------------------------------------------===//
+
+#define CATCH_CONFIG_MAIN
+#include "catch.hpp"
+
+#include "anofox_ner.hpp"
+
+#include <atomic>
+#include <string>
+#include <thread>
+#include <vector>
+
+using duckdb::anofox::LRUCache;
+
+TEST_CASE("LRUCache basic put/get and eviction order", "[ner][lru]") {
+    LRUCache<std::string, int> cache(2);
+
+    REQUIRE(cache.Size() == 0);
+    REQUIRE(cache.Capacity() == 2);
+    REQUIRE(!cache.Get("a").has_value());
+
+    cache.Put("a", 1);
+    cache.Put("b", 2);
+    REQUIRE(cache.Size() == 2);
+
+    // Touch "a" so that "b" becomes least recently used
+    REQUIRE(cache.Get("a").value() == 1);
+
+    // Inserting "c" must evict the least recently used entry "b"
+    cache.Put("c", 3);
+    REQUIRE(cache.Size() == 2);
+    REQUIRE(!cache.Get("b").has_value());
+    REQUIRE(cache.Get("a").value() == 1);
+    REQUIRE(cache.Get("c").value() == 3);
+
+    // Updating an existing key must not grow the cache
+    cache.Put("a", 10);
+    REQUIRE(cache.Size() == 2);
+    REQUIRE(cache.Get("a").value() == 10);
+}
+
+TEST_CASE("LRUCache clear empties the cache", "[ner][lru]") {
+    LRUCache<std::string, int> cache(4);
+    cache.Put("a", 1);
+    cache.Put("b", 2);
+    REQUIRE(cache.Size() == 2);
+
+    cache.Clear();
+    REQUIRE(cache.Size() == 0);
+    REQUIRE(!cache.Get("a").has_value());
+    REQUIRE(!cache.Get("b").has_value());
+}
+
+TEST_CASE("LRUCache Put with zero capacity is a safe no-op", "[ner][lru]") {
+    // Regression test for issue #50: with capacity 0, Put() used to evaluate
+    // cache_.size() >= capacity_ as true and call lru_list_.back() on an
+    // empty list (undefined behavior, observed as a crash).
+    LRUCache<std::string, int> cache(0);
+
+    cache.Put("a", 1);
+
+    REQUIRE(cache.Size() == 0);
+    REQUIRE(!cache.Get("a").has_value());
+}
+
+TEST_CASE("LRUCache SetCapacity(0) then Put is a safe no-op", "[ner][lru]") {
+    // Mirrors SET anofox_ner_cache_size = 0 happening while a query is using
+    // the cache: subsequent Put() calls must not touch an empty LRU list.
+    LRUCache<std::string, int> cache(4);
+    cache.Put("a", 1);
+    cache.Put("b", 2);
+
+    cache.SetCapacity(0);
+    REQUIRE(cache.Capacity() == 0);
+    REQUIRE(cache.Size() == 0); // all entries evicted
+
+    cache.Put("c", 3); // must not crash
+    REQUIRE(cache.Size() == 0);
+    REQUIRE(!cache.Get("c").has_value());
+
+    // Growing the capacity again must restore normal behavior
+    cache.SetCapacity(2);
+    cache.Put("d", 4);
+    REQUIRE(cache.Get("d").value() == 4);
+}
+
+TEST_CASE("LRUCache concurrent Get/Put/SetCapacity stress", "[ner][lru][threads]") {
+    // Issue #50: Capacity() read capacity_ without the mutex while
+    // SetCapacity() wrote it, and call sites checked Capacity() > 0 outside
+    // the lock before Put(). Toggling the capacity to 0 while workers insert
+    // reproduces the race (best-effort; run under TSan for a deterministic
+    // data-race report).
+    LRUCache<std::string, int> cache(64);
+    std::atomic<bool> stop {false};
+
+    std::vector<std::thread> workers;
+    for (int t = 0; t < 4; ++t) {
+        workers.emplace_back([&cache, &stop, t]() {
+            int i = 0;
+            while (!stop.load(std::memory_order_relaxed)) {
+                std::string key = "k" + std::to_string((t * 31 + i) % 97);
+                // Same pattern the NER call sites used: check capacity, then Put
+                if (cache.Capacity() > 0) {
+                    cache.Put(key, i);
+                }
+                cache.Get(key);
+                ++i;
+            }
+        });
+    }
+
+    for (int round = 0; round < 20000; ++round) {
+        cache.SetCapacity(round % 2 == 0 ? 0 : 32);
+    }
+    stop.store(true);
+    for (auto &worker : workers) {
+        worker.join();
+    }
+
+    cache.SetCapacity(8);
+    cache.Put("final", 42);
+    REQUIRE(cache.Get("final").value() == 42);
+}

--- a/test/sql/anofox_ner_cache_zero.test
+++ b/test/sql/anofox_ner_cache_zero.test
@@ -1,0 +1,68 @@
+# name: test/sql/anofox_ner_cache_zero.test
+# description: NER inference with the result cache disabled / resized (issue #50)
+# group: [anofox_tabular]
+
+# This test file requires OpenVINO to be available (NER model download needed).
+# On platforms without OpenVINO (musl/Alpine), these tests are skipped.
+require-env OPENVINO_AVAILABLE
+
+require anofox_tabular
+
+statement ok
+LOAD anofox_tabular
+
+# Disable the NER result cache: inference must still work and every Put must
+# be a safe no-op (previously UB on an empty LRU list, see issue #50)
+statement ok
+SET anofox_ner_cache_size = 0;
+
+query I
+SELECT list_contains(list_transform(pii_detect('John works at Microsoft'), x -> x.type), 'ORGANIZATION');
+----
+true
+
+# Repeated call with cache disabled re-runs inference and must return the same result
+query I
+SELECT list_contains(list_transform(pii_detect('John works at Microsoft'), x -> x.type), 'ORGANIZATION');
+----
+true
+
+# Multi-row query with cache disabled (exercises the batch path)
+query I
+SELECT bool_and(pii_contains(t)) FROM (VALUES
+    ('Angela Merkel visited Paris'),
+    ('Contact Apple Inc for details'),
+    ('Angela Merkel visited Paris')
+) AS v(t);
+----
+true
+
+# Shrink the cache to a tiny capacity mid-session: eviction must work
+statement ok
+SET anofox_ner_cache_size = 1;
+
+query I
+SELECT bool_and(pii_contains(t)) FROM (VALUES
+    ('John works at Microsoft'),
+    ('Angela Merkel visited Paris'),
+    ('John works at Microsoft')
+) AS v(t);
+----
+true
+
+# Back to 0 and again to a normal size: results stay consistent
+statement ok
+SET anofox_ner_cache_size = 0;
+
+query I
+SELECT pii_contains('She joined Google last year');
+----
+true
+
+statement ok
+SET anofox_ner_cache_size = 10000;
+
+query I
+SELECT pii_contains('She joined Google last year');
+----
+true


### PR DESCRIPTION
## Summary

Fixes the NER thread-safety findings from the 2026-06 code review (section 2.9, Phase 1). All five findings were re-verified as still present on `main` before fixing.

### Fixes

- **Shared mutable tokenizer state (HIGH):** `Encode()` mutated a member `offsets_` vector that `GetOffsets()` read afterwards, so a concurrent call could clear/replace the offsets between the two calls. Tokenization now returns ids and offsets **by value** via a `TokenizedInput` struct and `Encode()` is `const` — there is no mutable tokenizer state on the query path.
- **Shared `ov::InferRequest` (HIGH):** one infer request was reused for all inferences across DuckDB worker threads. OpenVINO infer requests are stateful and not thread-safe; compiled models *are* thread-safe for creating requests. Each inference now calls `compiled_model_->create_infer_request()` per invocation.
- **`LRUCache` races and zero-capacity UB (HIGH):** `Capacity()` read `capacity_` unlocked while `SetCapacity()` wrote it under the mutex, and call sites checked `Capacity() > 0` *outside* the lock before `Put()`. With capacity 0, `Put()` executed `lru_list_.back()` on an empty list (UB — segfaults deterministically, see red evidence below). `Capacity()` now locks, `Put()` handles zero capacity under the lock, eviction is guarded against an empty list, and the racy call-site pre-checks are removed.
- **Torn status reads (MED):** `status_message_`, `model_path_`, `current_model_name_` and `device_name_` were plain strings written by loader threads and read by `anofox_ner_status()`. They are now guarded by a state mutex and published as an immutable `NERStatusSnapshot` (single getter returning a struct copy); the status table function reads one consistent snapshot. `NERStatus::LOADED` is published last so any reader observing it sees the fully constructed model and tokenizer.
- **Duplicated pipeline / unused `max_batch_size` (LOW):** `ExtractEntities` and `ExtractEntitiesBatch` duplicated the entire tokenize/pad/infer/post-process/cache pipeline. Both now share a single private `RunSingleInference(text)` helper, so the safety fixes exist in exactly one place. The unused `max_batch_size` parameter is removed; true batched inference is out of scope here and tracked in #56.

## Red evidence (TDD)

The first commit contains only the new tests. The zero-capacity `Put` bug crashes deterministically under the new Catch2 binary:

```
[2/5] (40%): LRUCache Put with zero capacity is a safe no-op
...
/test/cpp/test_ner_lru_cache.cpp:61: FAILED:
due to a fatal error condition:
  SIGSEGV - Segmentation violation signal

test cases:  3 |  2 passed | 1 failed
assertions: 16 | 15 passed | 1 failed
```

After the fix all 5 test cases pass (23 assertions).

### Structural-fix rationale for the inference races

A deterministic red test for the tokenizer/infer-request races is not possible (they are timing-dependent data races). They are fixed structurally instead:

- per-call `ov::InferRequest` means no inference state is shared between threads by construction;
- by-value `TokenizedInput` means no tokenizer state is shared between threads by construction;
- `tokenizer_` and `compiled_model_` are written once under `init_lock_` before `status_` publishes `LOADED`, and are read-only afterwards.

A concurrent `Get`/`Put`/`SetCapacity` stress test for the cache is included (crashes pre-fix in repeated runs; run under TSan for a deterministic race report). Verified post-fix with a multi-threaded smoke run against the real DistilBERT model: `SET threads=8; SET anofox_ner_cache_size=0;` over 120 unique texts, 3 consecutive runs, deterministic 120/120 detections.

## Tests

- New standalone Catch2 binary `anofox_tabular_cpp_tests` (built from `test/cpp/`, uses the Catch2 header bundled with DuckDB): basic LRU eviction order, `Clear`, zero-capacity `Put`, `SetCapacity(0)` then `Put`, concurrent stress. All pass.
- New sqllogictest `test/sql/anofox_ner_cache_zero.test` (gated behind `require-env OPENVINO_AVAILABLE`, so CI may skip it): NER inference with the cache disabled and resized mid-session. Passes locally with the real model.
- `make test`: all pass (1624 assertions in 16 test cases, 2 env-gated skips) — identical to the pre-change baseline.
- `OPENVINO_AVAILABLE=1` runs of `anofox_pii_ner.test` (68 assertions) and `anofox_ner_cache_zero.test` (11 assertions): all pass with the real model, confirming per-call infer requests and by-value tokenization produce unchanged results.

Closes #50
