### PR TITLE
feat: implement vat_format, per-country checksum validation, country-code normalization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,6 +181,7 @@ set(EXTENSION_SOURCES
         src/anofox_money_currency.cpp
         src/anofox_vat.cpp
         src/anofox_vat_country.cpp
+        src/anofox_vat_checksum.cpp
         src/anofox_pii.cpp
         src/anofox_ner.cpp
 )

--- a/README.md
+++ b/README.md
@@ -371,7 +371,8 @@ European VAT number validation for regulatory compliance and data quality.
 - 10 SQL functions for VAT operations
 - 29 countries supported (28 EU + UK)
 - Syntax validation with country-specific regex patterns
-- EU membership checks
+- Check-digit (checksum) validation for 16 countries: AT, BE, DE, DK, ES, FI, FR, GR/EL, IE, IT, LU, NL, PL, PT, SE, SI
+- EU membership checks (accepts lowercase codes and the EL/XI VAT aliases)
 - Country name and information lookup
 
 ```sql
@@ -902,12 +903,15 @@ WHERE money_in_range(amount, 0.01, 99999.99)
 |----------|-----------|---------|-------------|
 | `anofox_tab_vat_is_eu_member` | `(country_code)` | BOOLEAN | Check if country is EU member |
 | `anofox_tab_vat_country_name` | `(country_code)` | VARCHAR | Get full country name |
-| `anofox_tab_vat_format` | `(vat_string, style)` | VARCHAR | Format VAT for display |
+| `anofox_tab_vat_format` | `(vat_string, style)` | VARCHAR | Format VAT for display: `'plain'` (digits only) or `'iso'` (VAT country prefix + digits) |
 
 #### Combined Validation
 | Function | Signature | Returns | Description |
 |----------|-----------|---------|-------------|
-| `anofox_tab_vat_is_valid` | `(vat_string)` | BOOLEAN | Full validation (syntax + country check) |
+| `anofox_tab_vat_is_valid` | `(vat_string)` | BOOLEAN | Full validation (syntax + check digit where implemented) |
+
+Check-digit (checksum) validation is implemented for: AT, BE, DE, DK, ES, FI, FR, GR/EL, IE, IT, LU, NL, PL, PT, SE, SI.
+All other countries are validated by syntax only. French VAT keys containing letters are accepted without check-digit verification.
 
 ### PII Detection Functions
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -726,7 +726,8 @@ SELECT anofox_tab_vat (alias: vat('DE123456789');
 
 #### `anofox_tab_is_valid_vat_country (alias: is_valid_vat_country`
 
-Check if country code is valid VAT country.
+Check if country code is valid VAT country. Codes are case-insensitive and the
+VAT aliases `EL` (Greece) and `XI` (Northern Ireland / GB) are accepted.
 
 **Signature:**
 ```sql
@@ -797,7 +798,8 @@ anofox_tab_vat (alias: vat_exists(vat_string VARCHAR) → BOOLEAN
 
 #### `anofox_tab_vat (alias: vat_is_eu_member`
 
-Check if country is EU member.
+Check if country is EU member. Codes are case-insensitive and the VAT aliases
+`EL`/`XI` are normalized (e.g. `vat_is_eu_member('EL')` is true, `'XI'` is false).
 
 **Signature:**
 ```sql
@@ -825,11 +827,25 @@ SELECT anofox_tab_vat (alias: vat_country_name('DE');
 
 #### `anofox_tab_vat (alias: vat_format`
 
-Format VAT for display.
+Format VAT for display. Supported styles (case-insensitive):
+
+- `'plain'` — digits only, without country prefix
+- `'iso'` — VAT country prefix + digits (Greece uses `EL`, Northern Ireland `XI`)
+
+Unparseable VAT numbers return `NULL`; unknown styles raise an error.
 
 **Signature:**
 ```sql
 anofox_tab_vat (alias: vat_format(vat_string VARCHAR, style VARCHAR) → VARCHAR
+```
+
+**Example:**
+```sql
+SELECT anofox_tab_vat_format('de 123-456-789', 'iso');
+-- Returns: 'DE123456789'
+
+SELECT anofox_tab_vat_format('GR123456783', 'plain');
+-- Returns: '123456783'
 ```
 
 ---
@@ -838,7 +854,11 @@ anofox_tab_vat (alias: vat_format(vat_string VARCHAR, style VARCHAR) → VARCHAR
 
 #### `anofox_tab_vat (alias: vat_is_valid`
 
-Full validation (syntax + country check).
+Full validation: syntax check plus country check-digit (checksum) validation where implemented.
+
+Check digits are verified for: AT, BE, DE, DK, ES, FI, FR, GR/EL, IE, IT, LU, NL, PL, PT, SE, SI.
+Other countries are validated by syntax only. French VAT keys containing letters are accepted
+without check-digit verification.
 
 **Signature:**
 ```sql
@@ -847,8 +867,11 @@ anofox_tab_vat (alias: vat_is_valid(vat_string VARCHAR) → BOOLEAN
 
 **Example:**
 ```sql
-SELECT anofox_tab_vat (alias: vat_is_valid('DE123456789');
+SELECT anofox_tab_vat_is_valid('DE111111125');
 -- Returns: true
+
+SELECT anofox_tab_vat_is_valid('DE123456789');
+-- Returns: false (valid syntax, invalid check digit)
 ```
 
 ---

--- a/src/anofox_vat.cpp
+++ b/src/anofox_vat.cpp
@@ -126,32 +126,30 @@ static void VATCountryNameFunc(DataChunk& args, ExpressionState& state,
 }
 
 // anofox_vat_format(vat, style) -> VARCHAR
+// Style: 'plain' = digits only, 'iso' = VAT country prefix (EL/XI) + digits
 static void VATFormatFunc(DataChunk& args, ExpressionState& state,
                          Vector& result) {
-  // Style: 'plain' = digits only, 'iso' = with country prefix
-  auto& vat_vec = args.data[0];
-  auto& style_vec = args.data[1];
-  size_t count = args.size();
-
-  UnifiedVectorFormat vat_data, style_data;
-  vat_vec.ToUnifiedFormat(count, vat_data);
-  style_vec.ToUnifiedFormat(count, style_data);
-
-  for (size_t i = 0; i < count; i++) {
-    size_t vat_idx = vat_data.sel->get_index(i);
-    size_t style_idx = style_data.sel->get_index(i);
-
-    if (!vat_data.validity.RowIsValid(vat_idx) ||
-        !style_data.validity.RowIsValid(style_idx)) {
-      FlatVector::SetNull(result, i, true);
-      continue;
+  auto& registry = VATRegistry::Instance();
+  IterateTwoStringInputs(args, result, [&](const std::string& vat,
+                                           const std::string& style,
+                                           size_t idx) {
+    auto split_result = registry.SplitVAT(vat);
+    if (!split_result.has_value()) {
+      FlatVector::SetNull(result, idx, true);
+      return;
     }
-
-    // For now, simplified implementation
-    FlatVector::SetNull(result, i, true);
-  }
-
-  result.Verify(count);
+    auto [country, digits] = split_result.value();
+    auto normalized_style = StringUtil::Lower(style);
+    if (normalized_style == "plain") {
+      SetStringResult(result, idx, digits);
+    } else if (normalized_style == "iso") {
+      SetStringResult(result, idx, registry.ConvertISOToVAT(country) + digits);
+    } else {
+      throw InvalidInputException(
+          "Unsupported VAT format style: %s (expected 'plain' or 'iso')",
+          style);
+    }
+  });
 }
 
 // ============================================================================
@@ -159,6 +157,7 @@ static void VATFormatFunc(DataChunk& args, ExpressionState& state,
 // ============================================================================
 
 // anofox_vat_is_valid(vat) -> BOOLEAN
+// Full validation: syntax plus country check digits where implemented.
 static void VATIsValidFunc(DataChunk& args, ExpressionState& state,
                           Vector& result) {
   auto& registry = VATRegistry::Instance();
@@ -169,7 +168,8 @@ static void VATIsValidFunc(DataChunk& args, ExpressionState& state,
       return;
     }
     auto [country, digits] = split_result.value();
-    SetBoolResult(result, idx, registry.IsValidSyntax(country, digits));
+    SetBoolResult(result, idx, registry.IsValidSyntax(country, digits) &&
+                                   registry.IsValidChecksum(country, digits));
   });
 }
 
@@ -323,10 +323,10 @@ void RegisterVATFunctions(ExtensionLoader& loader) {
   }
   {
     FunctionDescription desc;
-    desc.description = "Formats a raw VAT number using the specified format style (e.g., 'standard', 'compact').";
+    desc.description = "Formats a VAT number using the specified style: 'plain' (digits only) or 'iso' (VAT country prefix + digits).";
     desc.parameter_names = {"vat_number", "format_style"};
     desc.parameter_types = {LogicalType::VARCHAR, LogicalType::VARCHAR};
-    desc.examples = {"SELECT vat_format('DE123456789', 'standard');"};
+    desc.examples = {"SELECT vat_format('DE123456789', 'iso');"};
     desc.categories = {"vat", "formatting"};
     ScalarFunction format_func("anofox_tab_vat_format", {LogicalTypeId::VARCHAR, LogicalTypeId::VARCHAR}, LogicalTypeId::VARCHAR, VATFormatFunc);
     format_func.bind = VatFormatBind;
@@ -334,10 +334,10 @@ void RegisterVATFunctions(ExtensionLoader& loader) {
   }
   {
     FunctionDescription desc;
-    desc.description = "Returns TRUE if the VAT number has valid syntax and exists in the known country registry.";
+    desc.description = "Returns TRUE if the VAT number has valid syntax and passes the country's check-digit validation where implemented.";
     desc.parameter_names = {"vat_number"};
     desc.parameter_types = {LogicalType::VARCHAR};
-    desc.examples = {"SELECT vat_is_valid('DE123456789');"};
+    desc.examples = {"SELECT vat_is_valid('DE111111125');"};
     desc.categories = {"vat", "validation"};
     ScalarFunction is_valid_func("anofox_tab_vat_is_valid", {LogicalTypeId::VARCHAR}, LogicalTypeId::BOOLEAN, VATIsValidFunc);
     is_valid_func.bind = VatIsValidBind;

--- a/src/anofox_vat_checksum.cpp
+++ b/src/anofox_vat_checksum.cpp
@@ -1,0 +1,389 @@
+// Per-country VAT check-digit validation.
+//
+// Only countries whose algorithm is well-documented and verified with known
+// public examples are implemented here. For each implemented country the
+// registry entry in anofox_vat_country.cpp sets has_checksum = true; all other
+// countries honestly report has_checksum = false and are validated by syntax
+// only.
+//
+// All functions receive the VAT payload *without* the 2-letter country prefix,
+// already normalized (uppercase, alphanumeric only) and already matched
+// against the country's syntax pattern.
+
+#include "anofox_vat.hpp"
+
+#include <cctype>
+#include <cstdint>
+#include <string>
+
+namespace duckdb {
+
+namespace {
+
+inline bool IsDigitChar(char c) {
+  return std::isdigit(static_cast<unsigned char>(c)) != 0;
+}
+
+inline int DigitValue(char c) {
+  return c - '0';
+}
+
+// Parse a small all-digit substring into an integer. The caller guarantees
+// (via the syntax regex) that the characters are digits.
+int64_t ToNumber(const std::string& s, size_t pos, size_t len) {
+  int64_t value = 0;
+  for (size_t i = pos; i < pos + len && i < s.size(); i++) {
+    if (!IsDigitChar(s[i])) {
+      return -1;
+    }
+    value = value * 10 + DigitValue(s[i]);
+  }
+  return value;
+}
+
+// Austria: 'U' + 8 digits. Weights 1,2,1,2,1,2,1 over the first 7 digits,
+// doubled digits are reduced by digit sum; check = (96 - total) mod 10.
+bool ChecksumAT(const std::string& digits) {
+  if (digits.size() != 9 || digits[0] != 'U') {
+    return false;
+  }
+  int total = 0;
+  for (int i = 0; i < 7; i++) {
+    int d = DigitValue(digits[i + 1]);
+    if (i % 2 == 1) {
+      d *= 2;
+      d = d / 10 + d % 10;
+    }
+    total += d;
+  }
+  int check = ((96 - total) % 10 + 10) % 10;
+  return DigitValue(digits[8]) == check;
+}
+
+// Belgium: 10 digits; last two = 97 - (first 8 digits mod 97).
+bool ChecksumBE(const std::string& digits) {
+  if (digits.size() != 10) {
+    return false;
+  }
+  int64_t base = ToNumber(digits, 0, 8);
+  int64_t check = ToNumber(digits, 8, 2);
+  if (base < 0 || check < 0) {
+    return false;
+  }
+  return check == 97 - (base % 97);
+}
+
+// Germany: 9 digits, ISO 7064 MOD 11,10. Official example: DE111111125.
+bool ChecksumDE(const std::string& digits) {
+  if (digits.size() != 9) {
+    return false;
+  }
+  int product = 10;
+  for (int i = 0; i < 8; i++) {
+    int sum = (DigitValue(digits[i]) + product) % 10;
+    if (sum == 0) {
+      sum = 10;
+    }
+    product = (2 * sum) % 11;
+  }
+  int check = 11 - product;
+  if (check == 10) {
+    check = 0;
+  }
+  return DigitValue(digits[8]) == check;
+}
+
+// Denmark: 8 digits, weights 2,7,6,5,4,3,2,1; total mod 11 == 0.
+bool ChecksumDK(const std::string& digits) {
+  static const int kWeights[] = {2, 7, 6, 5, 4, 3, 2, 1};
+  if (digits.size() != 8) {
+    return false;
+  }
+  int total = 0;
+  for (int i = 0; i < 8; i++) {
+    total += kWeights[i] * DigitValue(digits[i]);
+  }
+  return total % 11 == 0;
+}
+
+// Spain: NIF (8 digits + letter), NIE (X/Y/Z + 7 digits + letter) and
+// CIF (letter + 7 digits + check digit or letter).
+bool ChecksumES(const std::string& digits) {
+  static const std::string kNifLetters = "TRWAGMYFPDXBNJZSQVHLCKE";
+  static const std::string kCifLetters = "JABCDEFGHI";
+  if (digits.size() != 9) {
+    return false;
+  }
+  char first = digits[0];
+  char last = digits[8];
+  if (IsDigitChar(first)) {
+    // Personal NIF: letter = table[number mod 23].
+    int64_t number = ToNumber(digits, 0, 8);
+    if (number < 0) {
+      return false;
+    }
+    return last == kNifLetters[number % 23];
+  }
+  if ((first == 'X' || first == 'Y' || first == 'Z') && !IsDigitChar(last)) {
+    // NIE: replace X/Y/Z with 0/1/2, then NIF rule.
+    int64_t number = ToNumber(digits, 1, 7);
+    if (number < 0) {
+      return false;
+    }
+    number += static_cast<int64_t>(first - 'X') * 10000000;
+    return last == kNifLetters[number % 23];
+  }
+  // CIF: Luhn-style over the 7 middle digits.
+  int total = 0;
+  for (int i = 0; i < 7; i++) {
+    int d = DigitValue(digits[i + 1]);
+    if (i % 2 == 0) {
+      d *= 2;
+      d = d / 10 + d % 10;
+    }
+    total += d;
+  }
+  int check = (10 - total % 10) % 10;
+  return last == static_cast<char>('0' + check) || last == kCifLetters[check];
+}
+
+// Finland: 8 digits, weights 7,9,10,5,8,4,2 over the first 7;
+// check = (11 - total mod 11), remainder 1 is invalid, remainder 0 -> 0.
+bool ChecksumFI(const std::string& digits) {
+  static const int kWeights[] = {7, 9, 10, 5, 8, 4, 2};
+  if (digits.size() != 8) {
+    return false;
+  }
+  int total = 0;
+  for (int i = 0; i < 7; i++) {
+    total += kWeights[i] * DigitValue(digits[i]);
+  }
+  int remainder = total % 11;
+  if (remainder == 1) {
+    return false;
+  }
+  int check = (11 - remainder) % 11;
+  return DigitValue(digits[7]) == check;
+}
+
+// France: 2-character key + 9-digit SIREN. For numeric keys:
+// key = (12 + 3 * (SIREN mod 97)) mod 97. Alphanumeric keys are accepted
+// without verification (no public algorithm with verified vectors).
+bool ChecksumFR(const std::string& digits) {
+  if (digits.size() != 11) {
+    return false;
+  }
+  if (!IsDigitChar(digits[0]) || !IsDigitChar(digits[1])) {
+    return true;
+  }
+  int64_t key = ToNumber(digits, 0, 2);
+  int64_t siren = ToNumber(digits, 2, 9);
+  if (key < 0 || siren < 0) {
+    return false;
+  }
+  return key == (12 + 3 * (siren % 97)) % 97;
+}
+
+// Greece: 9 digits, weights 256,128,64,32,16,8,4,2; check = total mod 11 mod 10.
+bool ChecksumGR(const std::string& digits) {
+  if (digits.size() != 9) {
+    return false;
+  }
+  int total = 0;
+  int weight = 256;
+  for (int i = 0; i < 8; i++) {
+    total += weight * DigitValue(digits[i]);
+    weight /= 2;
+  }
+  return DigitValue(digits[8]) == total % 11 % 10;
+}
+
+// Ireland: check letter from alphabet[(weighted digit sum + 9 * extra) mod 23].
+// New style: 7 digits + check letter (+ optional trailing letter).
+// Old style: digit + letter + 5 digits + check letter.
+bool ChecksumIE(const std::string& digits) {
+  static const std::string kAlphabet = "WABCDEFGHIJKLMNOPQRSTUV";
+  auto calcCheck = [&](const std::string& seven, char extra) -> char {
+    int total = 0;
+    for (int i = 0; i < 7; i++) {
+      if (!IsDigitChar(seven[i])) {
+        return '\0';
+      }
+      total += (8 - i) * DigitValue(seven[i]);
+    }
+    if (extra != '\0') {
+      auto pos = kAlphabet.find(extra);
+      if (pos == std::string::npos) {
+        return '\0';
+      }
+      total += 9 * static_cast<int>(pos);
+    }
+    return kAlphabet[total % 23];
+  };
+  if (digits.size() == 8 && !IsDigitChar(digits[1])) {
+    // Old style: move the leading digit behind the body, pad to 7 digits.
+    std::string seven = "0" + digits.substr(2, 5) + digits.substr(0, 1);
+    return digits[7] == calcCheck(seven, '\0');
+  }
+  if (digits.size() == 8) {
+    return digits[7] == calcCheck(digits.substr(0, 7), '\0');
+  }
+  if (digits.size() == 9) {
+    return digits[7] == calcCheck(digits.substr(0, 7), digits[8]);
+  }
+  return false;
+}
+
+// Italy: 11 digits, Luhn-style (even 0-based positions plain, odd doubled).
+bool ChecksumIT(const std::string& digits) {
+  if (digits.size() != 11) {
+    return false;
+  }
+  int total = 0;
+  for (int i = 0; i < 11; i++) {
+    int d = DigitValue(digits[i]);
+    if (i % 2 == 1) {
+      d *= 2;
+      if (d > 9) {
+        d -= 9;
+      }
+    }
+    total += d;
+  }
+  return total % 10 == 0;
+}
+
+// Luxembourg: 8 digits; last two = first six mod 89.
+bool ChecksumLU(const std::string& digits) {
+  if (digits.size() != 8) {
+    return false;
+  }
+  int64_t base = ToNumber(digits, 0, 6);
+  int64_t check = ToNumber(digits, 6, 2);
+  if (base < 0 || check < 0) {
+    return false;
+  }
+  return check == base % 89;
+}
+
+// Netherlands: 9 digits + 'B' + 2 digits. Valid if the first 9 digits pass the
+// legacy BSN mod-11 test, or (since 2020) the full number prefixed with 'NL'
+// passes ISO 7064 MOD 97-10 (letters mapped A=10..Z=35, result == 1).
+bool ChecksumNL(const std::string& digits) {
+  if (digits.size() != 12 || digits[9] != 'B') {
+    return false;
+  }
+  // Legacy mod-11 over the leading 9 digits.
+  int total = 0;
+  for (int i = 0; i < 8; i++) {
+    total += (9 - i) * DigitValue(digits[i]);
+  }
+  int remainder = total % 11;
+  if (remainder < 10 && remainder == DigitValue(digits[8])) {
+    return true;
+  }
+  // MOD 97-10 over "NL" + number with letters converted to two-digit values.
+  std::string full = "NL" + digits;
+  int64_t mod = 0;
+  for (char c : full) {
+    if (IsDigitChar(c)) {
+      mod = (mod * 10 + DigitValue(c)) % 97;
+    } else {
+      mod = (mod * 100 + (c - 'A' + 10)) % 97;
+    }
+  }
+  return mod == 1;
+}
+
+// Poland: 10 digits, weights 6,5,7,2,3,4,5,6,7; check = total mod 11.
+bool ChecksumPL(const std::string& digits) {
+  static const int kWeights[] = {6, 5, 7, 2, 3, 4, 5, 6, 7};
+  if (digits.size() != 10) {
+    return false;
+  }
+  int total = 0;
+  for (int i = 0; i < 9; i++) {
+    total += kWeights[i] * DigitValue(digits[i]);
+  }
+  return DigitValue(digits[9]) == total % 11;
+}
+
+// Portugal: 9 digits, weights 9..2; check = (11 - total mod 11) mod 11 mod 10.
+bool ChecksumPT(const std::string& digits) {
+  if (digits.size() != 9) {
+    return false;
+  }
+  int total = 0;
+  for (int i = 0; i < 8; i++) {
+    total += (9 - i) * DigitValue(digits[i]);
+  }
+  int check = (11 - total % 11) % 11 % 10;
+  return DigitValue(digits[8]) == check;
+}
+
+// Sweden: 12 digits ending in 01; Luhn over the first 10 digits.
+bool ChecksumSE(const std::string& digits) {
+  if (digits.size() != 12) {
+    return false;
+  }
+  int total = 0;
+  for (int i = 0; i < 10; i++) {
+    int d = DigitValue(digits[i]);
+    if (i % 2 == 0) {
+      d *= 2;
+      if (d > 9) {
+        d -= 9;
+      }
+    }
+    total += d;
+  }
+  return total % 10 == 0;
+}
+
+// Slovenia: 8 digits, weights 8..2; check = (-total mod 11) mod 10.
+bool ChecksumSI(const std::string& digits) {
+  if (digits.size() != 8) {
+    return false;
+  }
+  int total = 0;
+  for (int i = 0; i < 7; i++) {
+    total += (8 - i) * DigitValue(digits[i]);
+  }
+  int check = (11 - total % 11) % 11 % 10;
+  return DigitValue(digits[7]) == check;
+}
+
+}  // namespace
+
+bool VATRegistry::IsValidChecksum(const std::string& country,
+                                  const std::string& digits) const {
+  auto it = countries_.find(country);
+  if (it == countries_.end()) {
+    return false;
+  }
+  if (!it->second.has_checksum) {
+    // No verified checksum algorithm implemented; syntax-only validation.
+    return true;
+  }
+  if (country == "AT") return ChecksumAT(digits);
+  if (country == "BE") return ChecksumBE(digits);
+  if (country == "DE") return ChecksumDE(digits);
+  if (country == "DK") return ChecksumDK(digits);
+  if (country == "ES") return ChecksumES(digits);
+  if (country == "FI") return ChecksumFI(digits);
+  if (country == "FR") return ChecksumFR(digits);
+  if (country == "GR") return ChecksumGR(digits);
+  if (country == "IE") return ChecksumIE(digits);
+  if (country == "IT") return ChecksumIT(digits);
+  if (country == "LU") return ChecksumLU(digits);
+  if (country == "NL") return ChecksumNL(digits);
+  if (country == "PL") return ChecksumPL(digits);
+  if (country == "PT") return ChecksumPT(digits);
+  if (country == "SE") return ChecksumSE(digits);
+  if (country == "SI") return ChecksumSI(digits);
+  // has_checksum set without an implementation would be a programming error;
+  // fail closed so the mismatch is caught by tests.
+  return false;
+}
+
+}  // namespace duckdb

--- a/src/anofox_vat_country.cpp
+++ b/src/anofox_vat_country.cpp
@@ -16,53 +16,63 @@ VATRegistry::VATRegistry() {
   vat_to_iso_["XI"] = "GB";
   iso_to_vat_["GR"] = "EL";
   iso_to_vat_["GB"] = "XI";
+  // Precompile anchored syntax patterns once; IsValidSyntax runs per row.
+  for (auto& entry : countries_) {
+    entry.second.compiled_pattern =
+        std::regex("^" + entry.second.pattern + "$",
+                   std::regex::ECMAScript | std::regex::optimize);
+  }
 }
 
 void VATRegistry::InitializeCountries() {
   // All 29 countries: 28 EU + UK
   // Format: country_code, country_name, pattern (without country prefix), is_eu_member,
   // has_checksum
+  //
+  // has_checksum is only set for countries whose check-digit algorithm is
+  // implemented (and verified with known examples) in anofox_vat_checksum.cpp.
+  // All other countries are validated by syntax only.
   countries_["AT"] = {"AT", "Austria", "U[0-9]{8}", true, true};
   countries_["BE"] = {"BE", "Belgium", "[0-1][0-9]{9}", true, true};
-  countries_["BG"] = {"BG", "Bulgaria", "[0-9]{9,10}", true, true};
-  countries_["CY"] = {"CY", "Cyprus", "(?!12)[0-69][0-9]{7}[A-Z]", true, true};
+  countries_["BG"] = {"BG", "Bulgaria", "[0-9]{9,10}", true, false};
+  countries_["CY"] = {"CY", "Cyprus", "(?!12)[0-69][0-9]{7}[A-Z]", true, false};
   countries_["CZ"] = {"CZ", "Czech Republic", "[0-9]{8,10}", true, false};
   countries_["DE"] = {"DE", "Germany", "[0-9]{9}", true, true};
   countries_["DK"] = {"DK", "Denmark", "[0-9]{8}", true, true};
-  countries_["EE"] = {"EE", "Estonia", "10[0-9]{7}", true, true};
+  countries_["EE"] = {"EE", "Estonia", "10[0-9]{7}", true, false};
   countries_["ES"] = {"ES", "Spain",
                       "([A-Z][0-9]{8}|[0-9]{8}[A-Z]|[A-Z][0-9]{7}[A-Z])",
                       true, true};
   countries_["FI"] = {"FI", "Finland", "[0-9]{8}", true, true};
   countries_["FR"] = {"FR", "France", "[A-HJ-NP-Z0-9]{2}[0-9]{9}", true, true};
   countries_["GB"] = {"GB", "United Kingdom",
-                      "([0-9]{9}|[0-9]{12}|(HA|GD)[0-9]{3})", false, true};
+                      "([0-9]{9}|[0-9]{12}|(HA|GD)[0-9]{3})", false, false};
   countries_["GR"] = {"GR", "Greece", "[0-9]{9}", true, true};
-  countries_["HR"] = {"HR", "Croatia", "[0-9]{11}", true, true};
-  countries_["HU"] = {"HU", "Hungary", "[0-9]{8}", true, true};
+  countries_["HR"] = {"HR", "Croatia", "[0-9]{11}", true, false};
+  countries_["HU"] = {"HU", "Hungary", "[0-9]{8}", true, false};
   countries_["IE"] = {"IE", "Ireland", "([0-9][A-Z][0-9]{5}|[0-9]{7}[A-Z]?)[A-Z]",
                       true, true};
   countries_["IT"] = {"IT", "Italy", "[0-9]{11}", true, true};
   countries_["LT"] = {"LT", "Lithuania", "([0-9]{7}1[0-9]|[0-9]{10}1[0-9])",
-                      true, true};
+                      true, false};
   countries_["LU"] = {"LU", "Luxembourg", "[0-9]{8}", true, true};
   countries_["LV"] = {"LV", "Latvia", "[0-9]{11}", true, false};
-  countries_["MT"] = {"MT", "Malta", "[0-9]{8}", true, true};
+  countries_["MT"] = {"MT", "Malta", "[0-9]{8}", true, false};
   countries_["NL"] = {"NL", "Netherlands", "[0-9]{9}B[0-9]{2}", true, true};
   countries_["PL"] = {"PL", "Poland", "[0-9]{10}", true, true};
   countries_["PT"] = {"PT", "Portugal", "[0-9]{9}", true, true};
-  countries_["RO"] = {"RO", "Romania", "[1-9][0-9]{1,9}", true, true};
+  countries_["RO"] = {"RO", "Romania", "[1-9][0-9]{1,9}", true, false};
   countries_["SE"] = {"SE", "Sweden", "[0-9]{10}01", true, true};
   countries_["SI"] = {"SI", "Slovenia", "[0-9]{8}", true, true};
   countries_["SK"] = {"SK", "Slovakia", "[0-9]{10}", true, false};
 }
 
 bool VATRegistry::IsValidCountry(const std::string& code) const {
-  return countries_.find(code) != countries_.end();
+  return countries_.find(NormalizeCountryCode(code)) != countries_.end();
 }
 
 bool VATRegistry::IsEUMember(const std::string& code) const {
-  auto it = countries_.find(code);
+  auto it = countries_.find(NormalizeCountryCode(code));
   if (it == countries_.end()) {
     return false;
   }
@@ -70,7 +80,7 @@ bool VATRegistry::IsEUMember(const std::string& code) const {
 }
 
 std::string VATRegistry::GetCountryName(const std::string& code) const {
-  auto it = countries_.find(code);
+  auto it = countries_.find(NormalizeCountryCode(code));
   if (it == countries_.end()) {
     return "";
   }
@@ -83,24 +93,23 @@ bool VATRegistry::IsValidSyntax(const std::string& country,
   if (it == countries_.end()) {
     return false;
   }
-
-  try {
-    std::regex pattern("^" + it->second.pattern + "$");
-    return std::regex_match(digits, pattern);
-  } catch (const std::regex_error&) {
-    return false;
-  }
+  return std::regex_match(digits, it->second.compiled_pattern);
 }
 
 std::string VATRegistry::NormalizeVAT(const std::string& input) const {
   std::string result;
+  result.reserve(input.size());
   // Convert to uppercase and remove spaces, punctuation
-  for (char c : input) {
+  for (unsigned char c : input) {
     if (std::isalnum(c)) {
-      result += std::toupper(c);
+      result += static_cast<char>(std::toupper(c));
     }
   }
   return result;
+}
+
+std::string VATRegistry::NormalizeCountryCode(const std::string& code) const {
+  return ConvertVATToISO(NormalizeVAT(code));
 }
 
 std::optional<std::pair<std::string, std::string>> VATRegistry::SplitVAT(

--- a/src/include/anofox_vat.hpp
+++ b/src/include/anofox_vat.hpp
@@ -4,9 +4,11 @@
 #include "duckdb/common/types/string_type.hpp"
 #include "duckdb/common/vector_operations/vector_operations.hpp"
 #include "duckdb/execution/expression_executor.hpp"
-#include <string>
 #include <memory>
 #include <optional>
+#include <regex>
+#include <string>
+#include <unordered_map>
 
 namespace duckdb {
 
@@ -124,7 +126,12 @@ class VATRegistry {
   bool IsEUMember(const std::string& code) const;
   std::string GetCountryName(const std::string& code) const;
   bool IsValidSyntax(const std::string& country, const std::string& digits) const;
+  // Validates the country-specific check digits. Returns true for countries
+  // without an implemented checksum (syntax-only validation).
+  bool IsValidChecksum(const std::string& country, const std::string& digits) const;
   std::string NormalizeVAT(const std::string& input) const;
+  // Uppercases the code and resolves VAT prefixes (EL -> GR, XI -> GB) to ISO.
+  std::string NormalizeCountryCode(const std::string& code) const;
   std::optional<std::pair<std::string, std::string>> SplitVAT(
       const std::string& input) const;
   std::string ConvertVATToISO(const std::string& vat_country) const;
@@ -140,7 +147,8 @@ class VATRegistry {
     std::string country_name;
     std::string pattern;  // Regex pattern without country prefix
     bool is_eu_member;
-    bool has_checksum;  // Whether checksum validation is supported
+    bool has_checksum;  // Whether a check-digit algorithm is implemented
+    std::regex compiled_pattern;  // Anchored pattern, compiled at registry init
   };
 
   std::unordered_map<std::string, CountryInfo> countries_;

--- a/test/sql/anofox_vat.test
+++ b/test/sql/anofox_vat.test
@@ -3,8 +3,6 @@
 
 require anofox_tabular
 
-mode skip
-
 statement ok
 LOAD anofox_tabular
 
@@ -60,7 +58,7 @@ SELECT anofox_tab_is_valid_vat_country('XX')
 ----
 false
 
-# Test anofox_tab_is_valid_vat_country - All EU countries
+# Test anofox_tab_is_valid_vat_country - all 28 registry codes (27 EU + UK)
 query I
 SELECT COUNT(*) FROM (
   SELECT 'AT' AS c UNION ALL
@@ -73,7 +71,7 @@ SELECT COUNT(*) FROM (
   SELECT 'SE' UNION ALL SELECT 'SI' UNION ALL SELECT 'SK'
 ) WHERE anofox_tab_is_valid_vat_country(c)
 ----
-29
+28
 
 # Test anofox_tab_vat_normalize
 query T
@@ -203,27 +201,39 @@ SELECT anofox_tab_vat_country_name('XX')
 ----
 NULL
 
-# Test anofox_tab_vat_format - Plain style (simplified for now)
-query I
+# Test anofox_tab_vat_format - Plain style (digits only)
+query T
 SELECT anofox_tab_vat_format('DE123456789', 'plain')
 ----
-NULL
+123456789
+
+# Test anofox_tab_vat_format - ISO style (country prefix + digits)
+query T
+SELECT anofox_tab_vat_format('de 123-456-789', 'iso')
+----
+DE123456789
 
 # ============================================================================
 # Phase 6: Combined Validation
 # ============================================================================
 
-# Test anofox_tab_vat_is_valid - Valid syntax
+# Test anofox_tab_vat_is_valid - Valid syntax and check digit
 query I
-SELECT anofox_tab_vat_is_valid('DE123456789')
+SELECT anofox_tab_vat_is_valid('DE111111125')
 ----
 true
 
-# Test vat_is_valid alias - Valid syntax
+# Test vat_is_valid alias - Valid syntax and check digit
 query I
-SELECT vat_is_valid('DE123456789')
+SELECT vat_is_valid('DE111111125')
 ----
 true
+
+# Test anofox_tab_vat_is_valid - Valid syntax but invalid check digit
+query I
+SELECT anofox_tab_vat_is_valid('DE123456789')
+----
+false
 
 # Test anofox_tab_vat_is_valid - Invalid country code
 query I
@@ -266,10 +276,10 @@ NULL
 # Test batch validation
 query I
 SELECT COUNT(*) FROM (
-  SELECT 'DE123456789' AS vat UNION ALL
-  SELECT 'AT223456789' UNION ALL
-  SELECT 'BE1234567890' UNION ALL
-  SELECT 'FR12AB123456' UNION ALL
+  SELECT 'DE111111125' AS vat UNION ALL
+  SELECT 'ATU13585627' UNION ALL
+  SELECT 'BE0776091951' UNION ALL
+  SELECT 'FR40303265045' UNION ALL
   SELECT 'INVALID'
 ) WHERE anofox_tab_vat_is_valid(vat)
 ----
@@ -311,12 +321,12 @@ false
 
 # Test mixed case input
 query I
-SELECT anofox_tab_vat_is_valid('De123456789')
+SELECT anofox_tab_vat_is_valid('De111111125')
 ----
 true
 
 # Test with leading/trailing spaces (should be normalized)
 query I
-SELECT anofox_tab_vat_is_valid('  DE123456789  ')
+SELECT anofox_tab_vat_is_valid('  DE111111125  ')
 ----
 true

--- a/test/sql/anofox_vat_checksum.test
+++ b/test/sql/anofox_vat_checksum.test
@@ -1,0 +1,386 @@
+# VAT formatting, checksum validation and country-code normalization tests
+# Issue #53: vat_format, per-country check digits, country alias handling
+
+require anofox_tabular
+
+# ============================================================================
+# anofox_tab_vat_format
+# ============================================================================
+
+# plain style: digits only, input normalized first
+query T
+SELECT anofox_tab_vat_format('de 123-456-789', 'plain')
+----
+123456789
+
+# iso style: country prefix + digits
+query T
+SELECT anofox_tab_vat_format('DE123456789', 'iso')
+----
+DE123456789
+
+# iso style uses the VAT prefix (EL) for Greece, regardless of input alias
+query T
+SELECT anofox_tab_vat_format('GR123456783', 'iso')
+----
+EL123456783
+
+query T
+SELECT anofox_tab_vat_format('el 123456783', 'iso')
+----
+EL123456783
+
+query T
+SELECT anofox_tab_vat_format('EL123456783', 'plain')
+----
+123456783
+
+# style is case-insensitive
+query T
+SELECT anofox_tab_vat_format('DE123456789', 'ISO')
+----
+DE123456789
+
+# unparseable VAT yields NULL
+query T
+SELECT anofox_tab_vat_format('XX123', 'plain')
+----
+NULL
+
+# NULL handling
+query T
+SELECT anofox_tab_vat_format(NULL, 'plain')
+----
+NULL
+
+query T
+SELECT anofox_tab_vat_format('DE123456789', NULL)
+----
+NULL
+
+# unknown style is rejected
+statement error
+SELECT anofox_tab_vat_format('DE123456789', 'bogus')
+----
+Unsupported VAT format style
+
+# ============================================================================
+# Checksum validation: anofox_tab_vat_is_valid
+# Each implemented country has one known-valid vector and one vector with an
+# altered check digit.
+# ============================================================================
+
+# Austria (ATU + 8): official-style example
+query I
+SELECT anofox_tab_vat_is_valid('ATU13585627')
+----
+true
+
+query I
+SELECT anofox_tab_vat_is_valid('ATU13585626')
+----
+false
+
+# Belgium (mod 97)
+query I
+SELECT anofox_tab_vat_is_valid('BE0776091951')
+----
+true
+
+query I
+SELECT anofox_tab_vat_is_valid('BE0776091950')
+----
+false
+
+# Germany (ISO 7064 MOD 11,10) - official example DE111111125
+query I
+SELECT anofox_tab_vat_is_valid('DE111111125')
+----
+true
+
+query I
+SELECT anofox_tab_vat_is_valid('DE111111124')
+----
+false
+
+# Denmark (weighted mod 11)
+query I
+SELECT anofox_tab_vat_is_valid('DK13585628')
+----
+true
+
+query I
+SELECT anofox_tab_vat_is_valid('DK13585627')
+----
+false
+
+# Spain - NIF (personal, mod 23 letter)
+query I
+SELECT anofox_tab_vat_is_valid('ES54362315K')
+----
+true
+
+query I
+SELECT anofox_tab_vat_is_valid('ES54362315Z')
+----
+false
+
+# Spain - NIE (X/Y/Z prefix)
+query I
+SELECT anofox_tab_vat_is_valid('ESX2482300W')
+----
+true
+
+query I
+SELECT anofox_tab_vat_is_valid('ESX2482300A')
+----
+false
+
+# Spain - CIF (companies, digit or letter check)
+query I
+SELECT anofox_tab_vat_is_valid('ESA13585625')
+----
+true
+
+query I
+SELECT anofox_tab_vat_is_valid('ESA1358562E')
+----
+true
+
+query I
+SELECT anofox_tab_vat_is_valid('ESA13585624')
+----
+false
+
+# Finland (weighted mod 11)
+query I
+SELECT anofox_tab_vat_is_valid('FI13669598')
+----
+true
+
+query I
+SELECT anofox_tab_vat_is_valid('FI13669597')
+----
+false
+
+# France (numeric key: (12 + 3 * (SIREN mod 97)) mod 97)
+query I
+SELECT anofox_tab_vat_is_valid('FR40303265045')
+----
+true
+
+query I
+SELECT anofox_tab_vat_is_valid('FR41303265045')
+----
+false
+
+# Greece (weights 256..2, mod 11 mod 10) - EL alias and GR both accepted
+query I
+SELECT anofox_tab_vat_is_valid('EL123456783')
+----
+true
+
+query I
+SELECT anofox_tab_vat_is_valid('GR123456783')
+----
+true
+
+query I
+SELECT anofox_tab_vat_is_valid('EL123456784')
+----
+false
+
+# Ireland - new style (7 digits + check letter)
+query I
+SELECT anofox_tab_vat_is_valid('IE6433435F')
+----
+true
+
+query I
+SELECT anofox_tab_vat_is_valid('IE6433435E')
+----
+false
+
+# Ireland - new style with trailing letter
+query I
+SELECT anofox_tab_vat_is_valid('IE6433435OA')
+----
+true
+
+# Ireland - old style (second character is a letter)
+query I
+SELECT anofox_tab_vat_is_valid('IE8D79739I')
+----
+true
+
+query I
+SELECT anofox_tab_vat_is_valid('IE8D79739J')
+----
+false
+
+# Italy (Luhn) - official-style example
+query I
+SELECT anofox_tab_vat_is_valid('IT00743110157')
+----
+true
+
+query I
+SELECT anofox_tab_vat_is_valid('IT00743110158')
+----
+false
+
+# Luxembourg (first 6 mod 89 == last 2)
+query I
+SELECT anofox_tab_vat_is_valid('LU10000356')
+----
+true
+
+query I
+SELECT anofox_tab_vat_is_valid('LU10000355')
+----
+false
+
+# Netherlands - legacy BSN mod-11 path
+query I
+SELECT anofox_tab_vat_is_valid('NL004495445B01')
+----
+true
+
+query I
+SELECT anofox_tab_vat_is_valid('NL004495444B01')
+----
+false
+
+# Netherlands - post-2020 mod-97 path (fails mod-11, passes mod 97-10 on 'NL'+number)
+query I
+SELECT anofox_tab_vat_is_valid('NL111111111B40')
+----
+true
+
+query I
+SELECT anofox_tab_vat_is_valid('NL111111111B41')
+----
+false
+
+# Poland (weighted mod 11)
+query I
+SELECT anofox_tab_vat_is_valid('PL8567346215')
+----
+true
+
+query I
+SELECT anofox_tab_vat_is_valid('PL8567346216')
+----
+false
+
+# Portugal (weighted mod 11)
+query I
+SELECT anofox_tab_vat_is_valid('PT501964843')
+----
+true
+
+query I
+SELECT anofox_tab_vat_is_valid('PT501964844')
+----
+false
+
+# Sweden (Luhn over first 10 digits)
+query I
+SELECT anofox_tab_vat_is_valid('SE123456789701')
+----
+true
+
+query I
+SELECT anofox_tab_vat_is_valid('SE123456789601')
+----
+false
+
+# Slovenia (weighted mod 11)
+query I
+SELECT anofox_tab_vat_is_valid('SI50223054')
+----
+true
+
+query I
+SELECT anofox_tab_vat_is_valid('SI50223055')
+----
+false
+
+# ============================================================================
+# Countries without an implemented checksum stay syntax-only
+# ============================================================================
+
+query I
+SELECT anofox_tab_vat_is_valid('CZ12345678')
+----
+true
+
+query I
+SELECT anofox_tab_vat_is_valid('HU12345678')
+----
+true
+
+# ============================================================================
+# vat_is_valid_syntax stays syntax-only; vat_is_valid adds the checksum
+# ============================================================================
+
+# DE123456789 has valid syntax but an invalid check digit
+query I
+SELECT anofox_tab_vat_is_valid_syntax('DE123456789')
+----
+true
+
+query I
+SELECT anofox_tab_vat_is_valid('DE123456789')
+----
+false
+
+# ============================================================================
+# Country-code normalization (lowercase + EL/XI aliases)
+# ============================================================================
+
+query I
+SELECT anofox_tab_is_valid_vat_country('de')
+----
+true
+
+query I
+SELECT anofox_tab_is_valid_vat_country('EL')
+----
+true
+
+query I
+SELECT anofox_tab_is_valid_vat_country('xi')
+----
+true
+
+query I
+SELECT anofox_tab_is_valid_vat_country('XX')
+----
+false
+
+query I
+SELECT anofox_tab_vat_is_eu_member('EL')
+----
+true
+
+query I
+SELECT anofox_tab_vat_is_eu_member('el')
+----
+true
+
+# XI maps to GB, which is not an EU member
+query I
+SELECT anofox_tab_vat_is_eu_member('XI')
+----
+false
+
+query T
+SELECT anofox_tab_vat_country_name('el')
+----
+Greece
+
+query T
+SELECT anofox_tab_vat_country_name('de')
+----
+Germany


### PR DESCRIPTION
## Summary

Resolves the VAT module findings from the 2026-06 code review (section 2.10): `vat_format` was a public stub that always returned NULL, `vat_is_valid` was syntax-only despite the registry modeling `has_checksum`, and the country utilities rejected natural inputs like `'de'` and `'EL'`.

All findings were re-verified against current `main` before implementation — none had been fixed in the meantime.

### Changes

- **`anofox_tab_vat_format` implemented** with two styles (case-insensitive): `'plain'` (digits only) and `'iso'` (VAT country prefix + digits, i.e. `EL` for Greece, `XI` for GB). Unparseable VATs return NULL; unknown styles raise `InvalidInputException`. Reuses `SplitVAT`/`ConvertISOToVAT`/`SetStringResult` and the existing `IterateTwoStringInputs` helper.
- **Check-digit validation** added in new `src/anofox_vat_checksum.cpp`; `anofox_tab_vat_is_valid` now = syntax AND checksum, while `anofox_tab_vat_is_valid_syntax` stays syntax-only.
- **`NormalizeCountryCode` centralized** (uppercase + `EL`→`GR`, `XI`→`GB`) and used in `is_valid_vat_country`, `vat_is_eu_member`, `vat_country_name`.
- **Perf/UB fixes:** anchored syntax regexes precompiled once at registry init (`std::regex::optimize`); `<cctype>` calls in `NormalizeVAT` now cast to `unsigned char`; output reserved.
- **Tests:** new `test/sql/anofox_vat_checksum.test` (66 assertions); the legacy `anofox_vat.test` had been `mode skip` since the module's first commit — it is now enabled with corrected expectations (it contained latent wrong expectations, e.g. counting 29 codes in a 28-code list).
- **Docs:** README + `docs/API_REFERENCE.md` updated with styles, checksum country list, and alias/lowercase behavior.

### Checksum coverage

Implemented and verified with known-valid public vectors plus altered-check-digit negatives (each country has both in the tests):

| Country | Algorithm | Valid vector |
|---|---|---|
| AT | weighted Luhn variant, (96 − sum) mod 10 | ATU13585627 |
| BE | 97 − (first 8 mod 97) | BE0776091951 |
| DE | ISO 7064 MOD 11,10 | DE111111125 (official example) |
| DK | weights 2,7,6,5,4,3,2,1, mod 11 = 0 | DK13585628 |
| ES | NIF mod-23 letter, NIE (X/Y/Z), CIF Luhn digit/letter | ES54362315K, ESX2482300W, ESA13585625 |
| FI | weights 7,9,10,5,8,4,2 mod 11 | FI13669598 |
| FR | key = (12 + 3·(SIREN mod 97)) mod 97 | FR40303265045 |
| GR/EL | weights 256..2, mod 11 mod 10 | EL123456783 |
| IE | mod-23 letter (old + new style, optional 2nd letter) | IE6433435F, IE8D79739I, IE6433435OA |
| IT | Luhn | IT00743110157 |
| LU | first 6 mod 89 = last 2 | LU10000356 |
| NL | BSN mod-11 OR ISO 7064 MOD 97-10 over 'NL'+number (post-2020) | NL004495445B01, NL111111111B40 |
| PL | weights 6,5,7,2,3,4,5,6,7 mod 11 | PL8567346215 |
| PT | weights 9..2, (11 − r) mod 11 mod 10 | PT501964843 |
| SE | Luhn over first 10 digits | SE123456789701 |
| SI | weights 8..2, (11 − r) mod 11 mod 10 | SI50223054 |

Left syntax-only (with `has_checksum` honestly set to `false` instead of the previous over-claiming `true`): BG, CY, CZ, EE, GB, HR, HU, LT, LV, MT, RO, SK — no algorithm I could verify against trustworthy public vectors. French keys containing letters are accepted without check-digit verification (no verifiable public algorithm for the alphanumeric keys).

### Red state (TDD)

First commit (8256681) contains only the failing tests. Against unmodified `main` code:

```
SELECT anofox_tab_vat_format('de 123-456-789', 'plain');
Mismatch on row 1: NULL <> 123456789
test cases: 1 | 1 failed
```

```
fmt,bad_checksum_accepted,lowercase_country,el_alias,el_eu
NULL,true,false,false,false
```

(`vat_format` → NULL, `vat_is_valid('DE123456789')` → true despite invalid check digit, `is_valid_vat_country('de')`/`('EL')` and `vat_is_eu_member('EL')` → false.)

The regex-precompilation and cctype fixes are behavior-preserving and covered by the suite staying green.

### Test status

`make test`: **All tests passed (1 skipped test, 1737 assertions in 17 test cases)** — the only skip is the pre-existing `require-env OPENVINO_AVAILABLE`.

Closes #53
