### PR TITLE
fix: diff NULL-safe keys, bind-time schema validation, honest hashdiff params

### DIFF
--- a/README.md
+++ b/README.md
@@ -577,14 +577,15 @@ FROM outlier_tree('employees', 'job_title,salary,years_exp', 'outliers');
 Compare tables and identify changes:
 
 ```sql
--- Hash-based diff (fast, summary statistics)
-SELECT * FROM diff_hashdiff('source_tbl', 'target_tbl', ['id']);
--- Returns: {added: 150, removed: 25, changed: 300, unchanged: 10000}
-
--- Join-based diff (detailed, row-level changes)
+-- Join-based diff (row-level changes)
 SELECT * FROM diff_joindiff('source_tbl', 'target_tbl', ['user_id', 'date'])
 WHERE diff_type IN ('added', 'changed')
 LIMIT 100;
+
+-- diff_hashdiff currently computes the same row-level diff as diff_joindiff.
+-- Its bisection_threshold/bisection_factor parameters are not implemented and
+-- are rejected with a binder error.
+SELECT * FROM diff_hashdiff('source_tbl', 'target_tbl', ['id']);
 ```
 
 **Use Cases:**
@@ -595,7 +596,10 @@ LIMIT 100;
 
 **Features:**
 - Single and compound primary keys
-- Column-specific comparison
+- NULL-safe primary key matching (`IS NOT DISTINCT FROM`): rows with NULL key
+  values are matched across sides instead of being misreported as added/removed
+- Column-specific comparison (default: all non-key columns shared by both tables)
+- Primary key and compare columns are validated against both schemas at bind time
 - Efficient SQL-based implementation
 - Detailed change tracking
 
