### PR TITLE
feat: real DBSCAN metric table functions, consistent arities, legacy removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -530,13 +530,16 @@ Density-based anomaly detection for finding outliers in spatial data:
 
 ```sql
 -- Univariate: find noise points in single dimension
-SELECT * FROM metric_dbscan(
+SELECT * FROM dbscan(
     'transactions',
     'amount',
     10.0,       -- eps: neighborhood radius
     5,          -- min_pts: minimum points for dense region
     'clusters'  -- output mode: 'summary' or 'clusters'
 ) WHERE point_type = 'NOISE';
+
+-- Multivariate over several columns; all trailing parameters are optional
+SELECT * FROM dbscan_mv('transactions', 'amount,quantity');
 ```
 
 **Point Classifications:**
@@ -963,29 +966,33 @@ WHERE money_in_range(amount, 0.01, 99999.99)
 
 | Function | Description |
 |----------|-------------|
-| `anofox_tab_metric_isolation_forest` | Univariate Isolation Forest with all enhancements |
-| `anofox_tab_metric_isolation_forest_multivariate` | Multivariate Isolation Forest |
-| `anofox_tab_metric_dbscan` | Univariate DBSCAN clustering |
-| `anofox_tab_metric_dbscan_multivariate` | Multivariate DBSCAN clustering |
+| `anofox_tab_isolation_forest` (alias `isolation_forest`) | Univariate Isolation Forest with all enhancements |
+| `anofox_tab_isolation_forest_mv` (alias `isolation_forest_mv`) | Multivariate Isolation Forest |
+| `anofox_tab_dbscan` (alias `dbscan`) | Univariate DBSCAN clustering |
+| `anofox_tab_dbscan_mv` (alias `dbscan_mv`) | Multivariate DBSCAN clustering |
 | `outlier_tree` | Explainable outlier detection with conditional distributions |
 
 **Isolation Forest Full Signature:**
 ```sql
-metric_isolation_forest(
+isolation_forest(
     table_name VARCHAR,
     column_name VARCHAR,
     n_trees BIGINT,           -- 1-500, default 100
     sample_size BIGINT,       -- 1-10000, default 256
     contamination DOUBLE,     -- 0.0-0.5, default 0.1
-    output_mode VARCHAR,      -- 'summary' or 'scores'
-    ndim BIGINT,              -- 1-N, default 1 (Extended IF)
-    coef_type VARCHAR,        -- 'uniform' or 'normal'
-    scoring_metric VARCHAR,   -- 'depth', 'density', or 'adj_depth'
-    weight_column VARCHAR,    -- Column for sample weights (NULL = uniform)
-    ntry BIGINT,              -- 1-100, default 1 (SCiForest)
-    prob_pick_avg_gain DOUBLE -- 0.0-1.0, default 0.0
+    output_mode VARCHAR,      -- 'summary' (default) or 'scores'
+    seed BIGINT               -- optional RNG seed
 ) → TABLE
+-- isolation_forest_mv additionally accepts (in order):
+--   ndim BIGINT,              -- 1-N, default 1 (Extended IF)
+--   coef_type VARCHAR,        -- 'uniform' or 'normal'
+--   scoring_metric VARCHAR,   -- 'depth', 'density', or 'adj_depth'
+--   weight_column VARCHAR,    -- Column for sample weights (NULL = uniform)
+--   ntry BIGINT,              -- 1-100, default 1 (SCiForest)
+--   prob_pick_avg_gain DOUBLE -- 0.0-1.0, default 0.0
 ```
+
+All parameters after `column_name` are optional; `isolation_forest('sales', 'amount')` uses the defaults.
 
 **Parameters:**
 | Parameter | Range | Default | Description |
@@ -993,7 +1000,7 @@ metric_isolation_forest(
 | `n_trees` | 1-500 | 100 | Number of isolation trees |
 | `sample_size` | 1-10000 | 256 | Subsample size per tree |
 | `contamination` | 0.0-0.5 | 0.1 | Expected anomaly fraction |
-| `output_mode` | - | 'scores' | `'summary'` or `'scores'` |
+| `output_mode` | - | 'summary' | `'summary'` or `'scores'` |
 | `ndim` | 1-N | 1 | Hyperplane dimensions (Extended IF) |
 | `coef_type` | - | 'uniform' | `'uniform'` or `'normal'` |
 | `scoring_metric` | - | 'depth' | `'depth'`, `'density'`, `'adj_depth'` |
@@ -1001,10 +1008,23 @@ metric_isolation_forest(
 | `ntry` | 1-100 | 1 | Split candidates (SCiForest) |
 | `prob_pick_avg_gain` | 0.0-1.0 | 0.0 | Gain-based selection probability |
 
-**DBSCAN Parameters:**
-- **eps** (default 0.5): Neighborhood radius
-- **min_pts** (default 5): Minimum points for dense region
-- **output_mode**: `'summary'` or `'clusters'`
+**DBSCAN Full Signature:**
+```sql
+dbscan(
+    table_name VARCHAR,
+    column_name VARCHAR,
+    eps DOUBLE,          -- > 0.0, default 0.5: neighborhood radius
+    min_pts BIGINT,      -- >= 1, default 5: minimum points for dense region
+    output_mode VARCHAR  -- 'summary' (default) or 'clusters'
+) → TABLE
+-- dbscan_mv takes comma-separated column names as the second argument
+```
+
+All parameters after `column_name` are optional; `dbscan('orders', 'amount')` uses the defaults.
+
+**DBSCAN Output:**
+- `'summary'` (one row): `status` (`fail` when noise points exist, else `pass`), `cluster_count`, `noise_count`, `total_count`, `noise_rate`, `largest_cluster_size`, `eps`, `min_pts`, `n_columns` (`dbscan_mv` only), `message`
+- `'clusters'` (one row per non-NULL input row): `row_id`, `value` (univariate only), `cluster_id` (`-1` = noise), `point_type` (`'CORE'`, `'BORDER'`, `'NOISE'`), `neighbor_count`, `anomaly_score` (noise = 1.0), `is_anomaly`
 
 ### Data Diffing Functions
 

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1542,51 +1542,54 @@ SELECT * FROM metric_isolation_forest_multivariate(
 
 ### DBSCAN Clustering
 
-#### `anofox_tab_metric_ (alias: metric_dbscan`
+#### `anofox_tab_dbscan` (alias: `dbscan`)
 
 Univariate DBSCAN clustering for single column anomaly detection.
 
 **Signature:**
 ```sql
-anofox_tab_metric_ (alias: metric_dbscan(
+anofox_tab_dbscan(
     table_name VARCHAR,
     column_name VARCHAR,
-    eps DOUBLE,
-    min_pts BIGINT,
-    output_mode VARCHAR
+    eps DOUBLE,          -- optional, default 0.5
+    min_pts BIGINT,      -- optional, default 5
+    output_mode VARCHAR  -- optional, default 'summary'
 ) → TABLE
 ```
 
 **Parameters:**
-- `eps`: Neighborhood radius (default: 0.5)
-- `min_pts`: Minimum points for dense region (default: 5)
+- `eps`: Neighborhood radius, must be > 0.0 (default: 0.5)
+- `min_pts`: Minimum points for dense region, must be >= 1 (default: 5)
 - `output_mode`: `'summary'` (aggregate stats) or `'clusters'` (per-row results)
 
+All parameters after `column_name` are optional.
+
 **Returns:**
-- `TABLE`: Clustering results with `row_id`, `cluster_id`, `point_type`, `anomaly_score`
+- `'summary'`: one row with `status` (`fail` when noise points exist), `cluster_count`, `noise_count`, `total_count`, `noise_rate`, `largest_cluster_size`, `eps`, `min_pts`, `message`
+- `'clusters'`: one row per non-NULL input row with `row_id`, `value`, `cluster_id` (`-1` = noise), `point_type`, `neighbor_count`, `anomaly_score`, `is_anomaly`
 - `point_type`: `'CORE'` (dense region), `'BORDER'` (cluster edge), or `'NOISE'` (outlier)
 
 **Example:**
 ```sql
-SELECT * FROM anofox_tab_metric_ (alias: metric_dbscan(
+SELECT * FROM dbscan(
     'transactions', 'amount', 10.0, 5, 'clusters'
 ) WHERE point_type = 'NOISE';
 ```
 
 ---
 
-#### `anofox_tab_metric_ (alias: metric_dbscan_multivariate`
+#### `anofox_tab_dbscan_mv` (alias: `dbscan_mv`)
 
 Multivariate DBSCAN clustering for multiple column anomaly detection.
 
 **Signature:**
 ```sql
-anofox_tab_metric_ (alias: metric_dbscan_multivariate(
+anofox_tab_dbscan_mv(
     table_name VARCHAR,
     columns VARCHAR,
-    eps DOUBLE,
-    min_pts BIGINT,
-    output_mode VARCHAR
+    eps DOUBLE,          -- optional, default 0.5
+    min_pts BIGINT,      -- optional, default 5
+    output_mode VARCHAR  -- optional, default 'summary'
 ) → TABLE
 ```
 
@@ -1594,7 +1597,8 @@ anofox_tab_metric_ (alias: metric_dbscan_multivariate(
 - `columns`: Comma-separated column names
 
 **Returns:**
-- `TABLE`: Clustering results with `row_id`, `cluster_id`, `point_type`, `anomaly_score`
+- `'summary'`: same columns as `anofox_tab_dbscan` plus `n_columns` (no `value` column in `'clusters'` mode)
+- `'clusters'`: one row per non-NULL input row with `row_id`, `cluster_id`, `point_type`, `neighbor_count`, `anomaly_score`, `is_anomaly`
 
 ---
 

--- a/python/src/anofox/anomaly.py
+++ b/python/src/anofox/anomaly.py
@@ -121,17 +121,21 @@ def dbscan(
     column:
         Numeric column name.
     output_mode:
-        ``"summary"`` → dict; ``"scores"`` → DataFrame.
+        ``"summary"`` → dict; ``"scores"`` (or ``"clusters"``) → DataFrame
+        with one row per input row.
     epsilon:
         Neighbourhood radius ε (default 0.5).
     min_points:
         Minimum cluster size (default 5).
     """
     table_name, registered = resolve_table(conn, table_or_df)
+    # The extension's per-row DBSCAN mode is named 'clusters'; keep the
+    # package-level "scores" naming consistent with the other detectors.
+    sql_mode = "clusters" if output_mode == "scores" else output_mode
     try:
         query = (
             f"SELECT * FROM anofox_tab_dbscan("
-            f"'{table_name}', '{column}', {epsilon}, {min_points}, '{output_mode}')"
+            f"'{table_name}', '{column}', {epsilon}, {min_points}, '{sql_mode}')"
         )
         return _execute_anomaly(conn, query, output_mode)
     finally:
@@ -158,7 +162,8 @@ def dbscan_mv(
     columns:
         List of numeric column names.
     output_mode:
-        ``"summary"`` → dict; ``"scores"`` → DataFrame.
+        ``"summary"`` → dict; ``"scores"`` (or ``"clusters"``) → DataFrame
+        with one row per input row.
     epsilon:
         Neighbourhood radius ε (default 0.5).
     min_points:
@@ -166,10 +171,11 @@ def dbscan_mv(
     """
     table_name, registered = resolve_table(conn, table_or_df)
     cols_csv = ",".join(columns)
+    sql_mode = "clusters" if output_mode == "scores" else output_mode
     try:
         query = (
             f"SELECT * FROM anofox_tab_dbscan_mv("
-            f"'{table_name}', '{cols_csv}', {epsilon}, {min_points}, '{output_mode}')"
+            f"'{table_name}', '{cols_csv}', {epsilon}, {min_points}, '{sql_mode}')"
         )
         return _execute_anomaly(conn, query, output_mode)
     finally:

--- a/src/anofox_metric.cpp
+++ b/src/anofox_metric.cpp
@@ -14,7 +14,6 @@
 #include "duckdb/main/client_context.hpp"
 #include <algorithm>
 #include <chrono>
-#include <random>
 
 namespace duckdb {
 namespace anofox {
@@ -29,6 +28,29 @@ static unique_ptr<SubqueryRef> ParseSubquery(const string &query, const ParserOp
 	}
 	auto select_stmt = unique_ptr_cast<SQLStatement, SelectStatement>(std::move(parser.statements[0]));
 	return make_uniq<SubqueryRef>(std::move(select_stmt));
+}
+
+// Helper: parse a comma-separated column list, trimming whitespace and surrounding quotes
+static vector<string> ParseCommaSeparatedColumns(const string &columns_str) {
+	vector<string> column_names;
+	size_t start = 0;
+	for (size_t i = 0; i <= columns_str.length(); ++i) {
+		if (i == columns_str.length() || columns_str[i] == ',') {
+			string col = columns_str.substr(start, i - start);
+			size_t col_start = col.find_first_not_of(" \t\n\r");
+			size_t col_end = col.find_last_not_of(" \t\n\r");
+			if (col_start != string::npos) {
+				col = col.substr(col_start, col_end - col_start + 1);
+				if (col.length() >= 2 && ((col.front() == '"' && col.back() == '"') ||
+				                          (col.front() == '\'' && col.back() == '\''))) {
+					col = col.substr(1, col.length() - 2);
+				}
+				column_names.push_back(col);
+			}
+			start = i + 1;
+		}
+	}
+	return column_names;
 }
 
 // Helper: Generate SQL for volume metrics
@@ -469,6 +491,9 @@ static unique_ptr<FunctionData> IsolationForestBind(ClientContext &context, Tabl
 	if (contamination < 0.0 || contamination > 0.5) {
 		throw BinderException("contamination must be between 0.0 and 0.5");
 	}
+	if (output_mode != "summary" && output_mode != "scores") {
+		throw BinderException("isolation_forest: output_mode must be 'summary' or 'scores'");
+	}
 
 	// Define output schema based on mode
 	if (output_mode == "scores") {
@@ -513,28 +538,7 @@ static unique_ptr<FunctionData> IsolationForestMultivariateBind(ClientContext &c
 	string table_name = input.inputs[0].ToString();
 
 	// Parse comma-separated column names
-	string columns_str = input.inputs[1].ToString();
-	vector<string> column_names;
-
-	size_t start = 0;
-	for (size_t i = 0; i <= columns_str.length(); ++i) {
-		if (i == columns_str.length() || columns_str[i] == ',') {
-			string col = columns_str.substr(start, i - start);
-			size_t col_start = col.find_first_not_of(" \t\n\r");
-			size_t col_end = col.find_last_not_of(" \t\n\r");
-			if (col_start != string::npos) {
-				col = col.substr(col_start, col_end - col_start + 1);
-				// Remove quotes if present
-				if ((col.front() == '"' && col.back() == '"') ||
-				    (col.front() == '\'' && col.back() == '\'')) {
-					col = col.substr(1, col.length() - 2);
-				}
-				column_names.push_back(col);
-			}
-			start = i + 1;
-		}
-	}
-
+	auto column_names = ParseCommaSeparatedColumns(input.inputs[1].ToString());
 	if (column_names.empty()) {
 		throw BinderException("column_names must contain at least one column");
 	}
@@ -627,6 +631,9 @@ static unique_ptr<FunctionData> IsolationForestMultivariateBind(ClientContext &c
 	}
 	if (contamination < 0.0 || contamination > 0.5) {
 		throw BinderException("contamination must be between 0.0 and 0.5");
+	}
+	if (output_mode != "summary" && output_mode != "scores") {
+		throw BinderException("isolation_forest_mv: output_mode must be 'summary' or 'scores'");
 	}
 
 	// Define output schema based on mode
@@ -976,412 +983,309 @@ static void IsolationForestExecute(ClientContext &context, TableFunctionInput &d
 }
 
 //===--------------------------------------------------------------------===//
-// Legacy SQL Generation Functions (kept for reference, no longer used)
+// DBSCAN Table Function - Actual C++ Execution
 //===--------------------------------------------------------------------===//
 
-// Helper: Generate SQL for isolation forest metrics (summary mode) - DEPRECATED
-static string GenerateIsolationForestSummarySQL(
-	const string &table_ref,
-	const string &column_name,
-	size_t n_trees,
-	size_t sample_size,
-	double contamination
-) {
-	string n_trees_str = std::to_string(n_trees);
-	string sample_size_str = std::to_string(sample_size);
-	string contamination_str = std::to_string(contamination);
-
-	return "WITH data_sample AS ("
-		"SELECT ROW_NUMBER() OVER () as row_id, CAST(" + QuoteSqlIdentifier(column_name) + " AS DOUBLE) as value "
-		"FROM (SELECT * FROM " + table_ref + ") WHERE " + QuoteSqlIdentifier(column_name) + " IS NOT NULL"
-		"), "
-		"summary AS ("
-		"SELECT "
-		"  COUNT(*) as total_count, "
-		"  AVG(value) as avg_value, "
-		"  STDDEV(value) as stddev_value, "
-		"  COUNT(CASE WHEN value > 300 THEN 1 END) as outlier_count "
-		"FROM data_sample"
-		") "
-		"SELECT "
-		"CASE WHEN outlier_count > 0 THEN 'fail' ELSE 'pass' END as status, "
-		"outlier_count, "
-		"total_count, "
-		"CAST(avg_value AS DOUBLE) as avg_value, "
-		+ contamination_str + " as contamination, "
-		+ n_trees_str + " as n_trees, "
-		"CASE "
-		"  WHEN outlier_count = 0 THEN 'No anomalies detected by isolation forest' "
-		"  ELSE CAST(outlier_count AS VARCHAR) || ' anomalies detected' "
-		"END as message "
-		"FROM summary";
-}
-
-// Helper: Generate SQL for isolation forest metrics (scores mode)
-static string GenerateIsolationForestScoresSQL(
-	const string &table_ref,
-	const string &column_name,
-	size_t n_trees,
-	size_t sample_size,
-	double contamination
-) {
-	string n_trees_str = std::to_string(n_trees);
-	string sample_size_str = std::to_string(sample_size);
-	string contamination_str = std::to_string(contamination);
-
-	return "WITH data_sample AS ("
-		"SELECT ROW_NUMBER() OVER () as row_id, CAST(" + QuoteSqlIdentifier(column_name) + " AS DOUBLE) as value "
-		"FROM (SELECT * FROM " + table_ref + ") WHERE " + QuoteSqlIdentifier(column_name) + " IS NOT NULL"
-		"), "
-		"computed_scores AS ("
-		"SELECT "
-		"  row_id, "
-		"  value, "
-		"  CASE WHEN value > 300 THEN 0.75 ELSE 0.25 END as anomaly_score "
-		"FROM data_sample"
-		"), "
-		"threshold_calc AS ("
-		"SELECT QUANTILE_CONT(anomaly_score, 1.0 - " + contamination_str + ") as threshold "
-		"FROM computed_scores"
-		") "
-		"SELECT "
-		"row_id, "
-		"value, "
-		"c.anomaly_score, "
-		"c.anomaly_score >= t.threshold as is_anomaly "
-		"FROM computed_scores c, threshold_calc t "
-		"ORDER BY row_id";
-}
-
-// Helper: Generate SQL for isolation forest metrics - multivariate summary mode
-static string GenerateIsolationForestMultivariateSummarySQL(
-	const string &table_ref,
-	const vector<string> &column_names,
-	size_t n_trees,
-	size_t sample_size,
-	double contamination
-) {
-	string n_trees_str = std::to_string(n_trees);
-	string sample_size_str = std::to_string(sample_size);
-	string contamination_str = std::to_string(contamination);
-
-	// Build column list with NULL filtering
-	string column_list;
-	string null_checks;
-	for (size_t i = 0; i < column_names.size(); ++i) {
-		if (i > 0) {
-			column_list += ", ";
-			null_checks += " AND ";
-		}
-		column_list += "CAST(" + QuoteSqlIdentifier(column_names[i]) + " AS DOUBLE) as col_" + std::to_string(i);
-		null_checks += QuoteSqlIdentifier(column_names[i]) + " IS NOT NULL";
-	}
-
-	// Build anomaly detection condition based on number of columns
-	string anomaly_condition;
-	if (column_names.size() == 1) {
-		anomaly_condition = "col_0 > 300";
-	} else if (column_names.size() == 2) {
-		anomaly_condition = "(col_0 + col_1) > 600";
-	} else {
-		// For 3+ columns, use sum of all columns
-		anomaly_condition = "(col_0 + col_1 + col_2";
-		for (size_t i = 3; i < column_names.size(); ++i) {
-			anomaly_condition += " + col_" + std::to_string(i);
-		}
-		anomaly_condition += ") > (300 * " + std::to_string(column_names.size()) + ")";
-	}
-
-	return "WITH data_sample AS ("
-		"SELECT ROW_NUMBER() OVER () as row_id, " + column_list + " "
-		"FROM (SELECT * FROM " + table_ref + ") WHERE " + null_checks +
-		"), "
-		"summary AS ("
-		"SELECT "
-		"  COUNT(*) as total_count, "
-		"  COUNT(CASE WHEN " + anomaly_condition + " THEN 1 END) as outlier_count "
-		"FROM data_sample"
-		") "
-		"SELECT "
-		"CASE WHEN outlier_count > 0 THEN 'fail' ELSE 'pass' END as status, "
-		"outlier_count, "
-		"total_count, "
-		"CAST(" + std::to_string(column_names.size()) + " AS INTEGER) as n_columns, "
-		+ contamination_str + " as contamination, "
-		+ n_trees_str + " as n_trees, "
-		"CASE "
-		"  WHEN outlier_count = 0 THEN 'No anomalies detected' "
-		"  ELSE CAST(outlier_count AS VARCHAR) || ' anomalies detected' "
-		"END as message "
-		"FROM summary";
-}
-
-// Helper: Generate SQL for isolation forest metrics - multivariate scores mode
-static string GenerateIsolationForestMultivariateScoresSQL(
-	const string &table_ref,
-	const vector<string> &column_names,
-	size_t n_trees,
-	size_t sample_size,
-	double contamination
-) {
-	string n_trees_str = std::to_string(n_trees);
-	string sample_size_str = std::to_string(sample_size);
-	string contamination_str = std::to_string(contamination);
-
-	// Build column list with NULL filtering
-	string column_list;
-	string null_checks;
-	for (size_t i = 0; i < column_names.size(); ++i) {
-		if (i > 0) {
-			column_list += ", ";
-			null_checks += " AND ";
-		}
-		column_list += "CAST(" + QuoteSqlIdentifier(column_names[i]) + " AS DOUBLE) as col_" + std::to_string(i);
-		null_checks += QuoteSqlIdentifier(column_names[i]) + " IS NOT NULL";
-	}
-
-	// Build anomaly detection condition based on number of columns
-	string anomaly_condition;
-	if (column_names.size() == 1) {
-		anomaly_condition = "col_0 > 300";
-	} else if (column_names.size() == 2) {
-		anomaly_condition = "(col_0 + col_1) > 600";
-	} else {
-		// For 3+ columns, use sum of all columns
-		anomaly_condition = "(col_0 + col_1 + col_2";
-		for (size_t i = 3; i < column_names.size(); ++i) {
-			anomaly_condition += " + col_" + std::to_string(i);
-		}
-		anomaly_condition += ") > (300 * " + std::to_string(column_names.size()) + ")";
-	}
-
-	return "WITH data_sample AS ("
-		"SELECT ROW_NUMBER() OVER () as row_id, " + column_list + " "
-		"FROM (SELECT * FROM " + table_ref + ") WHERE " + null_checks +
-		"), "
-		"computed_scores AS ("
-		"SELECT "
-		"  row_id, "
-		"  CASE WHEN " + anomaly_condition + " THEN 0.75 ELSE 0.25 END as anomaly_score "
-		"FROM data_sample"
-		"), "
-		"threshold_calc AS ("
-		"SELECT QUANTILE_CONT(anomaly_score, 1.0 - " + contamination_str + ") as threshold "
-		"FROM computed_scores"
-		") "
-		"SELECT "
-		"row_id, "
-		"c.anomaly_score, "
-		"c.anomaly_score >= t.threshold as is_anomaly "
-		"FROM computed_scores c, threshold_calc t "
-		"ORDER BY row_id";
-}
-
-// Bind function for isolation forest
-static unique_ptr<TableRef> MetricIsolationForestBindReplace(ClientContext &context, TableFunctionBindInput &input) {
-	if (input.inputs.size() < 2) {
-		throw BinderException("anofox_metric_isolation_forest requires at least 2 arguments: table_name, column_name");
-	}
-
-	string table_name = input.inputs[0].ToString();
-	string column_name = input.inputs[1].ToString();
-
-	// Optional parameters with defaults
-	size_t n_trees = input.inputs.size() > 2 ? input.inputs[2].GetValue<int64_t>() : 100;
-	size_t sample_size = input.inputs.size() > 3 ? input.inputs[3].GetValue<int64_t>() : 256;
-	double contamination = input.inputs.size() > 4 ? input.inputs[4].GetValue<double>() : 0.1;
-	string output_mode = input.inputs.size() > 5 ? input.inputs[5].ToString() : "summary";
-
-	// Validate parameters
-	if (n_trees == 0 || n_trees > 500) {
-		throw BinderException("n_trees must be between 1 and 500");
-	}
-	if (sample_size == 0 || sample_size > 10000) {
-		throw BinderException("sample_size must be between 1 and 10000");
-	}
-	if (contamination < 0.0 || contamination > 0.5) {
-		throw BinderException("contamination must be between 0.0 and 0.5");
-	}
-
-	string table_ref = BuildQueryTableRef(table_name);
-	string sql = (output_mode == "scores") ?
-		GenerateIsolationForestScoresSQL(table_ref, column_name, n_trees, sample_size, contamination) :
-		GenerateIsolationForestSummarySQL(table_ref, column_name, n_trees, sample_size, contamination);
-
-	return ParseSubquery(sql, context.GetParserOptions(), "Failed to parse isolation forest metric query");
-}
-
-// Bind function for multivariate isolation forest
-static unique_ptr<TableRef> MetricIsolationForestMultivariateBindReplace(ClientContext &context, TableFunctionBindInput &input) {
-	if (input.inputs.size() < 3) {
-		throw BinderException("anofox_metric_isolation_forest_multivariate requires at least 3 arguments: table_name, column_names (VARCHAR comma-separated), output_mode");
-	}
-
-	string table_name = input.inputs[0].ToString();
-
-	// Parse comma-separated column names from a single string parameter
-	string columns_str = input.inputs[1].ToString();
+// Bind data for DBSCAN table function (immutable after bind)
+struct DBSCANBindData : public TableFunctionData {
+	string table_name;
 	vector<string> column_names;
+	double eps;
+	int64_t min_pts;
+	string output_mode; // "summary" or "clusters"
+	bool is_multivariate;
 
-	// Split by comma and trim whitespace
-	size_t start = 0;
-	for (size_t i = 0; i <= columns_str.length(); ++i) {
-		if (i == columns_str.length() || columns_str[i] == ',') {
-			string col = columns_str.substr(start, i - start);
-			// Trim whitespace
-			size_t col_start = col.find_first_not_of(" \t\n\r");
-			size_t col_end = col.find_last_not_of(" \t\n\r");
-			if (col_start != string::npos) {
-				col = col.substr(col_start, col_end - col_start + 1);
-				// Remove quotes if present
-				if ((col.front() == '"' && col.back() == '"') ||
-				    (col.front() == '\'' && col.back() == '\'')) {
-					col = col.substr(1, col.length() - 2);
-				}
-				column_names.push_back(col);
-			}
-			start = i + 1;
+	DBSCANBindData(string tbl, vector<string> cols, double eps_val, int64_t min_pts_val, string mode,
+	               bool force_multivariate)
+	    : table_name(std::move(tbl)), column_names(std::move(cols)), eps(eps_val), min_pts(min_pts_val),
+	      output_mode(std::move(mode)), is_multivariate(force_multivariate || column_names.size() > 1) {
+	}
+};
+
+// Global state for DBSCAN execution - stores mutable execution state
+struct DBSCANGlobalState : public GlobalTableFunctionState {
+	bool executed = false;
+	idx_t current_row = 0;
+
+	// Results computed during execution (stored here because bind_data is const)
+	std::vector<DBSCANPoint> points;
+	std::vector<double> anomaly_scores;
+	std::vector<double> first_column_values; // univariate only
+	int64_t total_count = 0;
+	int64_t cluster_count = 0;
+	int64_t noise_count = 0;
+	int64_t largest_cluster_size = 0;
+};
+
+// Initialize global state
+static unique_ptr<GlobalTableFunctionState> DBSCANInit(ClientContext &, TableFunctionInitInput &) {
+	return make_uniq<DBSCANGlobalState>();
+}
+
+// Shared optional-parameter handling and validation for both DBSCAN bind functions
+static void ParseDBSCANParameters(TableFunctionBindInput &input, const string &function_name, double &eps,
+                                  int64_t &min_pts, string &output_mode) {
+	eps = input.inputs.size() > 2 ? input.inputs[2].GetValue<double>() : 0.5;
+	min_pts = input.inputs.size() > 3 ? input.inputs[3].GetValue<int64_t>() : 5;
+	output_mode = input.inputs.size() > 4 ? input.inputs[4].ToString() : "summary";
+
+	if (eps <= 0.0) {
+		throw BinderException(function_name + ": eps must be > 0.0");
+	}
+	if (min_pts < 1) {
+		throw BinderException(function_name + ": min_pts must be >= 1");
+	}
+	if (output_mode != "summary" && output_mode != "clusters") {
+		throw BinderException(function_name + ": output_mode must be 'summary' or 'clusters'");
+	}
+}
+
+// Shared output schema for both DBSCAN functions
+static void DefineDBSCANSchema(const string &output_mode, bool include_value, bool include_n_columns,
+                               vector<LogicalType> &return_types, vector<string> &names) {
+	if (output_mode == "clusters") {
+		// Per-row output: one row per non-NULL input row
+		names.emplace_back("row_id");
+		return_types.emplace_back(LogicalType(LogicalTypeId::BIGINT));
+		if (include_value) {
+			names.emplace_back("value");
+			return_types.emplace_back(LogicalType(LogicalTypeId::DOUBLE));
 		}
+		names.emplace_back("cluster_id");
+		return_types.emplace_back(LogicalType(LogicalTypeId::INTEGER));
+		names.emplace_back("point_type");
+		return_types.emplace_back(LogicalType(LogicalTypeId::VARCHAR));
+		names.emplace_back("neighbor_count");
+		return_types.emplace_back(LogicalType(LogicalTypeId::BIGINT));
+		names.emplace_back("anomaly_score");
+		return_types.emplace_back(LogicalType(LogicalTypeId::DOUBLE));
+		names.emplace_back("is_anomaly");
+		return_types.emplace_back(LogicalType(LogicalTypeId::BOOLEAN));
+	} else {
+		// Summary output: a single row with aggregate clustering statistics
+		names.emplace_back("status");
+		return_types.emplace_back(LogicalType(LogicalTypeId::VARCHAR));
+		names.emplace_back("cluster_count");
+		return_types.emplace_back(LogicalType(LogicalTypeId::BIGINT));
+		names.emplace_back("noise_count");
+		return_types.emplace_back(LogicalType(LogicalTypeId::BIGINT));
+		names.emplace_back("total_count");
+		return_types.emplace_back(LogicalType(LogicalTypeId::BIGINT));
+		names.emplace_back("noise_rate");
+		return_types.emplace_back(LogicalType(LogicalTypeId::DOUBLE));
+		names.emplace_back("largest_cluster_size");
+		return_types.emplace_back(LogicalType(LogicalTypeId::BIGINT));
+		names.emplace_back("eps");
+		return_types.emplace_back(LogicalType(LogicalTypeId::DOUBLE));
+		names.emplace_back("min_pts");
+		return_types.emplace_back(LogicalType(LogicalTypeId::BIGINT));
+		if (include_n_columns) {
+			names.emplace_back("n_columns");
+			return_types.emplace_back(LogicalType(LogicalTypeId::INTEGER));
+		}
+		names.emplace_back("message");
+		return_types.emplace_back(LogicalType(LogicalTypeId::VARCHAR));
 	}
-
-	if (column_names.empty()) {
-		throw BinderException("column_names must contain at least one column");
-	}
-
-	// Optional parameters with defaults
-	size_t n_trees = input.inputs.size() > 2 ? input.inputs[2].GetValue<int64_t>() : 100;
-	size_t sample_size = input.inputs.size() > 3 ? input.inputs[3].GetValue<int64_t>() : 256;
-	double contamination = input.inputs.size() > 4 ? input.inputs[4].GetValue<double>() : 0.1;
-	string output_mode = input.inputs.size() > 5 ? input.inputs[5].ToString() : "summary";
-
-	// Validate parameters
-	if (n_trees == 0 || n_trees > 500) {
-		throw BinderException("n_trees must be between 1 and 500");
-	}
-	if (sample_size == 0 || sample_size > 10000) {
-		throw BinderException("sample_size must be between 1 and 10000");
-	}
-	if (contamination < 0.0 || contamination > 0.5) {
-		throw BinderException("contamination must be between 0.0 and 0.5");
-	}
-
-	string table_ref = BuildQueryTableRef(table_name);
-	string sql = (output_mode == "scores") ?
-		GenerateIsolationForestMultivariateScoresSQL(table_ref, column_names, n_trees, sample_size, contamination) :
-		GenerateIsolationForestMultivariateSummarySQL(table_ref, column_names, n_trees, sample_size, contamination);
-
-	return ParseSubquery(sql, context.GetParserOptions(), "Failed to parse multivariate isolation forest metric query");
 }
 
 // Bind function for univariate DBSCAN
-static unique_ptr<TableRef> MetricDBSCANBindReplace(ClientContext &context, TableFunctionBindInput &input) {
+static unique_ptr<FunctionData> DBSCANBind(ClientContext &context, TableFunctionBindInput &input,
+                                           vector<LogicalType> &return_types, vector<string> &names) {
 	PostHogTelemetry::Instance().CaptureFunctionExecution("metric_dbscan");
 	if (input.inputs.size() < 2) {
-		throw BinderException("anofox_metric_dbscan requires at least 2 arguments: table_name, column_name");
+		throw BinderException("dbscan requires at least 2 arguments: table_name, column_name");
 	}
 
 	string table_name = input.inputs[0].ToString();
-	string column_name = input.inputs[1].ToString();
+	vector<string> column_names = {input.inputs[1].ToString()};
 
-	// Optional parameters with defaults
-	double eps = input.inputs.size() > 2 ? input.inputs[2].GetValue<double>() : 0.5;
-	size_t min_pts = input.inputs.size() > 3 ? input.inputs[3].GetValue<int64_t>() : 5;
-	string output_mode = input.inputs.size() > 4 ? input.inputs[4].ToString() : "summary";
+	double eps;
+	int64_t min_pts;
+	string output_mode;
+	ParseDBSCANParameters(input, "dbscan", eps, min_pts, output_mode);
 
-	// Validate parameters
-	if (eps <= 0.0) {
-		throw BinderException("eps must be > 0.0");
-	}
-	if (min_pts < 1) {
-		throw BinderException("min_pts must be >= 1");
-	}
-
-	string table_ref = BuildQueryTableRef(table_name);
-
-	// For now, use simple placeholder SQL (distance > eps detection)
-	string sql = (output_mode == "clusters") ?
-		"WITH data_sample AS ("
-		"SELECT ROW_NUMBER() OVER () as row_id, CAST(" + QuoteSqlIdentifier(column_name) + " AS DOUBLE) as value "
-		"FROM (SELECT * FROM " + table_ref + ") WHERE " + QuoteSqlIdentifier(column_name) + " IS NOT NULL"
-		") "
-		"SELECT row_id, value, 0 as cluster_id, CAST('CORE' AS VARCHAR) as point_type, 5 as neighbor_count, 0.5 as anomaly_score, false as is_anomaly "
-		"FROM data_sample ORDER BY row_id" :
-		"WITH data_sample AS ("
-		"SELECT COUNT(*) as total_count, COUNT(DISTINCT CAST(" + QuoteSqlIdentifier(column_name) + " AS DOUBLE)) as cluster_count, "
-		"COUNT(CASE WHEN CAST(" + QuoteSqlIdentifier(column_name) + " AS DOUBLE) > 1000 THEN 1 END) as noise_count "
-		"FROM (SELECT * FROM " + table_ref + ") WHERE " + QuoteSqlIdentifier(column_name) + " IS NOT NULL"
-		") "
-		"SELECT 'pass' as status, cluster_count, noise_count, total_count, "
-		"CAST(noise_count AS DOUBLE) / CAST(total_count AS DOUBLE) as noise_rate, "
-		"cluster_count as largest_cluster_size, CAST(" + std::to_string(eps) + " AS DOUBLE) as eps, "
-		"CAST(" + std::to_string(min_pts) + " AS BIGINT) as min_pts, 'DBSCAN clustering complete' as message "
-		"FROM data_sample";
-
-	return ParseSubquery(sql, context.GetParserOptions(), "Failed to parse DBSCAN metric query");
+	DefineDBSCANSchema(output_mode, /*include_value=*/true, /*include_n_columns=*/false, return_types, names);
+	return make_uniq<DBSCANBindData>(table_name, std::move(column_names), eps, min_pts, output_mode, false);
 }
 
 // Bind function for multivariate DBSCAN
-static unique_ptr<TableRef> MetricDBSCANMultivariateBindReplace(ClientContext &context, TableFunctionBindInput &input) {
+static unique_ptr<FunctionData> DBSCANMultivariateBind(ClientContext &context, TableFunctionBindInput &input,
+                                                       vector<LogicalType> &return_types, vector<string> &names) {
 	PostHogTelemetry::Instance().CaptureFunctionExecution("metric_dbscan_mv");
 	if (input.inputs.size() < 2) {
-		throw BinderException("anofox_metric_dbscan_multivariate requires at least 2 arguments: table_name, column_names");
+		throw BinderException("dbscan_mv requires at least 2 arguments: table_name, column_names");
 	}
 
 	string table_name = input.inputs[0].ToString();
-
-	// Parse comma-separated column names
-	string columns_str = input.inputs[1].ToString();
-	vector<string> column_names;
-
-	size_t start = 0;
-	for (size_t i = 0; i <= columns_str.length(); ++i) {
-		if (i == columns_str.length() || columns_str[i] == ',') {
-			string col = columns_str.substr(start, i - start);
-			size_t col_start = col.find_first_not_of(" \t\n\r");
-			size_t col_end = col.find_last_not_of(" \t\n\r");
-			if (col_start != string::npos) {
-				col = col.substr(col_start, col_end - col_start + 1);
-				if ((col.front() == '"' && col.back() == '"') ||
-				    (col.front() == '\'' && col.back() == '\'')) {
-					col = col.substr(1, col.length() - 2);
-				}
-				column_names.push_back(col);
-			}
-			start = i + 1;
-		}
-	}
-
+	auto column_names = ParseCommaSeparatedColumns(input.inputs[1].ToString());
 	if (column_names.empty()) {
 		throw BinderException("column_names must contain at least one column");
 	}
 
-	double eps = input.inputs.size() > 2 ? input.inputs[2].GetValue<double>() : 0.5;
-	size_t min_pts = input.inputs.size() > 3 ? input.inputs[3].GetValue<int64_t>() : 5;
-	string output_mode = input.inputs.size() > 4 ? input.inputs[4].ToString() : "summary";
+	double eps;
+	int64_t min_pts;
+	string output_mode;
+	ParseDBSCANParameters(input, "dbscan_mv", eps, min_pts, output_mode);
 
-	if (eps <= 0.0) {
-		throw BinderException("eps must be > 0.0");
+	DefineDBSCANSchema(output_mode, /*include_value=*/false, /*include_n_columns=*/true, return_types, names);
+	return make_uniq<DBSCANBindData>(table_name, std::move(column_names), eps, min_pts, output_mode, true);
+}
+
+static const char *DBSCANPointTypeToString(PointType type) {
+	switch (type) {
+	case PointType::CORE:
+		return "CORE";
+	case PointType::BORDER:
+		return "BORDER";
+	case PointType::NOISE:
+		return "NOISE";
+	default:
+		return "UNVISITED";
 	}
-	if (min_pts < 1) {
-		throw BinderException("min_pts must be >= 1");
+}
+
+// Execute DBSCAN clustering
+static void DBSCANExecute(ClientContext &context, TableFunctionInput &data_p, DataChunk &output) {
+	auto &bind_data = data_p.bind_data->Cast<DBSCANBindData>();
+	auto &state = data_p.global_state->Cast<DBSCANGlobalState>();
+
+	// Execute algorithm only once
+	if (!state.executed) {
+		state.executed = true;
+
+		Connection con(*context.db);
+
+		// Materialize the selected columns as DOUBLE, skipping rows with NULLs
+		// (same query path as the isolation forest table function)
+		string column_list;
+		string null_checks;
+		for (size_t i = 0; i < bind_data.column_names.size(); ++i) {
+			if (i > 0) {
+				column_list += ", ";
+				null_checks += " AND ";
+			}
+			column_list += "CAST(" + QuoteSqlIdentifier(bind_data.column_names[i]) + " AS DOUBLE)";
+			null_checks += QuoteSqlIdentifier(bind_data.column_names[i]) + " IS NOT NULL";
+		}
+		string query = "SELECT " + column_list + " FROM " + BuildQueryTableRef(bind_data.table_name) + " WHERE " +
+		               null_checks;
+
+		auto result = con.Query(query);
+		if (result->HasError()) {
+			throw InvalidInputException("Failed to query source table: %s", result->GetError());
+		}
+
+		std::vector<std::vector<double>> data;
+		while (true) {
+			auto chunk = result->Fetch();
+			if (!chunk || chunk->size() == 0) {
+				break;
+			}
+			for (idx_t row = 0; row < chunk->size(); ++row) {
+				std::vector<double> point;
+				point.reserve(chunk->ColumnCount());
+				bool valid_row = true;
+				for (idx_t col = 0; col < chunk->ColumnCount(); ++col) {
+					auto val = chunk->GetValue(col, row);
+					if (val.IsNull()) {
+						valid_row = false;
+						break;
+					}
+					point.push_back(val.GetValue<double>());
+				}
+				if (valid_row) {
+					if (!bind_data.is_multivariate) {
+						state.first_column_values.push_back(point[0]);
+					}
+					data.push_back(std::move(point));
+				}
+			}
+		}
+
+		state.total_count = static_cast<int64_t>(data.size());
+
+		if (!data.empty()) {
+			DBSCAN dbscan(bind_data.eps, static_cast<size_t>(bind_data.min_pts));
+			dbscan.Fit(data);
+
+			state.points = dbscan.GetResults();
+			state.anomaly_scores = dbscan.ComputeAnomalyScores();
+			state.cluster_count = static_cast<int64_t>(dbscan.GetClusterCount());
+			state.noise_count = static_cast<int64_t>(dbscan.GetNoiseCount());
+			state.largest_cluster_size = static_cast<int64_t>(dbscan.GetLargestClusterSize());
+		}
+
+		AnofoxTrace(AnofoxLogLevel::Debug, "metric: dbscan table='" + bind_data.table_name +
+		                                       "' rows=" + std::to_string(state.total_count) +
+		                                       " clusters=" + std::to_string(state.cluster_count) +
+		                                       " noise=" + std::to_string(state.noise_count));
 	}
 
-	string table_ref = BuildQueryTableRef(table_name);
+	// Output results
+	if (bind_data.output_mode == "clusters") {
+		// Clusters mode - return one row per input point
+		idx_t count = 0;
+		while (state.current_row < state.points.size() && count < STANDARD_VECTOR_SIZE) {
+			auto &pt = state.points[state.current_row];
+			idx_t col = 0;
+			output.SetValue(col++, count, Value::BIGINT(static_cast<int64_t>(state.current_row + 1))); // 1-indexed
+			if (!bind_data.is_multivariate) {
+				output.SetValue(col++, count, Value::DOUBLE(state.first_column_values[state.current_row]));
+			}
+			output.SetValue(col++, count, Value::INTEGER(pt.cluster_id));
+			output.SetValue(col++, count, Value(DBSCANPointTypeToString(pt.point_type)));
+			output.SetValue(col++, count, Value::BIGINT(static_cast<int64_t>(pt.neighbor_count)));
+			output.SetValue(col++, count, Value::DOUBLE(state.anomaly_scores[state.current_row]));
+			output.SetValue(col++, count, Value::BOOLEAN(pt.cluster_id == -1));
+			state.current_row++;
+			count++;
+		}
+		output.SetCardinality(count);
+	} else {
+		// Summary mode - return single row
+		if (state.current_row == 0) {
+			string status = state.noise_count > 0 ? "fail" : "pass";
+			string message = state.noise_count == 0
+			                     ? "No noise points detected"
+			                     : std::to_string(state.noise_count) + " noise point(s) detected";
+			double noise_rate = state.total_count > 0
+			                        ? static_cast<double>(state.noise_count) / static_cast<double>(state.total_count)
+			                        : 0.0;
 
-	// Placeholder SQL for multivariate DBSCAN
-	string sql = (output_mode == "clusters") ?
-		"WITH data_sample AS ("
-		"SELECT ROW_NUMBER() OVER () as row_id "
-		"FROM (SELECT * FROM " + table_ref + ") LIMIT 10"
-		") "
-		"SELECT row_id, 0 as cluster_id, CAST('CORE' AS VARCHAR) as point_type, 5 as neighbor_count, 0.5 as anomaly_score, false as is_anomaly "
-		"FROM data_sample ORDER BY row_id" :
-		"SELECT 'pass' as status, 3 as cluster_count, 1 as noise_count, 10 as total_count, "
-		"0.1 as noise_rate, 5 as largest_cluster_size, CAST(" + std::to_string(eps) + " AS DOUBLE) as eps, "
-		"CAST(" + std::to_string(min_pts) + " AS BIGINT) as min_pts, CAST(" + std::to_string(column_names.size()) + " AS INTEGER) as n_columns, "
-		"'DBSCAN multivariate clustering complete' as message";
+			idx_t col = 0;
+			output.SetValue(col++, 0, Value(status));
+			output.SetValue(col++, 0, Value::BIGINT(state.cluster_count));
+			output.SetValue(col++, 0, Value::BIGINT(state.noise_count));
+			output.SetValue(col++, 0, Value::BIGINT(state.total_count));
+			output.SetValue(col++, 0, Value::DOUBLE(noise_rate));
+			output.SetValue(col++, 0, Value::BIGINT(state.largest_cluster_size));
+			output.SetValue(col++, 0, Value::DOUBLE(bind_data.eps));
+			output.SetValue(col++, 0, Value::BIGINT(bind_data.min_pts));
+			if (bind_data.is_multivariate) {
+				output.SetValue(col++, 0, Value::INTEGER(static_cast<int32_t>(bind_data.column_names.size())));
+			}
+			output.SetValue(col++, 0, Value(message));
+			output.SetCardinality(1);
+			state.current_row = 1;
+		} else {
+			output.SetCardinality(0);
+		}
+	}
+}
 
-	return ParseSubquery(sql, context.GetParserOptions(), "Failed to parse multivariate DBSCAN metric query");
+//===--------------------------------------------------------------------===//
+// Registration
+//===--------------------------------------------------------------------===//
+
+// Helper: register every prefix arity of full_args (from min_arity up) in a function set,
+// so that all trailing parameters with bind-time defaults are optional.
+static void AddPrefixArities(TableFunctionSet &set, const string &name, const vector<LogicalType> &full_args,
+                             idx_t min_arity, table_function_t function, table_function_bind_t bind,
+                             table_function_init_global_t init_global) {
+	for (idx_t arity = min_arity; arity <= full_args.size(); ++arity) {
+		vector<LogicalType> args(full_args.begin(), full_args.begin() + arity);
+		set.AddFunction(TableFunction(name, std::move(args), function, bind, init_global));
+	}
 }
 
 void RegisterMetricFunctions(ExtensionLoader &loader) {
@@ -1522,189 +1426,84 @@ void RegisterMetricFunctions(ExtensionLoader &loader) {
 	alias_freshness_info.alias_of = "anofox_tab_freshness";
 	loader.RegisterFunction(alias_freshness_info);
 
-	// anofox_tab_isolation_forest(table_name, column_name, n_trees=100, sample_size=256, contamination=0.1, output_mode='summary', seed=NULL)
-	// (alias: isolation_forest)
-	// Uses actual C++ isolation forest algorithm
+	// anofox_tab_isolation_forest(table_name, column_name, n_trees=100, sample_size=256, contamination=0.1,
+	//                             output_mode='summary', seed=NULL) (alias: isolation_forest)
+	// All parameters after column_name are optional; defaults are applied at bind time.
+	// Uses actual C++ isolation forest algorithm.
+	const vector<LogicalType> iso_forest_args = {
+	    LogicalType(LogicalTypeId::VARCHAR), LogicalType(LogicalTypeId::VARCHAR), LogicalType(LogicalTypeId::BIGINT),
+	    LogicalType(LogicalTypeId::BIGINT),  LogicalType(LogicalTypeId::DOUBLE),  LogicalType(LogicalTypeId::VARCHAR),
+	    LogicalType(LogicalTypeId::BIGINT)};
 	TableFunctionSet iso_forest_set("anofox_tab_isolation_forest");
-
-	// 6-parameter version (without seed)
-	TableFunction iso_forest_6("anofox_tab_isolation_forest",
-	                           {LogicalType(LogicalTypeId::VARCHAR), LogicalType(LogicalTypeId::VARCHAR),
-	                            LogicalType(LogicalTypeId::BIGINT), LogicalType(LogicalTypeId::BIGINT),
-	                            LogicalType(LogicalTypeId::DOUBLE), LogicalType(LogicalTypeId::VARCHAR)},
-	                           IsolationForestExecute, IsolationForestBind, IsolationForestInit);
-	iso_forest_set.AddFunction(iso_forest_6);
-
-	// 7-parameter version (with seed)
-	TableFunction iso_forest_7("anofox_tab_isolation_forest",
-	                           {LogicalType(LogicalTypeId::VARCHAR), LogicalType(LogicalTypeId::VARCHAR),
-	                            LogicalType(LogicalTypeId::BIGINT), LogicalType(LogicalTypeId::BIGINT),
-	                            LogicalType(LogicalTypeId::DOUBLE), LogicalType(LogicalTypeId::VARCHAR),
-	                            LogicalType(LogicalTypeId::BIGINT)},
-	                           IsolationForestExecute, IsolationForestBind, IsolationForestInit);
-	iso_forest_set.AddFunction(iso_forest_7);
-
+	AddPrefixArities(iso_forest_set, "anofox_tab_isolation_forest", iso_forest_args, 2, IsolationForestExecute,
+	                 IsolationForestBind, IsolationForestInit);
 	{
 		FunctionDescription desc;
-		desc.description = "Detects univariate outliers in a numeric column using the Isolation Forest algorithm. Returns scores and outlier labels.";
+		desc.description =
+		    "Detects univariate outliers in a numeric column using the Isolation Forest algorithm. Returns scores and outlier labels.";
 		desc.parameter_names = {"table_name", "column_name", "n_trees", "sample_size", "contamination", "output_mode", "seed"};
-		desc.examples = {"SELECT * FROM isolation_forest('sales', 'amount', 100, 256, 0.05, 'all');"};
+		desc.examples = {"SELECT * FROM isolation_forest('sales', 'amount', 100, 256, 0.05, 'scores');"};
 		desc.categories = {"metric", "anomaly-detection"};
-		CreateTableFunctionInfo iso_forest_info(iso_forest_set);
-		iso_forest_info.descriptions = {std::move(desc)};
-		loader.RegisterFunction(iso_forest_info);
+		RegisterTableFunctionSetWithAlias(loader, iso_forest_set, "isolation_forest", {std::move(desc)});
 	}
 
-	// Register alias: isolation_forest
-	TableFunctionSet alias_iso_forest_set("isolation_forest");
-	alias_iso_forest_set.AddFunction(iso_forest_6);
-	alias_iso_forest_set.AddFunction(iso_forest_7);
-	CreateTableFunctionInfo alias_iso_forest_info(alias_iso_forest_set);
-	alias_iso_forest_info.alias_of = "anofox_tab_isolation_forest";
-	loader.RegisterFunction(alias_iso_forest_info);
-
-	// anofox_tab_isolation_forest_mv(table_name, column_names (comma-separated), n_trees=100, sample_size=256, contamination=0.1, output_mode='summary', seed=NULL)
-	// (alias: isolation_forest_mv)
-	// Uses actual C++ isolation forest algorithm
+	// anofox_tab_isolation_forest_mv(table_name, column_names (comma-separated), n_trees=100, sample_size=256,
+	//                                contamination=0.1, output_mode='summary', seed=NULL, ndim=1,
+	//                                coef_type='uniform', scoring_metric='depth', weight_column=NULL, ntry=1,
+	//                                prob_pick_avg_gain=0.0) (alias: isolation_forest_mv)
+	// All parameters after column_names are optional; defaults are applied at bind time.
+	const vector<LogicalType> iso_forest_mv_args = {
+	    LogicalType(LogicalTypeId::VARCHAR), LogicalType(LogicalTypeId::VARCHAR), LogicalType(LogicalTypeId::BIGINT),
+	    LogicalType(LogicalTypeId::BIGINT),  LogicalType(LogicalTypeId::DOUBLE),  LogicalType(LogicalTypeId::VARCHAR),
+	    LogicalType(LogicalTypeId::BIGINT),  LogicalType(LogicalTypeId::BIGINT),  LogicalType(LogicalTypeId::VARCHAR),
+	    LogicalType(LogicalTypeId::VARCHAR), LogicalType(LogicalTypeId::VARCHAR), LogicalType(LogicalTypeId::BIGINT),
+	    LogicalType(LogicalTypeId::DOUBLE)};
 	TableFunctionSet iso_forest_mv_set("anofox_tab_isolation_forest_mv");
-
-	// 6-parameter version (without seed)
-	TableFunction iso_forest_mv_6("anofox_tab_isolation_forest_mv",
-	                              {LogicalType(LogicalTypeId::VARCHAR), LogicalType(LogicalTypeId::VARCHAR),
-	                               LogicalType(LogicalTypeId::BIGINT), LogicalType(LogicalTypeId::BIGINT),
-	                               LogicalType(LogicalTypeId::DOUBLE), LogicalType(LogicalTypeId::VARCHAR)},
-	                              IsolationForestExecute, IsolationForestMultivariateBind, IsolationForestInit);
-	iso_forest_mv_set.AddFunction(iso_forest_mv_6);
-
-	// 7-parameter version (with seed)
-	TableFunction iso_forest_mv_7("anofox_tab_isolation_forest_mv",
-	                              {LogicalType(LogicalTypeId::VARCHAR), LogicalType(LogicalTypeId::VARCHAR),
-	                               LogicalType(LogicalTypeId::BIGINT), LogicalType(LogicalTypeId::BIGINT),
-	                               LogicalType(LogicalTypeId::DOUBLE), LogicalType(LogicalTypeId::VARCHAR),
-	                               LogicalType(LogicalTypeId::BIGINT)},
-	                              IsolationForestExecute, IsolationForestMultivariateBind, IsolationForestInit);
-	iso_forest_mv_set.AddFunction(iso_forest_mv_7);
-
-	// 8-parameter version (with seed and ndim for Extended IF)
-	TableFunction iso_forest_mv_8("anofox_tab_isolation_forest_mv",
-	                              {LogicalType(LogicalTypeId::VARCHAR), LogicalType(LogicalTypeId::VARCHAR),
-	                               LogicalType(LogicalTypeId::BIGINT), LogicalType(LogicalTypeId::BIGINT),
-	                               LogicalType(LogicalTypeId::DOUBLE), LogicalType(LogicalTypeId::VARCHAR),
-	                               LogicalType(LogicalTypeId::BIGINT), LogicalType(LogicalTypeId::BIGINT)},
-	                              IsolationForestExecute, IsolationForestMultivariateBind, IsolationForestInit);
-	iso_forest_mv_set.AddFunction(iso_forest_mv_8);
-
-	// 9-parameter version (with seed, ndim, and coef_type for Extended IF)
-	TableFunction iso_forest_mv_9("anofox_tab_isolation_forest_mv",
-	                              {LogicalType(LogicalTypeId::VARCHAR), LogicalType(LogicalTypeId::VARCHAR),
-	                               LogicalType(LogicalTypeId::BIGINT), LogicalType(LogicalTypeId::BIGINT),
-	                               LogicalType(LogicalTypeId::DOUBLE), LogicalType(LogicalTypeId::VARCHAR),
-	                               LogicalType(LogicalTypeId::BIGINT), LogicalType(LogicalTypeId::BIGINT),
-	                               LogicalType(LogicalTypeId::VARCHAR)},
-	                              IsolationForestExecute, IsolationForestMultivariateBind, IsolationForestInit);
-	iso_forest_mv_set.AddFunction(iso_forest_mv_9);
-
-	// 10-parameter version (with scoring_metric)
-	TableFunction iso_forest_mv_10("anofox_tab_isolation_forest_mv",
-	                               {LogicalType(LogicalTypeId::VARCHAR), LogicalType(LogicalTypeId::VARCHAR),
-	                                LogicalType(LogicalTypeId::BIGINT), LogicalType(LogicalTypeId::BIGINT),
-	                                LogicalType(LogicalTypeId::DOUBLE), LogicalType(LogicalTypeId::VARCHAR),
-	                                LogicalType(LogicalTypeId::BIGINT), LogicalType(LogicalTypeId::BIGINT),
-	                                LogicalType(LogicalTypeId::VARCHAR), LogicalType(LogicalTypeId::VARCHAR)},
-	                               IsolationForestExecute, IsolationForestMultivariateBind, IsolationForestInit);
-	iso_forest_mv_set.AddFunction(iso_forest_mv_10);
-
-	// 11-parameter version (with weight_column)
-	TableFunction iso_forest_mv_11("anofox_tab_isolation_forest_mv",
-	                               {LogicalType(LogicalTypeId::VARCHAR), LogicalType(LogicalTypeId::VARCHAR),
-	                                LogicalType(LogicalTypeId::BIGINT), LogicalType(LogicalTypeId::BIGINT),
-	                                LogicalType(LogicalTypeId::DOUBLE), LogicalType(LogicalTypeId::VARCHAR),
-	                                LogicalType(LogicalTypeId::BIGINT), LogicalType(LogicalTypeId::BIGINT),
-	                                LogicalType(LogicalTypeId::VARCHAR), LogicalType(LogicalTypeId::VARCHAR),
-	                                LogicalType(LogicalTypeId::VARCHAR)},
-	                               IsolationForestExecute, IsolationForestMultivariateBind, IsolationForestInit);
-	iso_forest_mv_set.AddFunction(iso_forest_mv_11);
-
-	// 12-parameter version (with ntry for SCiForest)
-	TableFunction iso_forest_mv_12("anofox_tab_isolation_forest_mv",
-	                               {LogicalType(LogicalTypeId::VARCHAR), LogicalType(LogicalTypeId::VARCHAR),
-	                                LogicalType(LogicalTypeId::BIGINT), LogicalType(LogicalTypeId::BIGINT),
-	                                LogicalType(LogicalTypeId::DOUBLE), LogicalType(LogicalTypeId::VARCHAR),
-	                                LogicalType(LogicalTypeId::BIGINT), LogicalType(LogicalTypeId::BIGINT),
-	                                LogicalType(LogicalTypeId::VARCHAR), LogicalType(LogicalTypeId::VARCHAR),
-	                                LogicalType(LogicalTypeId::VARCHAR), LogicalType(LogicalTypeId::BIGINT)},
-	                               IsolationForestExecute, IsolationForestMultivariateBind, IsolationForestInit);
-	iso_forest_mv_set.AddFunction(iso_forest_mv_12);
-
-	// 13-parameter version (with ntry and prob_pick_avg_gain for SCiForest)
-	TableFunction iso_forest_mv_13("anofox_tab_isolation_forest_mv",
-	                               {LogicalType(LogicalTypeId::VARCHAR), LogicalType(LogicalTypeId::VARCHAR),
-	                                LogicalType(LogicalTypeId::BIGINT), LogicalType(LogicalTypeId::BIGINT),
-	                                LogicalType(LogicalTypeId::DOUBLE), LogicalType(LogicalTypeId::VARCHAR),
-	                                LogicalType(LogicalTypeId::BIGINT), LogicalType(LogicalTypeId::BIGINT),
-	                                LogicalType(LogicalTypeId::VARCHAR), LogicalType(LogicalTypeId::VARCHAR),
-	                                LogicalType(LogicalTypeId::VARCHAR), LogicalType(LogicalTypeId::BIGINT),
-	                                LogicalType(LogicalTypeId::DOUBLE)},
-	                               IsolationForestExecute, IsolationForestMultivariateBind, IsolationForestInit);
-	iso_forest_mv_set.AddFunction(iso_forest_mv_13);
-
+	AddPrefixArities(iso_forest_mv_set, "anofox_tab_isolation_forest_mv", iso_forest_mv_args, 2,
+	                 IsolationForestExecute, IsolationForestMultivariateBind, IsolationForestInit);
 	{
 		FunctionDescription desc;
-		desc.description = "Detects multivariate outliers across multiple numeric columns (comma-separated) using the Isolation Forest algorithm.";
-		desc.parameter_names = {"table_name", "column_names", "n_trees", "sample_size", "contamination", "output_mode", "seed"};
-		desc.examples = {"SELECT * FROM isolation_forest_mv('sales', 'amount,qty', 100, 256, 0.05, 'all');"};
+		desc.description =
+		    "Detects multivariate outliers across multiple numeric columns (comma-separated) using the Isolation Forest algorithm.";
+		desc.parameter_names = {"table_name",  "column_names",   "n_trees",       "sample_size", "contamination",
+		                        "output_mode", "seed",           "ndim",          "coef_type",   "scoring_metric",
+		                        "weight_column", "ntry",         "prob_pick_avg_gain"};
+		desc.examples = {"SELECT * FROM isolation_forest_mv('sales', 'amount,qty', 100, 256, 0.05, 'scores');"};
 		desc.categories = {"metric", "anomaly-detection"};
-		CreateTableFunctionInfo iso_forest_mv_info(iso_forest_mv_set);
-		iso_forest_mv_info.descriptions = {std::move(desc)};
-		loader.RegisterFunction(iso_forest_mv_info);
+		RegisterTableFunctionSetWithAlias(loader, iso_forest_mv_set, "isolation_forest_mv", {std::move(desc)});
 	}
-
-	// Register alias: isolation_forest_mv
-	TableFunctionSet alias_iso_forest_mv_set("isolation_forest_mv");
-	alias_iso_forest_mv_set.AddFunction(iso_forest_mv_6);
-	alias_iso_forest_mv_set.AddFunction(iso_forest_mv_7);
-	alias_iso_forest_mv_set.AddFunction(iso_forest_mv_8);
-	alias_iso_forest_mv_set.AddFunction(iso_forest_mv_9);
-	alias_iso_forest_mv_set.AddFunction(iso_forest_mv_10);
-	alias_iso_forest_mv_set.AddFunction(iso_forest_mv_11);
-	alias_iso_forest_mv_set.AddFunction(iso_forest_mv_12);
-	alias_iso_forest_mv_set.AddFunction(iso_forest_mv_13);
-	CreateTableFunctionInfo alias_iso_forest_mv_info(alias_iso_forest_mv_set);
-	alias_iso_forest_mv_info.alias_of = "anofox_tab_isolation_forest_mv";
-	loader.RegisterFunction(alias_iso_forest_mv_info);
 
 	// anofox_tab_dbscan(table_name, column_name, eps=0.5, min_pts=5, output_mode='summary') (alias: dbscan)
-	TableFunction dbscan_func("anofox_tab_dbscan",
-	                           {LogicalType(LogicalTypeId::VARCHAR), LogicalType(LogicalTypeId::VARCHAR),
-	                            LogicalType(LogicalTypeId::DOUBLE), LogicalType(LogicalTypeId::BIGINT),
-	                            LogicalType(LogicalTypeId::VARCHAR)},
-	                           nullptr, nullptr);
-	dbscan_func.bind_replace = MetricDBSCANBindReplace;
+	// All parameters after column_name are optional; defaults are applied at bind time.
+	// Uses actual C++ DBSCAN algorithm.
+	const vector<LogicalType> dbscan_args = {LogicalType(LogicalTypeId::VARCHAR), LogicalType(LogicalTypeId::VARCHAR),
+	                                         LogicalType(LogicalTypeId::DOUBLE), LogicalType(LogicalTypeId::BIGINT),
+	                                         LogicalType(LogicalTypeId::VARCHAR)};
+	TableFunctionSet dbscan_set("anofox_tab_dbscan");
+	AddPrefixArities(dbscan_set, "anofox_tab_dbscan", dbscan_args, 2, DBSCANExecute, DBSCANBind, DBSCANInit);
 	{
 		FunctionDescription desc;
 		desc.description = "Clusters rows by a numeric column using DBSCAN. Returns cluster labels and noise flags.";
 		desc.parameter_names = {"table_name", "column_name", "eps", "min_pts", "output_mode"};
-		desc.parameter_types = {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::DOUBLE, LogicalType::BIGINT, LogicalType::VARCHAR};
-		desc.examples = {"SELECT * FROM dbscan('orders', 'amount', 0.5, 5, 'all');"};
+		desc.examples = {"SELECT * FROM dbscan('orders', 'amount', 0.5, 5, 'clusters');"};
 		desc.categories = {"metric", "anomaly-detection"};
-		RegisterTableFunctionWithAlias(loader, dbscan_func, "dbscan", {std::move(desc)});
+		RegisterTableFunctionSetWithAlias(loader, dbscan_set, "dbscan", {std::move(desc)});
 	}
 
-	// anofox_tab_dbscan_mv(table_name, column_names (comma-separated), eps=0.5, min_pts=5, output_mode='summary') (alias: dbscan_mv)
-	TableFunction dbscan_mv_func("anofox_tab_dbscan_mv",
-	                              {LogicalType(LogicalTypeId::VARCHAR), LogicalType(LogicalTypeId::VARCHAR),
-	                               LogicalType(LogicalTypeId::DOUBLE), LogicalType(LogicalTypeId::BIGINT),
-	                               LogicalType(LogicalTypeId::VARCHAR)},
-	                              nullptr, nullptr);
-	dbscan_mv_func.bind_replace = MetricDBSCANMultivariateBindReplace;
+	// anofox_tab_dbscan_mv(table_name, column_names (comma-separated), eps=0.5, min_pts=5, output_mode='summary')
+	// (alias: dbscan_mv)
+	// All parameters after column_names are optional; defaults are applied at bind time.
+	TableFunctionSet dbscan_mv_set("anofox_tab_dbscan_mv");
+	AddPrefixArities(dbscan_mv_set, "anofox_tab_dbscan_mv", dbscan_args, 2, DBSCANExecute, DBSCANMultivariateBind,
+	                 DBSCANInit);
 	{
 		FunctionDescription desc;
-		desc.description = "Clusters rows by multiple numeric columns (comma-separated) using DBSCAN. Returns cluster labels and noise flags.";
+		desc.description =
+		    "Clusters rows by multiple numeric columns (comma-separated) using DBSCAN. Returns cluster labels and noise flags.";
 		desc.parameter_names = {"table_name", "column_names", "eps", "min_pts", "output_mode"};
-		desc.parameter_types = {LogicalType::VARCHAR, LogicalType::VARCHAR, LogicalType::DOUBLE, LogicalType::BIGINT, LogicalType::VARCHAR};
-		desc.examples = {"SELECT * FROM dbscan_mv('orders', 'amount,qty', 0.5, 5, 'all');"};
+		desc.examples = {"SELECT * FROM dbscan_mv('orders', 'amount,qty', 0.5, 5, 'clusters');"};
 		desc.categories = {"metric", "anomaly-detection"};
-		RegisterTableFunctionWithAlias(loader, dbscan_mv_func, "dbscan_mv", {std::move(desc)});
+		RegisterTableFunctionSetWithAlias(loader, dbscan_mv_set, "dbscan_mv", {std::move(desc)});
 	}
 }
 

--- a/test/sql/anofox_dbscan.test
+++ b/test/sql/anofox_dbscan.test
@@ -103,15 +103,197 @@ INSERT INTO dbscan_clustered_data VALUES
     (8, 100.0),
     (9, 200.0)
 
+# Fixture with a known clustering structure:
+# two tight groups {1.0, 1.1, 1.2} and {10.0, 10.1, 10.2} plus one isolated
+# point 100.0. With eps=0.5 and min_pts=2 this must yield exactly 2 clusters
+# and 1 noise point.
+statement ok
+CREATE TEMP TABLE dbscan_known_clusters (
+    id INTEGER,
+    value DOUBLE
+)
+
+statement ok
+INSERT INTO dbscan_known_clusters VALUES
+    (1, 1.0),
+    (2, 1.1),
+    (3, 1.2),
+    (4, 10.0),
+    (5, 10.1),
+    (6, 10.2),
+    (7, 100.0)
+
+# ===--------------------------------------------------------------------===
+# Real Clustering Results (known fixture)
+# ===--------------------------------------------------------------------===
+
+# Test K1: Summary mode returns the true cluster/noise/total counts
+query IIII
+SELECT cluster_count, noise_count, total_count, largest_cluster_size
+FROM dbscan('dbscan_known_clusters', 'value', 0.5, 2, 'summary')
+----
+2	1	7	3
+
+# Test K2: Summary mode echoes parameters and reports noise via status
+query TRI
+SELECT status, eps, min_pts
+FROM dbscan('dbscan_known_clusters', 'value', 0.5, 2, 'summary')
+----
+fail	0.5	2
+
+# Test K3: Summary mode noise rate is noise_count / total_count
+query R
+SELECT round(noise_rate, 3) FROM dbscan('dbscan_known_clusters', 'value', 0.5, 2, 'summary')
+----
+0.143
+
+# Test K4: Clusters mode returns the true per-row cluster assignment
+query IIT
+SELECT row_id, cluster_id, point_type
+FROM dbscan('dbscan_known_clusters', 'value', 0.5, 2, 'clusters')
+ORDER BY row_id
+----
+1	0	CORE
+2	0	CORE
+3	0	CORE
+4	1	CORE
+5	1	CORE
+6	1	CORE
+7	-1	NOISE
+
+# Test K5: Noise point is flagged as anomaly with maximum score
+query IRT
+SELECT cluster_id, anomaly_score, is_anomaly
+FROM dbscan('dbscan_known_clusters', 'value', 0.5, 2, 'clusters')
+WHERE row_id = 7
+----
+-1	1.0	true
+
+# Test K6: Cluster members are not anomalies and score below noise
+query I
+SELECT COUNT(*)
+FROM dbscan('dbscan_known_clusters', 'value', 0.5, 2, 'clusters')
+WHERE NOT is_anomaly AND anomaly_score < 0.5 AND neighbor_count >= 2
+----
+6
+
+# Test K7: Clusters mode reports the original values
+query R
+SELECT value FROM dbscan('dbscan_known_clusters', 'value', 0.5, 2, 'clusters')
+WHERE row_id = 4
+----
+10.0
+
+# Test K8: When no noise exists the summary passes
+query TII
+SELECT status, cluster_count, noise_count
+FROM dbscan('dbscan_identical_values', 'value', 0.5, 2, 'summary')
+----
+pass	1	0
+
+# Test K9: Multivariate summary returns the true counts (same structure in 2D)
+statement ok
+CREATE TEMP TABLE dbscan_mv_known (
+    id INTEGER,
+    x DOUBLE,
+    y DOUBLE
+)
+
+statement ok
+INSERT INTO dbscan_mv_known VALUES
+    (1, 1.0, 1.0),
+    (2, 1.1, 1.1),
+    (3, 1.2, 1.2),
+    (4, 10.0, 10.0),
+    (5, 10.1, 10.1),
+    (6, 10.2, 10.2),
+    (7, 100.0, 100.0)
+
+query IIIII
+SELECT cluster_count, noise_count, total_count, largest_cluster_size, n_columns
+FROM dbscan_mv('dbscan_mv_known', 'x,y', 0.5, 2, 'summary')
+----
+2	1	7	3	2
+
+# Test K10: Multivariate clusters mode returns the true per-row assignment
+query IIT
+SELECT row_id, cluster_id, point_type
+FROM dbscan_mv('dbscan_mv_known', 'x,y', 0.5, 2, 'clusters')
+ORDER BY row_id
+----
+1	0	CORE
+2	0	CORE
+3	0	CORE
+4	1	CORE
+5	1	CORE
+6	1	CORE
+7	-1	NOISE
+
+# ===--------------------------------------------------------------------===
+# Arity / Default Parameter Tests
+# ===--------------------------------------------------------------------===
+
+# Test A1: dbscan(table, column) binds with defaults (eps=0.5, min_pts=5, summary)
+query II
+SELECT cluster_count, noise_count FROM dbscan('dbscan_known_clusters', 'value')
+----
+0	7
+
+# Test A2: dbscan(table, column, eps) binds with min_pts=5 default
+query II
+SELECT cluster_count, noise_count FROM dbscan('dbscan_known_clusters', 'value', 0.5)
+----
+0	7
+
+# Test A3: dbscan(table, column, eps, min_pts) defaults to summary mode
+query II
+SELECT cluster_count, noise_count FROM dbscan('dbscan_known_clusters', 'value', 0.5, 2)
+----
+2	1
+
+# Test A4: dbscan_mv(table, columns) binds with defaults
+query II
+SELECT cluster_count, noise_count FROM dbscan_mv('dbscan_mv_known', 'x,y')
+----
+0	7
+
+# Test A5: dbscan_mv(table, columns, eps, min_pts) defaults to summary mode
+query II
+SELECT cluster_count, noise_count FROM dbscan_mv('dbscan_mv_known', 'x,y', 0.5, 2)
+----
+2	1
+
+# ===--------------------------------------------------------------------===
+# output_mode Validation
+# ===--------------------------------------------------------------------===
+
+# Test V1: Invalid output_mode for dbscan errors at bind time
+statement error
+SELECT * FROM dbscan('dbscan_known_clusters', 'value', 0.5, 2, 'bogus')
+----
+output_mode must be
+
+# Test V2: 'scores' is not a valid dbscan output mode
+statement error
+SELECT * FROM dbscan('dbscan_known_clusters', 'value', 0.5, 2, 'all')
+----
+output_mode must be
+
+# Test V3: Invalid output_mode for dbscan_mv errors at bind time
+statement error
+SELECT * FROM dbscan_mv('dbscan_mv_known', 'x,y', 0.5, 2, 'bogus')
+----
+output_mode must be
+
 # ===--------------------------------------------------------------------===
 # Univariate Summary Mode Tests
 # ===--------------------------------------------------------------------===
 
-# Test 1: Basic summary mode with default parameters
+# Test 1: With eps=0.5/min_pts=5 every point of dbscan_normal_data is noise
 query T
 SELECT status FROM dbscan('dbscan_normal_data', 'value', 0.5, 5, 'summary')
 ----
-pass
+fail
 
 # Test 2: Summary mode with different eps parameter
 query I
@@ -125,17 +307,17 @@ SELECT COUNT(*) FROM dbscan('dbscan_normal_data', 'value', 0.5, 2, 'summary')
 ----
 1
 
-# Test 4: Check message field in summary mode
+# Test 4: Check message field in summary mode (all 6 points are noise)
 query T
 SELECT message FROM dbscan('dbscan_normal_data', 'value', 0.5, 5, 'summary')
 ----
-DBSCAN clustering complete
+6 noise point(s) detected
 
-# Test 5: Summary on data with clear clusters
+# Test 5: Summary on data with clear clusters (100.0 and 200.0 are noise)
 query T
 SELECT status FROM dbscan('dbscan_clustered_data', 'value', 2.0, 2, 'summary')
 ----
-pass
+fail
 
 # Test 6: Summary on small dataset
 query T
@@ -191,11 +373,11 @@ SELECT COUNT(*) FROM dbscan('dbscan_empty', 'value', 0.5, 5, 'clusters')
 ----
 0
 
-# Test 13: Single row - summary mode
-query T
-SELECT status FROM dbscan('dbscan_single_row', 'value', 0.5, 5, 'summary')
+# Test 13: Single row - the single point has no neighbours, so it is noise
+query TII
+SELECT status, cluster_count, noise_count FROM dbscan('dbscan_single_row', 'value', 0.5, 5, 'summary')
 ----
-pass
+fail	0	1
 
 # Test 14: Single row - clusters mode
 query I
@@ -213,7 +395,7 @@ SELECT status FROM dbscan('dbscan_identical_values', 'value', 0.5, 2, 'summary')
 ----
 pass
 
-# Test 16: Identical values - clusters mode
+# Test 16: Identical values - clusters mode (all points are CORE)
 query I
 SELECT COUNT(DISTINCT point_type) FROM dbscan('dbscan_identical_values', 'value', 0.5, 2, 'clusters')
 ----
@@ -267,63 +449,63 @@ min_pts must be
 # Different Epsilon Values
 # ===--------------------------------------------------------------------===
 
-# Test 23: Very small epsilon (0.1)
+# Test 23: Very small epsilon (0.1) - all points isolated -> noise
 query T
 SELECT status FROM dbscan('dbscan_normal_data', 'value', 0.1, 5, 'summary')
 ----
-pass
+fail
 
-# Test 24: Small epsilon (1.0)
+# Test 24: Small epsilon (1.0) - still no dense region of min_pts points
 query T
 SELECT status FROM dbscan('dbscan_normal_data', 'value', 1.0, 5, 'summary')
 ----
-pass
+fail
 
-# Test 25: Medium epsilon (5.0)
+# Test 25: Medium epsilon (5.0) - 500.0 remains noise
 query T
 SELECT status FROM dbscan('dbscan_normal_data', 'value', 5.0, 5, 'summary')
 ----
-pass
+fail
 
-# Test 26: Large epsilon (100.0)
+# Test 26: Large epsilon (100.0) - 500.0 still out of reach
 query T
 SELECT status FROM dbscan('dbscan_normal_data', 'value', 100.0, 5, 'summary')
 ----
-pass
+fail
 
 # ===--------------------------------------------------------------------===
 # Different min_pts Values
 # ===--------------------------------------------------------------------===
 
-# Test 27: Minimal min_pts (1)
+# Test 27: Minimal min_pts (1) on dense identical values clusters everything
 query T
-SELECT status FROM dbscan('dbscan_normal_data', 'value', 0.5, 1, 'summary')
+SELECT status FROM dbscan('dbscan_identical_values', 'value', 0.5, 1, 'summary')
 ----
 pass
 
-# Test 28: Small min_pts (2)
+# Test 28: Small min_pts (2) - dbscan_normal_data points are all isolated at eps=0.5
 query T
 SELECT status FROM dbscan('dbscan_normal_data', 'value', 0.5, 2, 'summary')
 ----
-pass
+fail
 
 # Test 29: Medium min_pts (5)
 query T
 SELECT status FROM dbscan('dbscan_normal_data', 'value', 0.5, 5, 'summary')
 ----
-pass
+fail
 
 # Test 30: Large min_pts (10)
 query T
 SELECT status FROM dbscan('dbscan_normal_data', 'value', 0.5, 10, 'summary')
 ----
-pass
+fail
 
 # ===--------------------------------------------------------------------===
 # Output Mode Tests
 # ===--------------------------------------------------------------------===
 
-# Test 31: Default output mode is 'summary' when specified
+# Test 31: Summary mode returns a single row
 query I
 SELECT COUNT(*) FROM dbscan('dbscan_normal_data', 'value', 0.5, 5, 'summary')
 ----
@@ -356,7 +538,7 @@ SELECT s1.status FROM
   (SELECT status FROM dbscan('dbscan_normal_data', 'value', 0.5, 5, 'summary')) s2
 WHERE s1.status = s2.status
 ----
-pass
+fail
 
 # Test 35: Clusters mode is reproducible with same parameters
 query I
@@ -383,11 +565,11 @@ INSERT INTO dbscan_large_values VALUES
     (5, 1.01e10),
     (6, 1e15)
 
-# Test 36: Large values - summary mode
+# Test 36: Large values - 1.05e10 and 1e15 are isolated at eps=1e8
 query T
 SELECT status FROM dbscan('dbscan_large_values', 'value', 1e8, 2, 'summary')
 ----
-pass
+fail
 
 # Test 37: Large values - clusters mode should include all rows
 query I
@@ -414,11 +596,11 @@ INSERT INTO dbscan_small_values VALUES
     (5, 1.01e-10),
     (6, 1e-5)
 
-# Test 38: Small values - summary mode
+# Test 38: Small values - the 1e-5 point is noise
 query T
 SELECT status FROM dbscan('dbscan_small_values', 'value', 1e-11, 2, 'summary')
 ----
-pass
+fail
 
 # Test 39: Small values - clusters mode
 query I
@@ -445,11 +627,11 @@ INSERT INTO dbscan_negative_values VALUES
     (5, -103.0),
     (6, -500.0)
 
-# Test 40: Negative values - summary mode
+# Test 40: Negative values - no point has 5 neighbours within eps=2.0
 query T
 SELECT status FROM dbscan('dbscan_negative_values', 'value', 2.0, 5, 'summary')
 ----
-pass
+fail
 
 # Test 41: Negative values - clusters mode
 query I
@@ -476,11 +658,11 @@ INSERT INTO dbscan_mixed_sign_values VALUES
     (5, -48.0),
     (6, 200.0)
 
-# Test 42: Mixed sign values - summary mode
+# Test 42: Mixed sign values - 200.0 is noise
 query T
 SELECT status FROM dbscan('dbscan_mixed_sign_values', 'value', 10.0, 2, 'summary')
 ----
-pass
+fail
 
 # Test 43: Mixed sign values - clusters mode
 query I
@@ -492,29 +674,29 @@ SELECT COUNT(*) FROM dbscan('dbscan_mixed_sign_values', 'value', 10.0, 2, 'clust
 # Boundary Tests
 # ===--------------------------------------------------------------------===
 
-# Test 44: Boundary - eps very small (0.001)
+# Test 44: Boundary - eps very small (0.001) -> all noise
 query T
 SELECT status FROM dbscan('dbscan_normal_data', 'value', 0.001, 5, 'summary')
 ----
-pass
+fail
 
-# Test 45: Boundary - eps very large (10000.0)
+# Test 45: Boundary - eps very large (10000.0) -> one big cluster, no noise
 query T
 SELECT status FROM dbscan('dbscan_normal_data', 'value', 10000.0, 5, 'summary')
 ----
 pass
 
-# Test 46: Boundary - min_pts = 1 (minimum viable)
+# Test 46: Boundary - min_pts = 1 on dense data clusters everything
 query T
-SELECT status FROM dbscan('dbscan_normal_data', 'value', 0.5, 1, 'summary')
+SELECT status FROM dbscan('dbscan_identical_values', 'value', 0.5, 1, 'summary')
 ----
 pass
 
-# Test 47: Boundary - min_pts = dataset size
+# Test 47: Boundary - min_pts = dataset size with isolated points -> all noise
 query T
 SELECT status FROM dbscan('dbscan_normal_data', 'value', 0.5, 6, 'summary')
 ----
-pass
+fail
 
 # ===--------------------------------------------------------------------===
 # Return Value Type Tests
@@ -526,19 +708,19 @@ SELECT typeof(status) FROM dbscan('dbscan_normal_data', 'value', 0.5, 5, 'summar
 ----
 VARCHAR
 
-# Test 49: Summary mode - noise_count is INTEGER
+# Test 49: Summary mode - noise_count is BIGINT
 query T
 SELECT typeof(noise_count) FROM dbscan('dbscan_normal_data', 'value', 0.5, 5, 'summary')
 ----
 BIGINT
 
-# Test 50: Summary mode - total_count is INTEGER
+# Test 50: Summary mode - total_count is BIGINT
 query T
 SELECT typeof(total_count) FROM dbscan('dbscan_normal_data', 'value', 0.5, 5, 'summary')
 ----
 BIGINT
 
-# Test 51: Clusters mode - row_id is INTEGER
+# Test 51: Clusters mode - row_id is BIGINT
 query T
 SELECT typeof(row_id) FROM (
   SELECT * FROM dbscan('dbscan_normal_data', 'value', 0.5, 5, 'clusters')
@@ -547,14 +729,14 @@ SELECT typeof(row_id) FROM (
 ----
 BIGINT
 
-# Test 52: Clusters mode - anomaly_score is numeric
+# Test 52: Clusters mode - anomaly_score is DOUBLE
 query T
 SELECT typeof(anomaly_score) FROM (
   SELECT * FROM dbscan('dbscan_normal_data', 'value', 0.5, 5, 'clusters')
   LIMIT 1
 )
 ----
-DECIMAL(2,1)
+DOUBLE
 
 # Test 53: Clusters mode - point_type is VARCHAR
 query T
@@ -601,11 +783,11 @@ INSERT INTO dbscan_multivar_3col VALUES
     (4, 800.0, 400.0, 200.0),
     (5, 13.0, 23.0, 33.0)
 
-# Test 54: Multivariate summary mode - basic test
+# Test 54: Multivariate summary mode - (600,300) is noise
 query T
 SELECT status FROM dbscan_mv('dbscan_multivar_data', 'x,y', 5.0, 2, 'summary')
 ----
-pass
+fail
 
 # Test 55: Multivariate summary mode - two columns
 query I
@@ -638,7 +820,7 @@ SELECT COUNT(*) FROM (
 query T
 SELECT status FROM dbscan_mv('dbscan_multivar_data', '"x","y"', 5.0, 2, 'summary')
 ----
-pass
+fail
 
 # Test 60: Multivariate parameter validation - eps
 statement error
@@ -662,13 +844,13 @@ column_names must contain
 query T
 SELECT status FROM dbscan_mv('dbscan_multivar_data', 'x', 5.0, 2, 'summary')
 ----
-pass
+fail
 
-# Test 64: Multivariate three columns summary
+# Test 64: Multivariate three columns summary - (800,400,200) is noise
 query T
 SELECT status FROM dbscan_mv('dbscan_multivar_3col', 'a,b,c', 50.0, 2, 'summary')
 ----
-pass
+fail
 
 # Test 65: Multivariate three columns clusters count
 query I
@@ -680,38 +862,38 @@ SELECT COUNT(*) FROM dbscan_mv('dbscan_multivar_3col', 'a,b,c', 50.0, 2, 'cluste
 query T
 SELECT status FROM dbscan_mv('dbscan_multivar_data', ' x , y ', 5.0, 2, 'summary')
 ----
-pass
+fail
 
-# Test 67: Multivariate clusters mode - return types
+# Test 67: Multivariate clusters mode - CORE cluster plus NOISE point
 query I
 SELECT COUNT(DISTINCT point_type) FROM dbscan_mv('dbscan_multivar_data', 'x,y', 5.0, 2, 'clusters')
 ----
-1
+2
 
 # ===--------------------------------------------------------------------===
 # Clustering Quality Tests
 # ===--------------------------------------------------------------------===
 
-# Test 68: Verify points within cluster have low anomaly scores
+# Test 68: Points inside the cluster have low anomaly scores; 500.0 is noise
 query I
 SELECT COUNT(*) FROM dbscan('dbscan_normal_data', 'value', 5.0, 2, 'clusters')
 WHERE anomaly_score <= 0.5
 ----
-6
+5
 
-# Test 69: Verify outliers have higher anomaly scores
+# Test 69: All anomaly scores are non-negative
 query I
 SELECT COUNT(*) FROM dbscan('dbscan_normal_data', 'value', 2.0, 5, 'clusters')
 WHERE anomaly_score >= 0.0
 ----
 6
 
-# Test 70: Multi-cluster detection with clear separation
+# Test 70: Multi-cluster detection with clear separation finds both clusters
 query I
 SELECT COUNT(DISTINCT cluster_id) FROM dbscan('dbscan_clustered_data', 'value', 2.0, 2, 'clusters')
 WHERE cluster_id >= 0
 ----
-1
+2
 
 # ===--------------------------------------------------------------------===
 # Special Cases: Dense vs Sparse Regions
@@ -765,11 +947,11 @@ INSERT INTO dbscan_uniform_data VALUES
     (4, 4.0),
     (5, 5.0)
 
-# Test 73: Uniform distribution with small eps - no large clusters
+# Test 73: Uniform distribution with small eps - every point is noise
 query T
 SELECT status FROM dbscan('dbscan_uniform_data', 'value', 0.5, 2, 'summary')
 ----
-pass
+fail
 
 # Test 74: Uniform distribution with large eps - single cluster
 query I
@@ -788,8 +970,10 @@ SELECT COUNT(*) FROM (
   SELECT 1
   FROM dbscan('dbscan_normal_data', 'value', 0.5, 5, 'summary')
   WHERE status IS NOT NULL
+    AND cluster_count IS NOT NULL
     AND noise_count IS NOT NULL
     AND total_count IS NOT NULL
+    AND largest_cluster_size IS NOT NULL
     AND message IS NOT NULL
 )
 ----
@@ -811,17 +995,15 @@ SELECT COUNT(*) FROM (
 
 # Test 77: Verify noise_count matches cluster_id = -1
 query I
-SELECT COUNT(*) FROM (
-  SELECT COUNT(DISTINCT cluster_id) FROM dbscan('dbscan_normal_data', 'value', 0.5, 5, 'clusters')
-  WHERE cluster_id = -1
-)
+SELECT COUNT(*) FROM dbscan('dbscan_normal_data', 'value', 0.5, 5, 'clusters')
+WHERE cluster_id = -1
 ----
-1
+6
 
 # Test 78: Verify point_type matches expected values
 query I
 SELECT COUNT(DISTINCT point_type) FROM dbscan('dbscan_normal_data', 'value', 0.5, 5, 'clusters')
-WHERE point_type IN ('CORE', 'BORDER', 'NOISE', 'UNVISITED')
+WHERE point_type IN ('CORE', 'BORDER', 'NOISE')
 ----
 1
 
@@ -839,7 +1021,7 @@ SELECT COUNT(*) FROM (
 ----
 6
 
-# Test 80: Different eps produces different results
+# Test 80: Status is deterministic across eps values that both produce noise
 query I
 SELECT COUNT(DISTINCT status) FROM (
   SELECT s1.status FROM
@@ -848,4 +1030,3 @@ SELECT COUNT(DISTINCT status) FROM (
 )
 ----
 1
-

--- a/test/sql/anofox_dbscan.test
+++ b/test/sql/anofox_dbscan.test
@@ -16,7 +16,7 @@ SET anofox_tab_trace_enabled = false
 # ===--------------------------------------------------------------------===
 
 statement ok
-CREATE TEMP TABLE dbscan_normal_data (
+CREATE TABLE dbscan_normal_data (
     id INTEGER,
     value DOUBLE
 )
@@ -31,7 +31,7 @@ INSERT INTO dbscan_normal_data VALUES
     (6, 500.0)
 
 statement ok
-CREATE TEMP TABLE dbscan_small_data (
+CREATE TABLE dbscan_small_data (
     id INTEGER,
     value DOUBLE
 )
@@ -42,7 +42,7 @@ INSERT INTO dbscan_small_data VALUES
     (2, 12.0)
 
 statement ok
-CREATE TEMP TABLE dbscan_single_row (
+CREATE TABLE dbscan_single_row (
     id INTEGER,
     value DOUBLE
 )
@@ -52,7 +52,7 @@ INSERT INTO dbscan_single_row VALUES
     (1, 42.0)
 
 statement ok
-CREATE TEMP TABLE dbscan_identical_values (
+CREATE TABLE dbscan_identical_values (
     id INTEGER,
     value DOUBLE
 )
@@ -65,7 +65,7 @@ INSERT INTO dbscan_identical_values VALUES
     (4, 50.0)
 
 statement ok
-CREATE TEMP TABLE dbscan_with_nulls (
+CREATE TABLE dbscan_with_nulls (
     id INTEGER,
     value DOUBLE
 )
@@ -80,13 +80,13 @@ INSERT INTO dbscan_with_nulls VALUES
     (6, 101.0)
 
 statement ok
-CREATE TEMP TABLE dbscan_empty (
+CREATE TABLE dbscan_empty (
     id INTEGER,
     value DOUBLE
 )
 
 statement ok
-CREATE TEMP TABLE dbscan_clustered_data (
+CREATE TABLE dbscan_clustered_data (
     id INTEGER,
     value DOUBLE
 )
@@ -108,7 +108,7 @@ INSERT INTO dbscan_clustered_data VALUES
 # point 100.0. With eps=0.5 and min_pts=2 this must yield exactly 2 clusters
 # and 1 noise point.
 statement ok
-CREATE TEMP TABLE dbscan_known_clusters (
+CREATE TABLE dbscan_known_clusters (
     id INTEGER,
     value DOUBLE
 )
@@ -193,7 +193,7 @@ pass	1	0
 
 # Test K9: Multivariate summary returns the true counts (same structure in 2D)
 statement ok
-CREATE TEMP TABLE dbscan_mv_known (
+CREATE TABLE dbscan_mv_known (
     id INTEGER,
     x DOUBLE,
     y DOUBLE
@@ -551,7 +551,7 @@ SELECT COUNT(DISTINCT point_type) FROM dbscan('dbscan_normal_data', 'value', 0.5
 # ===--------------------------------------------------------------------===
 
 statement ok
-CREATE TEMP TABLE dbscan_large_values (
+CREATE TABLE dbscan_large_values (
     id INTEGER,
     value DOUBLE
 )
@@ -582,7 +582,7 @@ SELECT COUNT(*) FROM dbscan('dbscan_large_values', 'value', 1e8, 2, 'clusters')
 # ===--------------------------------------------------------------------===
 
 statement ok
-CREATE TEMP TABLE dbscan_small_values (
+CREATE TABLE dbscan_small_values (
     id INTEGER,
     value DOUBLE
 )
@@ -613,7 +613,7 @@ SELECT COUNT(*) FROM dbscan('dbscan_small_values', 'value', 1e-11, 2, 'clusters'
 # ===--------------------------------------------------------------------===
 
 statement ok
-CREATE TEMP TABLE dbscan_negative_values (
+CREATE TABLE dbscan_negative_values (
     id INTEGER,
     value DOUBLE
 )
@@ -644,7 +644,7 @@ SELECT COUNT(*) FROM dbscan('dbscan_negative_values', 'value', 2.0, 5, 'clusters
 # ===--------------------------------------------------------------------===
 
 statement ok
-CREATE TEMP TABLE dbscan_mixed_sign_values (
+CREATE TABLE dbscan_mixed_sign_values (
     id INTEGER,
     value DOUBLE
 )
@@ -752,7 +752,7 @@ VARCHAR
 # ===--------------------------------------------------------------------===
 
 statement ok
-CREATE TEMP TABLE dbscan_multivar_data (
+CREATE TABLE dbscan_multivar_data (
     id INTEGER,
     x DOUBLE,
     y DOUBLE
@@ -768,7 +768,7 @@ INSERT INTO dbscan_multivar_data VALUES
     (6, 600.0, 300.0)
 
 statement ok
-CREATE TEMP TABLE dbscan_multivar_3col (
+CREATE TABLE dbscan_multivar_3col (
     id INTEGER,
     a DOUBLE,
     b DOUBLE,
@@ -900,7 +900,7 @@ WHERE cluster_id >= 0
 # ===--------------------------------------------------------------------===
 
 statement ok
-CREATE TEMP TABLE dbscan_dense_sparse (
+CREATE TABLE dbscan_dense_sparse (
     id INTEGER,
     value DOUBLE
 )
@@ -934,7 +934,7 @@ WHERE value > 50.0
 # ===--------------------------------------------------------------------===
 
 statement ok
-CREATE TEMP TABLE dbscan_uniform_data (
+CREATE TABLE dbscan_uniform_data (
     id INTEGER,
     value DOUBLE
 )

--- a/test/sql/anofox_isolation_forest.test
+++ b/test/sql/anofox_isolation_forest.test
@@ -1484,3 +1484,71 @@ SELECT * FROM isolation_forest_mv('eif_2d',
     'x,y', 100, 256, 0.1, 'scores', 42, 1, 'uniform', 'depth', NULL, 10, 1.5)
 ----
 prob_pick_avg_gain must be
+
+# ===--------------------------------------------------------------------===
+# Arity / Default Parameter Tests (#52)
+# ===--------------------------------------------------------------------===
+
+# Test 135: isolation_forest(table, column) binds with documented defaults
+query I
+SELECT COUNT(*) FROM isolation_forest('iso_normal_data', 'value')
+----
+1
+
+# Test 136: isolation_forest(table, column, n_trees) binds
+query I
+SELECT n_trees FROM isolation_forest('iso_normal_data', 'value', 50)
+----
+50
+
+# Test 137: isolation_forest(table, column, n_trees, sample_size) binds
+query I
+SELECT COUNT(*) FROM isolation_forest('iso_normal_data', 'value', 50, 64)
+----
+1
+
+# Test 138: isolation_forest(table, column, n_trees, sample_size, contamination) binds
+query I
+SELECT COUNT(*) FROM isolation_forest('iso_normal_data', 'value', 50, 64, 0.1)
+----
+1
+
+# Test 139: short-arity default output mode is 'summary' (single row)
+query T
+SELECT status IS NOT NULL FROM isolation_forest('iso_normal_data', 'value')
+----
+true
+
+# Test 140: isolation_forest_mv(table, columns) binds with documented defaults
+query I
+SELECT COUNT(*) FROM isolation_forest_mv('iso_with_nulls', 'id,value')
+----
+1
+
+# Test 141: isolation_forest_mv with 5 arguments binds
+query I
+SELECT COUNT(*) FROM isolation_forest_mv('iso_with_nulls', 'id,value', 50, 64, 0.1)
+----
+1
+
+# ===--------------------------------------------------------------------===
+# output_mode Validation (#52)
+# ===--------------------------------------------------------------------===
+
+# Test 142: invalid output_mode for isolation_forest errors at bind time
+statement error
+SELECT * FROM isolation_forest('iso_normal_data', 'value', 100, 256, 0.1, 'bogus')
+----
+output_mode must be
+
+# Test 143: 'all' is not a valid isolation_forest output mode
+statement error
+SELECT * FROM isolation_forest('iso_normal_data', 'value', 100, 256, 0.1, 'all')
+----
+output_mode must be
+
+# Test 144: invalid output_mode for isolation_forest_mv errors at bind time
+statement error
+SELECT * FROM isolation_forest_mv('iso_with_nulls', 'id,value', 100, 256, 0.1, 'bogus')
+----
+output_mode must be

--- a/test/sql/anofox_sql_quoting.test
+++ b/test/sql/anofox_sql_quoting.test
@@ -92,13 +92,13 @@ SELECT status IS NOT NULL FROM anofox_tab_isolation_forest('quoting it''s tbl', 
 true
 
 # ===----------------------------------------------------------------------===
-# dbscan / dbscan_mv: generated SQL via bind_replace
+# dbscan / dbscan_mv: execute generated SQL on a nested Connection
 # ===----------------------------------------------------------------------===
 
 query I
-SELECT status FROM anofox_tab_dbscan('quoting it''s tbl', 'va"l', 0.5, 2, 'summary');
+SELECT status IS NOT NULL FROM anofox_tab_dbscan('quoting it''s tbl', 'va"l', 0.5, 2, 'summary');
 ----
-pass
+true
 
 query I
 SELECT count(*) >= 0 FROM anofox_tab_dbscan_mv('quoting it''s tbl', 'va"l,select', 0.5, 2, 'clusters');


### PR DESCRIPTION
## Summary

Implements the three findings of #52 in `src/anofox_metric.cpp` (stacked on #64 / `fix/42-sql-quoting`; auto-retargets to `main` when #64 merges).

- **HIGH — real DBSCAN:** `anofox_tab_dbscan` / `anofox_tab_dbscan_mv` were `bind_replace` placeholders (univariate summary emitted `COUNT(DISTINCT …)` as `cluster_count`; multivariate emitted literal `3 as cluster_count, 1 as noise_count, 10 as total_count`; clusters mode emitted constant `cluster_id=0, point_type='CORE'`). They are now real table functions mirroring the isolation forest pattern (bind data + global state + execute): the column(s) are materialized as `DOUBLE` on a nested `Connection` (NULL rows skipped), `DBSCAN::Fit` runs, and the output is built from `GetResults`, `ComputeAnomalyScores`, `GetClusterCount`, `GetNoiseCount`, `GetLargestClusterSize`.
- **MED — reachable arities:** the bind-time defaults (`eps=0.5`, `min_pts=5`, `n_trees=100`, …) were unreachable because only fixed arities were registered. A new `AddPrefixArities` helper registers every prefix arity: `dbscan`/`dbscan_mv` 2–5 args, `isolation_forest` 2–7 args, `isolation_forest_mv` 2–13 args. `isolation_forest('t','x')` and `dbscan('t','x')` now bind. Registration uses the existing `RegisterTableFunctionSetWithAlias` helper instead of hand-rolled alias sets.
- **LOW — legacy removal:** removed the dead isolation-forest SQL generators (`GenerateIsolationForest*SQL`) and the unreferenced `MetricIsolationForest*BindReplace` functions; the duplicated comma-separated column parser is now a shared helper.
- **output_mode validation** (anticipating #55 for these binds only): `BinderException` on anything but `'summary'|'clusters'` (dbscan) / `'summary'|'scores'` (isolation forest).

## Output schemas (documented in README / API_REFERENCE)

- `summary`: `status` (`fail` when noise points exist, matching the isolation forest convention), `cluster_count`, `noise_count`, `total_count`, `noise_rate`, `largest_cluster_size`, `eps`, `min_pts`, `n_columns` (mv only), `message`
- `clusters`: `row_id`, `value` (univariate only), `cluster_id` (`-1` = noise), `point_type` (`CORE`/`BORDER`/`NOISE`), `neighbor_count`, `anomaly_score` (noise = 1.0), `is_anomaly`

## Red/green TDD

First commit is tests-only. Red evidence against the placeholder build:

```
test/sql/anofox_dbscan.test:131: Wrong result in query!
SELECT cluster_count, noise_count, total_count, largest_cluster_size
FROM dbscan('dbscan_known_clusters', 'value', 0.5, 2, 'summary');
Expected: 2  1  7  3
Actual:   7  0  7  7

test/sql/anofox_isolation_forest.test:1493: Query unexpectedly failed
SELECT COUNT(*) FROM isolation_forest('iso_normal_data', 'value');
Binder Error: No function matches the given name and argument types
'isolation_forest(VARCHAR, VARCHAR)'.
```

The known fixture (two tight groups `{1.0,1.1,1.2}`, `{10.0,10.1,10.2}` plus isolated `100.0`, `eps=0.5`, `min_pts=2`) asserts the true partition per row (cluster ids 0/0/0/1/1/1/-1, `CORE`×6 + `NOISE`) and summary counts (2 clusters, 1 noise, largest=3). Expectations were chosen to hold under both the current `DBSCAN` class semantics and the standard-DBSCAN semantics #44 introduces (fixtures avoid the minPts off-by-one boundary and border-promotion cases), so the branches compose at merge time.

## Notes

- Existing `anofox_dbscan.test` expectations that enshrined placeholder constants (always-`pass` status, `DBSCAN clustering complete` message, `DECIMAL(2,1)` score type, single-cluster assertions) were updated to honest values; fixtures switched from TEMP to regular tables because the nested `Connection` cannot see TEMP tables (same constraint as the isolation forest tests).
- One #64 quoting-test assertion (`dbscan` → `status = 'pass'`) also enshrined the placeholder's always-pass status; it now asserts `status IS NOT NULL` like its isolation-forest sibling, keeping the quoting regression intent.
- The python package translated `output_mode="scores"` straight into the SQL call for dbscan; it now maps to the SQL-level `'clusters'` mode, so the package API is unchanged under the strict validation.
- Class-level DBSCAN correctness (minPts semantics, border promotion, refit state) is #44 and intentionally untouched here.

## Tests

- `make test`: all green — `All tests passed (1 skipped test, 1756 assertions in 17 test cases)` (skip is the pre-existing `OPENVINO_AVAILABLE` gate)
- `python/tests/test_anomaly.py`: 17 passed

Closes #52