@@ -1010,8 +1014,8 @@ metric_isolation_forest(
 
 | Function | Signature | Description |
 |----------|-----------|-------------|
-| `anofox_tab_diff_hashdiff` | `(source VARCHAR, target VARCHAR, pk_cols LIST<VARCHAR> [, compare_cols LIST<VARCHAR>]) → TABLE` | Fast hash-based summary diff |
-| `anofox_tab_diff_joindiff` | `(source VARCHAR, target VARCHAR, pk_cols LIST<VARCHAR> [, compare_cols LIST<VARCHAR>]) → TABLE` | Detailed row-level diff with source/target data |
+| `anofox_tab_diff_hashdiff` | `(source VARCHAR, target VARCHAR, pk VARCHAR\|LIST<VARCHAR>) → TABLE` | Row-level diff (currently identical to joindiff; `bisection_threshold`/`bisection_factor` are not implemented and rejected) |
+| `anofox_tab_diff_joindiff` | `(source VARCHAR, target VARCHAR, pk VARCHAR\|LIST<VARCHAR> [, compare_cols LIST<VARCHAR> [, include_all BOOLEAN]]) → TABLE` | Detailed row-level diff with target data |
 
 ### Data Profiling Functions
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1704,73 +1704,80 @@ Compare tables and identify changes for migration validation and regression test
 
 ### Functions
 
-#### `anofox_tab_diff_ (alias: diff_hashdiff`
+#### `anofox_tab_diff_joindiff` (alias: `diff_joindiff`)
 
-Fast hash-based summary diff (efficient for large tables).
+Detailed row-level diff between two tables or views.
 
 **Signature:**
 ```sql
-anofox_tab_diff_ (alias: diff_hashdiff(
+anofox_tab_diff_joindiff(
     source VARCHAR,
     target VARCHAR,
-    pk_cols LIST<VARCHAR>
-    [, compare_cols LIST<VARCHAR>]
+    primary_key VARCHAR | LIST<VARCHAR>
+    [, compare_columns LIST<VARCHAR>]
+    [, include_all BOOLEAN]
 ) → TABLE
 ```
 
 **Parameters:**
-- `source`: Source table name
-- `target`: Target table name
-- `pk_cols`: Primary key columns for matching rows
-- `compare_cols`: Optional list of columns to compare (default: all columns)
+- `source`: Source table or view name
+- `target`: Target table or view name
+- `primary_key`: Primary key column(s) for matching rows (single name or list)
+- `compare_columns`: Optional list of columns to compare (default: all
+  non-key columns present in both tables)
+- `include_all`: Include `unchanged` rows in the output (default: `false`)
 
-**Returns:**
-```sql
-TABLE(
-    added BIGINT,
-    removed BIGINT,
-    changed BIGINT,
-    unchanged BIGINT
-)
-```
-
-**Example:**
-```sql
-SELECT * FROM anofox_tab_diff_ (alias: diff_hashdiff('source_tbl', 'target_tbl', ['id']);
--- Returns: {added: 150, removed: 25, changed: 300, unchanged: 10000}
-```
-
----
-
-#### `anofox_tab_diff_ (alias: diff_joindiff`
-
-Detailed row-level diff with source/target data (slower but comprehensive).
-
-**Signature:**
-```sql
-anofox_tab_diff_ (alias: diff_joindiff(
-    source VARCHAR,
-    target VARCHAR,
-    pk_cols LIST<VARCHAR>
-    [, compare_cols LIST<VARCHAR>]
-) → TABLE
-```
+**Semantics:**
+- Primary keys are matched NULL-safely (`IS NOT DISTINCT FROM`), so rows with
+  NULL key values are compared across sides instead of being misreported as
+  added/removed.
+- Primary key and compare columns are validated against both table schemas at
+  bind time; missing columns or tables produce a clear binder error.
 
 **Returns:**
 ```sql
 TABLE(
     diff_type VARCHAR,      -- 'added', 'removed', 'changed', 'unchanged'
-    row_id BIGINT,          -- Row identifier
-    source_* VARCHAR,       -- Source column values (prefixed with 'source_')
-    target_* VARCHAR        -- Target column values (prefixed with 'target_')
+    <primary key columns>,  -- COALESCE of source/target key values
+    <target columns>        -- remaining target columns (NULL for removed rows)
 )
 ```
 
 **Example:**
 ```sql
-SELECT * FROM anofox_tab_diff_ (alias: diff_joindiff('source_tbl', 'target_tbl', ['user_id', 'date'])
+SELECT * FROM diff_joindiff('source_tbl', 'target_tbl', ['user_id', 'date'])
 WHERE diff_type IN ('added', 'changed')
 LIMIT 100;
+```
+
+---
+
+#### `anofox_tab_diff_hashdiff` (alias: `diff_hashdiff`)
+
+Row-level diff between two tables or views. Currently computes exactly the
+same result as `diff_joindiff` (without `compare_columns`/`include_all`).
+
+**Signature:**
+```sql
+anofox_tab_diff_hashdiff(
+    source VARCHAR,
+    target VARCHAR,
+    primary_key VARCHAR | LIST<VARCHAR>
+) → TABLE
+```
+
+**Parameters:**
+- `source`: Source table or view name
+- `target`: Target table or view name
+- `primary_key`: Primary key column(s) for matching rows (single name or list)
+
+**Note:** The `bisection_threshold` and `bisection_factor` parameters of the
+hash/bisection algorithm are **not implemented**. Passing them raises a binder
+error instead of being silently ignored.
+
+**Example:**
+```sql
+SELECT * FROM diff_hashdiff('source_tbl', 'target_tbl', ['id']);
 ```
 
 ---
@@ -2049,9 +2056,10 @@ SET anofox_telemetry_key = 'your_custom_key';
    - Use `'summary'` output mode for large tables to reduce memory usage
 
 9. **Data diffing**:
-   - `anofox_tab_diff_ (alias: diff_hashdiff`: Fast, O(n) complexity, returns summary statistics only
-   - `anofox_tab_diff_ (alias: diff_joindiff`: Slower, O(n log n) complexity, returns detailed row-level changes
-   - Both functions support compound primary keys
+   - `anofox_tab_diff_joindiff` (alias `diff_joindiff`): detailed row-level changes
+   - `anofox_tab_diff_hashdiff` (alias `diff_hashdiff`): currently identical to
+     `diff_joindiff`; the bisection parameters are not implemented and rejected
+   - Both functions support compound primary keys and match keys NULL-safely
 
 ---
 

--- a/python/src/anofox/diff.py
+++ b/python/src/anofox/diff.py
@@ -92,9 +92,11 @@ def hashdiff(
     primary_keys:
         Column name(s) forming the primary key.
     bisection_threshold:
-        Row-count threshold for bisection (optional).
+        Row-count threshold for bisection. Not implemented yet — passing a
+        value raises a DuckDB binder error.
     bisection_factor:
-        Bisection factor (optional, requires bisection_threshold).
+        Bisection factor (requires bisection_threshold). Not implemented
+        yet — passing a value raises a DuckDB binder error.
 
     Returns
     -------
@@ -132,5 +134,5 @@ def _format_pk(primary_keys: Union[str, list[str]]) -> str:
         return f"'{primary_keys}'"
     if len(primary_keys) == 1:
         return f"'{primary_keys[0]}'"
-    # Compound key — join as CSV string
-    return f"'{','.join(primary_keys)}'"
+    # Compound key — pass as a LIST<VARCHAR> literal
+    return "[" + ", ".join(f"'{k}'" for k in primary_keys) + "]"

--- a/python/tests/test_diff.py
+++ b/python/tests/test_diff.py
@@ -102,10 +102,27 @@ class TestHashdiff:
         result = diff.hashdiff(conn, src, tgt, primary_keys="id")
         assert len(result) > 0
 
-    def test_with_bisection_threshold(self, conn, diff_tables):
+    def test_compound_primary_key(self, conn, diff_tables):
         import pandas as pd
         from anofox import diff
         src, tgt = diff_tables
-        # bisection_threshold is optional — exercise the parameter path
-        result = diff.hashdiff(conn, src, tgt, primary_keys="id", bisection_threshold=1000)
+        result = diff.hashdiff(conn, src, tgt, primary_keys=["id", "name"])
         assert isinstance(result, pd.DataFrame)
+        assert len(result) > 0
+
+    def test_bisection_threshold_rejected(self, conn, diff_tables):
+        from anofox import diff
+        src, tgt = diff_tables
+        # The bisection algorithm is not implemented; the extension rejects
+        # the parameters with a clear binder error instead of ignoring them.
+        with pytest.raises(Exception, match="bisection"):
+            diff.hashdiff(conn, src, tgt, primary_keys="id", bisection_threshold=1000)
+
+    def test_bisection_factor_rejected(self, conn, diff_tables):
+        from anofox import diff
+        src, tgt = diff_tables
+        with pytest.raises(Exception, match="bisection"):
+            diff.hashdiff(
+                conn, src, tgt, primary_keys="id",
+                bisection_threshold=1000, bisection_factor=5,
+            )

--- a/src/anofox_diff.cpp
+++ b/src/anofox_diff.cpp
@@ -3,15 +3,19 @@
 #include "anofox_sql_utils.hpp"
 #include "telemetry.hpp"
 
+#include "duckdb/catalog/catalog.hpp"
+#include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
+#include "duckdb/catalog/catalog_entry/view_catalog_entry.hpp"
+#include "duckdb/catalog/entry_lookup_info.hpp"
 #include "duckdb/common/string_util.hpp"
 #include "duckdb/common/types/value.hpp"
 #include "duckdb/function/table_function.hpp"
 #include "duckdb/parser/parser.hpp"
+#include "duckdb/parser/qualified_name.hpp"
 #include "duckdb/parser/tableref/subqueryref.hpp"
 #include "duckdb/parser/parsed_data/create_table_function_info.hpp"
 #include "duckdb/main/client_context.hpp"
 
-#include <algorithm>
 #include <string>
 #include <unordered_set>
 
@@ -20,45 +24,17 @@ namespace anofox {
 
 namespace {
 
-constexpr const char *DIFF_TYPE_ADDED = "added";
-constexpr const char *DIFF_TYPE_REMOVED = "removed";
-constexpr const char *DIFF_TYPE_CHANGED = "changed";
-constexpr const char *DIFF_TYPE_UNCHANGED = "unchanged";
-
-//===--------------------------------------------------------------------===//
-// Diff Function Bind Data
-//===--------------------------------------------------------------------===//
-struct DiffFunctionBindData : public TableFunctionData {
-	vector<string> primary_keys;
-	vector<string> compare_columns;
-	bool include_all;
-
-	DiffFunctionBindData(vector<string> pks, vector<string> cols, bool include_all_rows)
-	    : primary_keys(std::move(pks)), compare_columns(std::move(cols)), include_all(include_all_rows) {
-	}
-};
-
-//===--------------------------------------------------------------------===//
-// Diff Function Local State
-//===--------------------------------------------------------------------===//
-struct DiffFunctionLocalState : public LocalTableFunctionState {
-	DiffFunctionLocalState() : initialized(false), finished(false) {
-	}
-
-	bool initialized;
-	bool finished;
-	idx_t current_row;
-};
-
 //===--------------------------------------------------------------------===//
 // Helper Functions
 //===--------------------------------------------------------------------===//
-static unique_ptr<LocalTableFunctionState> DiffLocalInit(ExecutionContext &context, TableFunctionInitInput &input,
-                                                         GlobalTableFunctionState *global_state) {
-	return make_uniq<DiffFunctionLocalState>();
-}
 
-static vector<string> ParseColumnList(const Value &column_value) {
+// Marker columns used to track row presence on each side of the FULL OUTER
+// JOIN. Unlike "first primary key IS NULL" checks, the markers stay correct
+// when primary key values themselves are NULL.
+constexpr const char *SOURCE_PRESENT_MARKER = "__anofox_diff_s_present";
+constexpr const char *TARGET_PRESENT_MARKER = "__anofox_diff_t_present";
+
+vector<string> ParseColumnList(const Value &column_value) {
 	vector<string> result;
 	if (column_value.IsNull()) {
 		return result;
@@ -80,125 +56,103 @@ static vector<string> ParseColumnList(const Value &column_value) {
 	return result;
 }
 
-static void ValidatePrimaryKeys(const vector<string> &primary_keys, const vector<string> &available_columns,
-                               const string &table_name) {
-	if (primary_keys.empty()) {
-		throw InvalidInputException("Primary key(s) must be specified for data diff");
+// Resolve the column names of a table or view through the catalog so schema
+// problems surface as clear binder errors instead of confusing errors from
+// the generated SQL.
+vector<string> GetRelationColumnNames(ClientContext &context, const string &function_name, const string &table_name) {
+	auto qname = QualifiedName::Parse(table_name);
+	EntryLookupInfo lookup_info(CatalogType::TABLE_ENTRY, qname.name);
+	auto entry = Catalog::GetEntry(context, qname.catalog, qname.schema, lookup_info, OnEntryNotFound::RETURN_NULL);
+	if (!entry) {
+		throw BinderException("%s: table or view '%s' does not exist", function_name, table_name);
 	}
 
-	std::unordered_set<string> available_set(available_columns.begin(), available_columns.end());
+	vector<string> result;
+	if (entry->type == CatalogType::TABLE_ENTRY) {
+		auto &table = entry->Cast<TableCatalogEntry>();
+		for (auto &col : table.GetColumns().Logical()) {
+			result.push_back(col.Name());
+		}
+	} else if (entry->type == CatalogType::VIEW_ENTRY) {
+		auto &view = entry->Cast<ViewCatalogEntry>();
+		view.BindView(context);
+		auto column_info = view.GetColumnInfo();
+		if (!column_info) {
+			throw BinderException("%s: unable to resolve the columns of view '%s'", function_name, table_name);
+		}
+		for (idx_t i = 0; i < column_info->names.size(); i++) {
+			result.push_back(i < view.aliases.size() ? view.aliases[i] : column_info->names[i]);
+		}
+	} else {
+		throw BinderException("%s: '%s' is not a table or view", function_name, table_name);
+	}
+	return result;
+}
 
+// DuckDB matches identifiers case-insensitively, so validation does too.
+std::unordered_set<string> MakeColumnSet(const vector<string> &columns) {
+	std::unordered_set<string> result;
+	for (const auto &col : columns) {
+		result.insert(StringUtil::Lower(col));
+	}
+	return result;
+}
+
+void ValidatePrimaryKeys(const string &function_name, const vector<string> &primary_keys,
+                         const std::unordered_set<string> &available_columns, const string &side,
+                         const string &table_name) {
 	for (const auto &pk : primary_keys) {
-		if (available_set.find(pk) == available_set.end()) {
-			throw InvalidInputException("Primary key column '%s' not found in %s table", pk, table_name);
+		if (available_columns.find(StringUtil::Lower(pk)) == available_columns.end()) {
+			throw BinderException("%s: Primary key column '%s' not found in %s table '%s'", function_name, pk, side,
+			                      table_name);
 		}
 	}
 }
 
-static void ValidateCompareColumns(const vector<string> &compare_columns, const vector<string> &available_columns,
-                                  const vector<string> &primary_keys) {
-	if (compare_columns.empty()) {
-		return; // Will use all columns
-	}
-
-	std::unordered_set<string> available_set(available_columns.begin(), available_columns.end());
-
+void ValidateCompareColumns(const string &function_name, const vector<string> &compare_columns,
+                            const std::unordered_set<string> &available_columns, const string &side,
+                            const string &table_name) {
 	for (const auto &col : compare_columns) {
-		if (available_set.find(col) == available_set.end()) {
-			throw InvalidInputException("Compare column '%s' not found in table", col);
+		if (available_columns.find(StringUtil::Lower(col)) == available_columns.end()) {
+			throw BinderException("%s: Compare column '%s' not found in %s table '%s'", function_name, col, side,
+			                      table_name);
 		}
 	}
 }
 
-//===--------------------------------------------------------------------===//
-// JoinDiff Bind Function
-//===--------------------------------------------------------------------===//
-static unique_ptr<FunctionData> JoinDiffBind(ClientContext &context, TableFunctionBindInput &input,
-                                             vector<LogicalType> &return_types, vector<string> &names) {
-	// Parameters:
-	// 0: source_table (TABLE)
-	// 1: target_table (TABLE)
-	// 2: primary_key(s) (VARCHAR or LIST<VARCHAR>)
-	// 3: compare_columns (LIST<VARCHAR>, optional, default NULL)
-	// 4: include_all (BOOLEAN, optional, default false)
+// Validate the requested key/compare columns against both table schemas and
+// resolve the effective compare set (defaults to the shared non-key columns).
+vector<string> ResolveCompareColumns(ClientContext &context, const string &function_name, const string &source_table,
+                                     const string &target_table, const vector<string> &primary_keys,
+                                     const vector<string> &compare_columns) {
+	auto source_columns = GetRelationColumnNames(context, function_name, source_table);
+	auto target_columns = GetRelationColumnNames(context, function_name, target_table);
+	auto source_set = MakeColumnSet(source_columns);
+	auto target_set = MakeColumnSet(target_columns);
 
-	if (input.inputs.size() < 3) {
-		throw InvalidInputException("anofox_diff_joindiff requires at least 3 arguments: source_table, target_table, primary_key(s)");
+	ValidatePrimaryKeys(function_name, primary_keys, source_set, "source", source_table);
+	ValidatePrimaryKeys(function_name, primary_keys, target_set, "target", target_table);
+
+	if (!compare_columns.empty()) {
+		ValidateCompareColumns(function_name, compare_columns, source_set, "source", source_table);
+		ValidateCompareColumns(function_name, compare_columns, target_set, "target", target_table);
+		return compare_columns;
 	}
 
-	// Parse primary keys
-	vector<string> primary_keys = ParseColumnList(input.inputs[2]);
-	if (primary_keys.empty()) {
-		throw InvalidInputException("Primary key(s) cannot be empty");
+	// Default: compare every non-key column the two tables share, in target
+	// column order (the output projects the target side)
+	auto pk_set = MakeColumnSet(primary_keys);
+	vector<string> shared_columns;
+	for (const auto &col : target_columns) {
+		auto lower = StringUtil::Lower(col);
+		if (pk_set.find(lower) != pk_set.end()) {
+			continue;
+		}
+		if (source_set.find(lower) != source_set.end()) {
+			shared_columns.push_back(col);
+		}
 	}
-
-	// Parse compare columns (optional)
-	vector<string> compare_columns;
-	if (input.inputs.size() > 3 && !input.inputs[3].IsNull()) {
-		compare_columns = ParseColumnList(input.inputs[3]);
-	}
-
-	// Parse include_all (optional, default false)
-	bool include_all = false;
-	if (input.inputs.size() > 4 && !input.inputs[4].IsNull()) {
-		include_all = input.inputs[4].GetValue<bool>();
-	}
-
-	// Output schema: diff_type + primary keys + compared columns
-	return_types.emplace_back(LogicalType(LogicalTypeId::VARCHAR));
-	names.emplace_back("diff_type");
-
-	// For now, we'll determine the actual schema dynamically during execution
-	// This is a simplified bind - in practice, we need access to the input table schemas
-
-	// LogMessage(context, "diff", "Binding JoinDiff with %zu primary key(s), %zu compare column(s), include_all=%d",
-	//           primary_keys.size(), compare_columns.size(), include_all);
-
-	return make_uniq<DiffFunctionBindData>(std::move(primary_keys), std::move(compare_columns), include_all);
-}
-
-//===--------------------------------------------------------------------===//
-// JoinDiff In-Out Function
-//===--------------------------------------------------------------------===//
-static OperatorResultType JoinDiffFunction(ExecutionContext &context, TableFunctionInput &data_p, DataChunk &input,
-                                          DataChunk &output) {
-	auto &bind_data = data_p.bind_data->Cast<DiffFunctionBindData>();
-	auto &local_state = data_p.local_state->Cast<DiffFunctionLocalState>();
-
-	if (local_state.finished) {
-		output.SetCardinality(0);
-		return OperatorResultType::FINISHED;
-	}
-
-	if (!local_state.initialized) {
-		// LogMessage(context.client, "diff", "Initializing JoinDiff function");
-		local_state.initialized = true;
-		local_state.current_row = 0;
-	}
-
-	// TODO: Implement actual FULL OUTER JOIN logic
-	// For now, return empty result set
-	output.SetCardinality(0);
-	local_state.finished = true;
-
-	return OperatorResultType::FINISHED;
-}
-
-//===--------------------------------------------------------------------===//
-// JoinDiff Finalize Function
-//===--------------------------------------------------------------------===//
-static OperatorFinalizeResultType JoinDiffFinalize(ExecutionContext &context, TableFunctionInput &data_p,
-                                                   DataChunk &output) {
-	auto &local_state = data_p.local_state->Cast<DiffFunctionLocalState>();
-
-	if (local_state.finished) {
-		return OperatorFinalizeResultType::FINISHED;
-	}
-
-	output.SetCardinality(0);
-	local_state.finished = true;
-
-	return OperatorFinalizeResultType::FINISHED;
+	return shared_columns;
 }
 
 } // anonymous namespace
@@ -220,13 +174,15 @@ static unique_ptr<SubqueryRef> ParseSubquery(const string &query, const ParserOp
 static string GenerateJoinDiffSQL(const string &source_table, const string &target_table,
                                   const vector<string> &primary_keys, const vector<string> &compare_columns,
                                   bool include_all) {
-	// Build the primary key join condition
+	// NULL-safe primary key join condition: rows whose key components are
+	// NULL still match their counterpart on the other side
 	string pk_join_condition;
 	for (size_t i = 0; i < primary_keys.size(); i++) {
 		if (i > 0) {
 			pk_join_condition += " AND ";
 		}
-		pk_join_condition += "s." + QuoteSqlIdentifier(primary_keys[i]) + " = t." + QuoteSqlIdentifier(primary_keys[i]);
+		pk_join_condition += "s." + QuoteSqlIdentifier(primary_keys[i]) + " IS NOT DISTINCT FROM t." +
+		                     QuoteSqlIdentifier(primary_keys[i]);
 	}
 
 	// Build the COALESCE expressions for primary keys
@@ -239,25 +195,22 @@ static string GenerateJoinDiffSQL(const string &source_table, const string &targ
 		             ") AS " + QuoteSqlIdentifier(primary_keys[i]);
 	}
 
-	// Generate the diff query
+	// Classify rows via the side-presence markers (robust against NULL keys)
 	string sql = "SELECT ";
 	sql += "CASE ";
-	sql += "WHEN s." + QuoteSqlIdentifier(primary_keys[0]) + " IS NULL THEN 'added' ";
-	sql += "WHEN t." + QuoteSqlIdentifier(primary_keys[0]) + " IS NULL THEN 'removed' ";
+	sql += "WHEN s." + string(SOURCE_PRESENT_MARKER) + " IS NULL THEN 'added' ";
+	sql += "WHEN t." + string(TARGET_PRESENT_MARKER) + " IS NULL THEN 'removed' ";
 
-	// For comparison, we need to check if any non-PK columns differ
-	// Simplified: use a hash-based comparison
-	if (compare_columns.empty()) {
-		// Compare all columns (approximation using struct comparison)
-		sql += "WHEN s IS DISTINCT FROM t THEN 'changed' ";
-	} else {
-		// Compare specific columns
+	// Compare the resolved columns one by one; the compare set was validated
+	// against both schemas at bind time
+	if (!compare_columns.empty()) {
 		sql += "WHEN (";
 		for (size_t i = 0; i < compare_columns.size(); i++) {
 			if (i > 0) {
 				sql += " OR ";
 			}
-			sql += "s." + QuoteSqlIdentifier(compare_columns[i]) + " IS DISTINCT FROM t." + QuoteSqlIdentifier(compare_columns[i]);
+			sql += "s." + QuoteSqlIdentifier(compare_columns[i]) + " IS DISTINCT FROM t." +
+			       QuoteSqlIdentifier(compare_columns[i]);
 		}
 		sql += ") THEN 'changed' ";
 	}
@@ -265,20 +218,22 @@ static string GenerateJoinDiffSQL(const string &source_table, const string &targ
 	sql += "ELSE 'unchanged' END AS diff_type, ";
 	sql += pk_select;
 
-	// Add all columns from target except primary keys (showing target values for changed rows)
+	// Add all columns from target except primary keys and the presence marker
+	// (showing target values for changed rows)
 	sql += ", t.* EXCLUDE (";
+	sql += string(TARGET_PRESENT_MARKER);
 	for (size_t i = 0; i < primary_keys.size(); i++) {
-		if (i > 0) {
-			sql += ", ";
-		}
-		sql += QuoteSqlIdentifier(primary_keys[i]);
+		sql += ", " + QuoteSqlIdentifier(primary_keys[i]);
 	}
 	sql += ")";
 
-	// Reference both tables via query_table() so hostile and schema-qualified
-	// names are handled by the shared quoting helpers
-	sql += " FROM " + BuildQueryTableRef(source_table) + " s ";
-	sql += "FULL OUTER JOIN " + BuildQueryTableRef(target_table) + " t ";
+	// Wrap each side with a constant presence marker; table references go
+	// through query_table() so hostile and schema-qualified names are handled
+	// by the shared quoting helpers
+	sql += " FROM (SELECT true AS " + string(SOURCE_PRESENT_MARKER) + ", * FROM " + BuildQueryTableRef(source_table) +
+	       ") s ";
+	sql += "FULL OUTER JOIN (SELECT true AS " + string(TARGET_PRESENT_MARKER) + ", * FROM " +
+	       BuildQueryTableRef(target_table) + ") t ";
 	sql += "ON " + pk_join_condition;
 
 	if (!include_all) {
@@ -298,7 +253,7 @@ static unique_ptr<TableRef> JoinDiffBindReplace(ClientContext &context, TableFun
 	// 4: include_all (BOOLEAN, optional)
 
 	if (input.inputs.size() < 3) {
-		throw BinderException("anofox_diff_joindiff requires at least 3 arguments: source_table, target_table, primary_key(s)");
+		throw BinderException("diff_joindiff requires at least 3 arguments: source_table, target_table, primary_key(s)");
 	}
 
 	// Parse source and target table names
@@ -316,24 +271,20 @@ static unique_ptr<TableRef> JoinDiffBindReplace(ClientContext &context, TableFun
 	}
 
 	// Parse compare columns (optional)
-	// Note: param 3 could also be bisection_threshold (BIGINT) for HashDiff compat
 	vector<string> compare_columns;
 	if (input.inputs.size() > 3 && !input.inputs[3].IsNull()) {
-		// Check type - LIST means compare_columns, BIGINT means bisection_threshold (ignore)
-		if (input.inputs[3].type().id() == LogicalTypeId::LIST) {
-			compare_columns = ParseColumnList(input.inputs[3]);
-		}
+		compare_columns = ParseColumnList(input.inputs[3]);
 	}
 
 	// Parse include_all (optional, default false)
-	// Note: param 4 could also be bisection_factor (BIGINT) for HashDiff compat
 	bool include_all = false;
 	if (input.inputs.size() > 4 && !input.inputs[4].IsNull()) {
-		// Check type - BOOLEAN means include_all, BIGINT means bisection_factor (ignore)
-		if (input.inputs[4].type().id() == LogicalTypeId::BOOLEAN) {
-			include_all = input.inputs[4].GetValue<bool>();
-		}
+		include_all = input.inputs[4].GetValue<bool>();
 	}
+
+	// Validate both schemas and resolve the effective compare set
+	compare_columns = ResolveCompareColumns(context, "diff_joindiff", source_table, target_table, primary_keys,
+	                                        compare_columns);
 
 	// Generate SQL query
 	string sql = GenerateJoinDiffSQL(source_table, target_table, primary_keys, compare_columns, include_all);
@@ -347,11 +298,18 @@ static unique_ptr<TableRef> JoinDiffBindReplace(ClientContext &context, TableFun
 // HashDiff bind_replace - wraps JoinDiff with separate telemetry tracking
 static unique_ptr<TableRef> HashDiffBindReplace(ClientContext &context, TableFunctionBindInput &input) {
 	PostHogTelemetry::Instance().CaptureFunctionExecution("diff_hashdiff");
-	// Currently, HashDiff uses the same logic as JoinDiff
-	// But we track it separately for telemetry purposes
+	// HashDiff currently executes the same NULL-safe full outer join plan as
+	// JoinDiff; it is tracked separately for telemetry purposes.
 
 	if (input.inputs.size() < 3) {
-		throw BinderException("anofox_diff_hashdiff requires at least 3 arguments: source_table, target_table, primary_key(s)");
+		throw BinderException("diff_hashdiff requires at least 3 arguments: source_table, target_table, primary_key(s)");
+	}
+
+	// The hash/bisection algorithm behind bisection_threshold/bisection_factor
+	// is not implemented; reject the parameters instead of silently ignoring them
+	if (input.inputs.size() > 3) {
+		throw BinderException("diff_hashdiff: the bisection_threshold/bisection_factor parameters are not implemented "
+		                      "yet; remove them (diff_hashdiff currently computes the same full diff as diff_joindiff)");
 	}
 
 	// Parse source and target table names
@@ -368,13 +326,11 @@ static unique_ptr<TableRef> HashDiffBindReplace(ClientContext &context, TableFun
 		throw BinderException("Primary key(s) cannot be empty");
 	}
 
-	// HashDiff specific parameters (bisection_threshold, bisection_factor) are ignored for now
-	// as we fall back to JoinDiff logic
-	vector<string> compare_columns;
-	bool include_all = false;
+	// Validate both schemas and resolve the compare set (all shared non-key columns)
+	auto compare_columns = ResolveCompareColumns(context, "diff_hashdiff", source_table, target_table, primary_keys, {});
 
 	// Generate SQL query using same logic as JoinDiff
-	string sql = GenerateJoinDiffSQL(source_table, target_table, primary_keys, compare_columns, include_all);
+	string sql = GenerateJoinDiffSQL(source_table, target_table, primary_keys, compare_columns, false);
 
 	// Parse and return as SubqueryRef
 	auto subquery_ref = ParseSubquery(sql, context.GetParserOptions(),
@@ -383,12 +339,13 @@ static unique_ptr<TableRef> HashDiffBindReplace(ClientContext &context, TableFun
 }
 
 void RegisterDiffFunctions(ExtensionLoader &loader) {
-	// Register anofox_tab_diff_joindiff using bind_replace for SQL generation
-	// This accepts table NAMES (VARCHAR) and generates the diff SQL query
+	// The diff functions are implemented purely as bind_replace SQL rewrites:
+	// they accept table NAMES (VARCHAR) and expand into a FULL OUTER JOIN query
+	// that DuckDB optimizes and executes natively.
 
 	// Register anofox_tab_diff_joindiff with all overloads (alias: diff_joindiff)
 	TableFunctionSet joindiff_set("anofox_tab_diff_joindiff");
-	
+
 	// Single primary key overload (VARCHAR primary_key)
 	TableFunction joindiff_single("anofox_tab_diff_joindiff",
 	                             {LogicalType(LogicalTypeId::VARCHAR), LogicalType(LogicalTypeId::VARCHAR),
@@ -466,47 +423,29 @@ void RegisterDiffFunctions(ExtensionLoader &loader) {
 	joindiff_compound_full.named_parameters["compare_columns"] = LogicalType::LIST(LogicalType(LogicalTypeId::VARCHAR));
 	joindiff_compound_full.named_parameters["include_all"] = LogicalType(LogicalTypeId::BOOLEAN);
 	joindiff_set.AddFunction(joindiff_compound_full);
-	
+
 	{
 		FunctionDescription desc;
-		desc.description = "Computes a row-level diff between two tables using a primary key (VARCHAR or VARCHAR[]), returning rows that were added, removed, or changed.";
+		desc.description = "Computes a row-level diff between two tables using a primary key (VARCHAR or VARCHAR[]), returning rows that were added, removed, or changed. Primary keys are matched NULL-safely (IS NOT DISTINCT FROM).";
 		desc.parameter_names = {"source_table", "target_table", "primary_key"};
 		desc.examples = {"SELECT * FROM diff_joindiff('orders_v1', 'orders_v2', 'order_id');",
 		                 "SELECT * FROM diff_joindiff('orders_v1', 'orders_v2', ['order_id', 'line_id']);"};
 		desc.categories = {"diff", "data-quality"};
 
-		CreateTableFunctionInfo joindiff_info(joindiff_set);
-		joindiff_info.descriptions = {std::move(desc)};
-		loader.RegisterFunction(joindiff_info);
+		RegisterTableFunctionSetWithAlias(loader, joindiff_set, "diff_joindiff", {std::move(desc)});
 	}
-
-	// Register alias
-	TableFunctionSet alias_joindiff_set("diff_joindiff");
-	for (const auto &func : joindiff_set.functions) {
-		TableFunction alias_func("diff_joindiff", func.arguments, func.function, func.bind, func.init_global, func.init_local);
-		alias_func.init_global = func.init_global;
-		alias_func.init_local = func.init_local;
-		alias_func.bind_replace = func.bind_replace;
-		alias_func.named_parameters = func.named_parameters;
-		alias_joindiff_set.AddFunction(alias_func);
-	}
-	CreateTableFunctionInfo alias_joindiff_info(alias_joindiff_set);
-	alias_joindiff_info.alias_of = "anofox_tab_diff_joindiff";
-	loader.RegisterFunction(alias_joindiff_info);
 
 	//===--------------------------------------------------------------------===//
 	// HashDiff Function Registration
-	// Note: Currently uses bind_replace like JoinDiff
-	// Full bisection with iterative checksum comparison would require
-	// a different architecture (e.g., external process or UDF)
+	// Note: Currently uses the same bind_replace rewrite as JoinDiff. The
+	// bisection_threshold/bisection_factor overloads remain registered so that
+	// callers get a clear "not implemented" binder error instead of a generic
+	// overload-resolution failure or silently ignored parameters.
 	//===--------------------------------------------------------------------===//
-
-	// For now, HashDiff is an alias to JoinDiff
-	// Future: Implement SQL-based bisection using recursive CTEs
 
 	// Register anofox_tab_diff_hashdiff with all overloads (alias: diff_hashdiff)
 	TableFunctionSet hashdiff_set("anofox_tab_diff_hashdiff");
-	
+
 	// Single PK, basic
 	TableFunction hashdiff_single("anofox_tab_diff_hashdiff",
 	                             {LogicalType(LogicalTypeId::VARCHAR), LogicalType(LogicalTypeId::VARCHAR),
@@ -518,7 +457,7 @@ void RegisterDiffFunctions(ExtensionLoader &loader) {
 	hashdiff_single.named_parameters["primary_key"] = LogicalType(LogicalTypeId::VARCHAR);
 	hashdiff_set.AddFunction(hashdiff_single);
 
-	// Single PK with bisection_threshold (ignored for now)
+	// Single PK with bisection_threshold (rejected as not implemented)
 	TableFunction hashdiff_single_threshold("anofox_tab_diff_hashdiff",
 	                                       {LogicalType(LogicalTypeId::VARCHAR), LogicalType(LogicalTypeId::VARCHAR),
 	                                        LogicalType(LogicalTypeId::VARCHAR), LogicalType(LogicalTypeId::BIGINT)},
@@ -530,7 +469,7 @@ void RegisterDiffFunctions(ExtensionLoader &loader) {
 	hashdiff_single_threshold.named_parameters["bisection_threshold"] = LogicalType(LogicalTypeId::BIGINT);
 	hashdiff_set.AddFunction(hashdiff_single_threshold);
 
-	// Single PK with all parameters (ignored for now)
+	// Single PK with bisection_threshold and bisection_factor (rejected as not implemented)
 	TableFunction hashdiff_single_full("anofox_tab_diff_hashdiff",
 	                                  {LogicalType(LogicalTypeId::VARCHAR), LogicalType(LogicalTypeId::VARCHAR),
 	                                   LogicalType(LogicalTypeId::VARCHAR), LogicalType(LogicalTypeId::BIGINT),
@@ -554,33 +493,17 @@ void RegisterDiffFunctions(ExtensionLoader &loader) {
 	hashdiff_compound.named_parameters["target_table"] = LogicalType(LogicalTypeId::VARCHAR);
 	hashdiff_compound.named_parameters["primary_keys"] = LogicalType::LIST(LogicalType(LogicalTypeId::VARCHAR));
 	hashdiff_set.AddFunction(hashdiff_compound);
-	
+
 	{
 		FunctionDescription desc;
-		desc.description = "Computes a hash-based diff between two tables using a primary key (VARCHAR or VARCHAR[]), returning rows that differ by row hash.";
+		desc.description = "Computes a row-level diff between two tables using a primary key (VARCHAR or VARCHAR[]). Currently identical to diff_joindiff; the bisection_threshold/bisection_factor parameters are not implemented and rejected.";
 		desc.parameter_names = {"source_table", "target_table", "primary_key"};
 		desc.examples = {"SELECT * FROM diff_hashdiff('products_v1', 'products_v2', 'product_id');",
 		                 "SELECT * FROM diff_hashdiff('products_v1', 'products_v2', ['product_id', 'sku']);"};
 		desc.categories = {"diff", "data-quality"};
 
-		CreateTableFunctionInfo hashdiff_info(hashdiff_set);
-		hashdiff_info.descriptions = {std::move(desc)};
-		loader.RegisterFunction(hashdiff_info);
+		RegisterTableFunctionSetWithAlias(loader, hashdiff_set, "diff_hashdiff", {std::move(desc)});
 	}
-
-	// Register alias
-	TableFunctionSet alias_hashdiff_set("diff_hashdiff");
-	for (const auto &func : hashdiff_set.functions) {
-		TableFunction alias_func("diff_hashdiff", func.arguments, func.function, func.bind, func.init_global, func.init_local);
-		alias_func.init_global = func.init_global;
-		alias_func.init_local = func.init_local;
-		alias_func.bind_replace = func.bind_replace;
-		alias_func.named_parameters = func.named_parameters;
-		alias_hashdiff_set.AddFunction(alias_func);
-	}
-	CreateTableFunctionInfo alias_hashdiff_info(alias_hashdiff_set);
-	alias_hashdiff_info.alias_of = "anofox_tab_diff_hashdiff";
-	loader.RegisterFunction(alias_hashdiff_info);
 }
 
 } // namespace anofox

--- a/test/sql/anofox_diff.test
+++ b/test/sql/anofox_diff.test
@@ -295,17 +295,17 @@ added	3	2024-01-03	300.00	pending
 changed	1	2024-01-02	200.00	completed
 removed	2	2024-01-01	NULL	NULL
 
-# Test 4: HashDiff with custom bisection_threshold
-query I
+# Test 4: HashDiff rejects the unimplemented bisection_threshold parameter
+statement error
 SELECT COUNT(*) FROM diff_hashdiff('source_data', 'target_data', 'id', 1000);
 ----
-3
+bisection
 
-# Test 5: HashDiff with bisection_threshold and bisection_factor
-query I
+# Test 5: HashDiff rejects bisection_threshold and bisection_factor
+statement error
 SELECT COUNT(*) FROM diff_hashdiff('source_data', 'target_data', 'id', 1000, 5);
 ----
-3
+bisection
 
 # Test 6: Verify HashDiff produces same results as JoinDiff
 statement ok

--- a/test/sql/anofox_diff_correctness.test
+++ b/test/sql/anofox_diff_correctness.test
@@ -1,0 +1,198 @@
+# name: test/sql/anofox_diff_correctness.test
+# description: Diff correctness — NULL-safe primary keys, bind-time schema validation,
+#              honest hashdiff parameters (issue #46)
+# group: [anofox_tabular]
+
+require anofox_tabular
+
+statement ok
+LOAD anofox_tabular;
+
+#############################
+# NULL primary keys (single key)
+#############################
+
+statement ok
+CREATE TABLE npk_source (id INTEGER, val VARCHAR);
+
+statement ok
+CREATE TABLE npk_target (id INTEGER, val VARCHAR);
+
+statement ok
+INSERT INTO npk_source VALUES (NULL, 'same'), (1, 'a'), (2, 'old');
+
+statement ok
+INSERT INTO npk_target VALUES (NULL, 'same'), (1, 'a'), (2, 'new');
+
+# A NULL-key row present on both sides with identical values must not be
+# reported as added+removed — the only diff is the changed id=2 row.
+query III rowsort
+SELECT diff_type, id, val FROM diff_joindiff('npk_source', 'npk_target', 'id');
+----
+changed	2	new
+
+# With include_all the NULL-key row classifies as unchanged
+query II
+SELECT diff_type, val FROM diff_joindiff('npk_source', 'npk_target', 'id', NULL, true) WHERE id IS NULL;
+----
+unchanged	same
+
+# A NULL-key row whose value changed must classify as changed, not added+removed
+statement ok
+CREATE TABLE npk_chg_source (id INTEGER, val VARCHAR);
+
+statement ok
+CREATE TABLE npk_chg_target (id INTEGER, val VARCHAR);
+
+statement ok
+INSERT INTO npk_chg_source VALUES (NULL, 'before');
+
+statement ok
+INSERT INTO npk_chg_target VALUES (NULL, 'after');
+
+query III
+SELECT diff_type, id, val FROM diff_joindiff('npk_chg_source', 'npk_chg_target', 'id');
+----
+changed	NULL	after
+
+# A NULL-key row only present in the source is removed, not added
+statement ok
+CREATE TABLE npk_rm_source (id INTEGER, val VARCHAR);
+
+statement ok
+CREATE TABLE npk_rm_target (id INTEGER, val VARCHAR);
+
+statement ok
+INSERT INTO npk_rm_source VALUES (NULL, 'gone');
+
+query III
+SELECT diff_type, id, val FROM diff_joindiff('npk_rm_source', 'npk_rm_target', 'id');
+----
+removed	NULL	NULL
+
+#############################
+# Compound key with NULL first component
+#############################
+
+statement ok
+CREATE TABLE cpk_source (k1 INTEGER, k2 INTEGER, val VARCHAR);
+
+statement ok
+CREATE TABLE cpk_target (k1 INTEGER, k2 INTEGER, val VARCHAR);
+
+statement ok
+INSERT INTO cpk_source VALUES (NULL, 1, 'stable'), (1, 1, 'x');
+
+statement ok
+INSERT INTO cpk_target VALUES (NULL, 1, 'stable'), (1, 1, 'y');
+
+# The (NULL, 1) row exists unchanged on both sides; only (1, 1) changed.
+query IIII rowsort
+SELECT diff_type, k1, k2, val FROM diff_joindiff('cpk_source', 'cpk_target', ['k1', 'k2']);
+----
+changed	1	1	y
+
+# hashdiff must agree with joindiff on NULL-safe key matching
+query IIII rowsort
+SELECT diff_type, k1, k2, val FROM diff_hashdiff('cpk_source', 'cpk_target', ['k1', 'k2']);
+----
+changed	1	1	y
+
+#############################
+# Bind-time schema validation
+#############################
+
+# Missing primary key column -> clear binder error
+statement error
+SELECT * FROM diff_joindiff('npk_source', 'npk_target', 'missing_pk');
+----
+Primary key column 'missing_pk' not found
+
+# Primary key present in source but missing in target
+statement ok
+CREATE TABLE pk_only_source (id INTEGER, other_id INTEGER, val VARCHAR);
+
+statement ok
+CREATE TABLE pk_only_target (other_id INTEGER, val VARCHAR);
+
+statement error
+SELECT * FROM diff_joindiff('pk_only_source', 'pk_only_target', 'id');
+----
+Primary key column 'id' not found in target
+
+# Missing compare column -> clear binder error
+statement error
+SELECT * FROM diff_joindiff('npk_source', 'npk_target', 'id', ['no_such_col']);
+----
+Compare column 'no_such_col' not found
+
+# Nonexistent table -> clear error naming the table
+statement error
+SELECT * FROM diff_joindiff('no_such_table_xyz', 'npk_target', 'id');
+----
+no_such_table_xyz
+
+# Default compare set is the shared non-PK columns: a column that exists only
+# in the source must neither error out nor mark shared-equal rows as changed.
+statement ok
+CREATE TABLE extra_source (id INTEGER, val VARCHAR, source_only VARCHAR);
+
+statement ok
+CREATE TABLE extra_target (id INTEGER, val VARCHAR);
+
+statement ok
+INSERT INTO extra_source VALUES (1, 'a', 'ignore-me');
+
+statement ok
+INSERT INTO extra_target VALUES (1, 'a');
+
+query I
+SELECT COUNT(*) FROM diff_joindiff('extra_source', 'extra_target', 'id');
+----
+0
+
+#############################
+# Regression guards: views and temp tables keep working with bind validation
+#############################
+
+statement ok
+CREATE VIEW npk_source_v AS SELECT * FROM npk_source;
+
+statement ok
+CREATE VIEW npk_target_v AS SELECT * FROM npk_target;
+
+query III rowsort
+SELECT diff_type, id, val FROM diff_joindiff('npk_source_v', 'npk_target_v', 'id');
+----
+changed	2	new
+
+statement ok
+CREATE TEMP TABLE npk_tmp_src (id INTEGER, val VARCHAR);
+
+statement ok
+CREATE TEMP TABLE npk_tmp_tgt (id INTEGER, val VARCHAR);
+
+statement ok
+INSERT INTO npk_tmp_src VALUES (1, 'a');
+
+statement ok
+INSERT INTO npk_tmp_tgt VALUES (1, 'b');
+
+query III
+SELECT diff_type, id, val FROM diff_joindiff('npk_tmp_src', 'npk_tmp_tgt', 'id');
+----
+changed	1	b
+
+#############################
+# diff_hashdiff bisection parameters are not implemented -> binder error
+#############################
+
+statement error
+SELECT * FROM diff_hashdiff('npk_source', 'npk_target', 'id', 1000);
+----
+bisection
+
+statement error
+SELECT * FROM diff_hashdiff('npk_source', 'npk_target', 'id', 1000, 5);
+----
+bisection


### PR DESCRIPTION
Closes #46. Part of the 2026-06 code review program (section 2.6, Phase 1).

> **Stacked PR:** based on `fix/42-sql-quoting` (#64). It will retarget to `main` automatically when #64 merges.

## Summary

- **NULL-safe primary keys (HIGH):** the generated join now uses `IS NOT DISTINCT FROM` per key, and row presence is tracked via side-presence marker columns (`__anofox_diff_s_present` / `__anofox_diff_t_present`) wrapped around each side, instead of inferring presence from `<first_pk> IS NULL`. Rows with NULL key values (including compound keys with a NULL first component) are now matched across sides and classified `changed`/`unchanged` instead of being misreported as `added`+`removed`. Markers are excluded from the output.
- **Bind-time schema validation (MED):** the previously dead `ValidatePrimaryKeys`/`ValidateCompareColumns` helpers are now wired in (reworked to resolve table/view columns from the catalog). Primary key and compare columns must exist on **both** sides; the default compare set is computed explicitly as the shared non-key columns and compared column by column (`s.col IS DISTINCT FROM t.col`) instead of the whole-row `s IS DISTINCT FROM t` struct comparison, which broke as soon as the schemas diverged. Missing tables/columns now raise clear `BinderException`s. Works for tables, views, and temp tables (regression-guarded in tests).
- **Honest `diff_hashdiff` parameters (MED):** `bisection_threshold`/`bisection_factor` are now rejected with a clear binder error ("not implemented yet") instead of being silently ignored. The overloads stay registered so callers get that message rather than a generic overload-resolution failure. README, API reference, and the Python package docs/tests were updated accordingly.
- **Dead code (LOW):** removed the unregistered native table-function scaffold (bind/local-state/execute/finalize stubs and `DIFF_TYPE_*` constants); registration now uses `RegisterTableFunctionSetWithAlias` from `anofox_function_alias.hpp` instead of manual alias copying.
- **Python:** compound primary keys are now passed as a `LIST` literal (the old CSV string `'a,b'` never bound correctly); added tests for compound keys and the bisection rejection path.

## Already fixed by #42 (re-verified, not redone)

The "column identifiers concatenated unquoted" finding was already resolved on the base branch by the #42 quoting sweep (`QuoteSqlIdentifier`/`BuildQueryTableRef` in `anofox_diff.cpp`), with hostile-identifier coverage in `test/sql/anofox_sql_quoting.test` (table names with quotes/spaces, key/compare columns with spaces, embedded quotes, and keywords). Those tests stay green with the changes here.

## Red/green TDD

First commit is tests-only (`test/sql/anofox_diff_correctness.test` plus tightening the two hashdiff bisection assertions in `test/sql/anofox_diff.test`). Red output against the unmodified implementation:

```
Wrong row count in query! (test/sql/anofox_diff_correctness.test:29)!
Expected 1 rows, but got 3 rows
SELECT diff_type, id, val FROM diff_joindiff('npk_source', 'npk_target', 'id');
Actual result:
changed	2	new
added	NULL	NULL
added	NULL	same
```

```
Query unexpectedly succeeded! (test/sql/anofox_diff.test:299)!
SELECT COUNT(*) FROM diff_hashdiff('source_data', 'target_data', 'id', 1000);
[ Rows: 1]
3
```

Missing-column errors previously leaked from the generated SQL, e.g.:

```
Binder Error: Values list "s" does not have a column named "missing_pk"
```

now:

```
Binder Error: diff_joindiff: Primary key column 'missing_pk' not found in source table 'npk_source'
```

## Testing

- `make test`: all green (1724 assertions in 18 test cases; baseline before the change was also fully green at 1664/17, including `anofox_sql_quoting.test`)
- Python: `pytest tests/` — 244 passed (12 in `test_diff.py`, including the new compound-key and rejection tests)
- Known pre-existing: the standalone shell/unittest binary can segfault in the PostHog telemetry thread on process exit; unrelated to this change