### PR TITLE
feat: honest NER model management, bounded inputs, atomic downloads

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -300,6 +300,7 @@ endif()
 if(EXISTS "${DUCKDB_CATCH_DIR}/catch.hpp")
     add_executable(anofox_tabular_cpp_tests
         test/cpp/test_ner_lru_cache.cpp
+        test/cpp/test_ner_input_bounding.cpp
     )
     target_include_directories(anofox_tabular_cpp_tests PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/src/include

--- a/README.md
+++ b/README.md
@@ -403,6 +403,9 @@ Detect and mask Personally Identifiable Information (PII) in text data with 17 s
   - Available on: Linux x64 (glibc), macOS (x64 & ARM64)
   - Not available on: Windows x64, Linux ARM64, Linux musl (Alpine)
   - On unsupported platforms: NAME uses dictionary fallback, other NER types unavailable
+  - Inputs are truncated at the model's 512-token limit; entities beyond that are not detected
+  - The built-in tokenizer is ASCII-focused (English model); non-ASCII punctuation is not treated as a word boundary
+  - Model selection via `SET anofox_ner_model` (currently `distilbert-en` only) must happen before the model is first loaded
 
 **Masking Strategies:**
 - `REDACT` - Replace with [TYPE] label

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -1079,9 +1079,25 @@ anofox_ner_status() → TABLE(onnx_available, model_status, model_path, model_si
 **Example:**
 ```sql
 SELECT * FROM anofox_ner_status();
--- onnx_available | model_status  | model_path                                          | model_size_mb | status_message
--- true           | LOADED        | /home/user/.duckdb/extensions/anofox/ner/model.onnx | 66.5          | Model loaded successfully
+-- onnx_available | model_status  | model_path                                                                 | model_size_mb | status_message
+-- true           | LOADED        | /home/user/.duckdb/extensions/anofox/ner/distilbert-en/model_quantized.onnx | 66.5        | Model loaded successfully
 ```
+
+**NER configuration options:**
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `anofox_ner_model` | `distilbert-en` | NER model to use. Only models with downloadable assets are accepted; the value cannot be changed after the model has been loaded (restart required). |
+| `anofox_ner_device` | `AUTO` | OpenVINO inference device (`AUTO`, `CPU`, `GPU`, `GPU.0`, ...). Takes effect on next model load. |
+| `anofox_ner_cache_size` | `10000` | LRU cache size for NER results (0 disables caching). |
+
+**NER input limits:**
+
+- Inputs are truncated at the model's maximum sequence length (512 tokens for
+  DistilBERT). Entities beyond the first ~512 tokens are not detected.
+- The built-in WordPiece tokenizer is ASCII-focused: UTF-8 multibyte text is
+  kept intact inside words, but non-ASCII punctuation/whitespace is not
+  recognized as a word boundary. The bundled DistilBERT model is English-only.
 
 ---
 

--- a/src/anofox_ner.cpp
+++ b/src/anofox_ner.cpp
@@ -11,7 +11,9 @@
 #include <cctype>
 #include <thread>
 #include <chrono>
+#include <cstdio>
 #include <cstring>
+#include <system_error>
 #include <curl/curl.h>
 
 #if HAVE_SENTENCEPIECE
@@ -55,16 +57,26 @@ const std::vector<std::string>& NERModelManager::GetLabels() {
 // ============================================================================
 
 /**
- * Metadata for supported NER models
+ * Metadata for supported NER models.
+ *
+ * All on-disk asset paths and download URLs are derived from this registry
+ * (one directory per model name), so a model may only be listed here if its
+ * assets are actually downloadable (issue #56). The previously advertised
+ * "xlm-roberta-multi" entry was removed: its HuggingFace URLs do not exist
+ * (HTTP 401, the repository has no ONNX export) and SentencePiece support is
+ * disabled in the build, so selecting it silently ran DistilBERT instead.
  */
 struct ModelMetadata {
-    std::string name;           // Short identifier (e.g., "distilbert-en")
-    std::string display_name;   // Human-readable name
-    std::string model_url;      // URL to download ONNX model
-    std::string tokenizer_url;  // URL to download tokenizer config
-    std::string tokenizer_type; // "wordpiece" or "openvino"
+    std::string name;            // Short identifier (e.g., "distilbert-en")
+    std::string display_name;    // Human-readable name
+    std::string model_url;       // URL to download ONNX model
+    std::string tokenizer_url;   // URL to download tokenizer config
+    std::string model_file;      // On-disk model file name inside the model directory
+    std::string tokenizer_file;  // On-disk tokenizer file name inside the model directory
+    std::string tokenizer_type;  // "wordpiece" or "sentencepiece"
     std::vector<std::string> languages;  // Supported languages
-    size_t model_size_mb;       // Approximate model size in MB
+    size_t model_size_mb;        // Approximate model size in MB
+    size_t max_seq_length;       // Maximum input sequence length (incl. special tokens)
 };
 
 /**
@@ -77,18 +89,12 @@ static const std::vector<ModelMetadata>& GetSupportedModels() {
             "DistilBERT English (Fast, 66MB)",
             "https://huggingface.co/onnx-community/distilbert-base-cased-finetuned-conll03-english-ONNX/resolve/main/onnx/model_quantized.onnx",
             "https://huggingface.co/onnx-community/distilbert-base-cased-finetuned-conll03-english-ONNX/resolve/main/tokenizer.json",
+            "model_quantized.onnx",
+            "tokenizer.json",
             "wordpiece",
             {"en"},
-            66
-        },
-        {
-            "xlm-roberta-multi",
-            "XLM-RoBERTa Multilingual Quantized (280MB)",
-            "https://huggingface.co/Davlan/xlm-roberta-large-finetuned-conll03-english/resolve/main/onnx/model_quantized.onnx",
-            "https://huggingface.co/Davlan/xlm-roberta-large-finetuned-conll03-english/resolve/main/tokenizer.json",
-            "openvino",  // Will use OpenVINO Tokenizers extension
-            {"en", "de", "es", "nl", "fr", "it", "pt", "pl", "ru", "zh", "ja", "ar"},
-            280
+            66,
+            NER_MAX_SEQ_LENGTH
         }
     };
     return models;
@@ -209,33 +215,8 @@ bool WordPieceTokenizer::Load(const std::string &vocab_path) {
     return !vocab_.empty();
 }
 
-std::vector<std::string> WordPieceTokenizer::Tokenize(const std::string &text) {
-    // Basic tokenization: split on whitespace and punctuation
-    std::vector<std::string> words;
-    std::string current_word;
-
-    for (size_t i = 0; i < text.size(); ++i) {
-        char c = text[i];
-        if (std::isspace(static_cast<unsigned char>(c))) {
-            if (!current_word.empty()) {
-                words.push_back(current_word);
-                current_word.clear();
-            }
-        } else if (std::ispunct(static_cast<unsigned char>(c))) {
-            if (!current_word.empty()) {
-                words.push_back(current_word);
-                current_word.clear();
-            }
-            words.push_back(std::string(1, c));
-        } else {
-            current_word += c;
-        }
-    }
-    if (!current_word.empty()) {
-        words.push_back(current_word);
-    }
-
-    return words;
+int64_t WordPieceTokenizer::SequenceEndTokenId() const {
+    return SEP_TOKEN_ID;
 }
 
 int WordPieceTokenizer::TokenToId(const std::string &token) const {
@@ -260,8 +241,8 @@ TokenizedInput WordPieceTokenizer::Encode(const std::string &text) const {
     result.ids.push_back(CLS_TOKEN_ID);
     result.offsets.push_back({0, 0});  // CLS has no text position
 
-    // Tokenize text into words
-    std::vector<std::string> words = Tokenize(text);
+    // Tokenize text into words (ASCII-focused splitting, see BasicWordSplit)
+    std::vector<std::string> words = BasicWordSplit(text);
 
     // Track position in original text
     size_t text_pos = 0;
@@ -460,24 +441,81 @@ std::string NERModelManager::GetStatusMessage() const {
     return status_message_;
 }
 
-std::string NERModelManager::DefaultModelPath() {
-    // Default path: ~/.duckdb/extensions/anofox/ner/
+/**
+ * Base directory for all NER model assets: ~/.duckdb/extensions/anofox/ner
+ * Returns an empty path when no home directory can be determined.
+ */
+static std::filesystem::path NERModelBaseDir() {
 #ifdef _WIN32
     // Windows: use USERPROFILE environment variable
     const char* userprofile = std::getenv("USERPROFILE");
     if (userprofile) {
-        auto path = std::filesystem::path(userprofile) / ".duckdb" / "extensions" / "anofox" / "ner" / "model_quantized.onnx";
-        return path.string();
+        return std::filesystem::path(userprofile) / ".duckdb" / "extensions" / "anofox" / "ner";
     }
 #else
     // Unix-like: use HOME environment variable
     const char* home = std::getenv("HOME");
     if (home) {
-        auto path = std::filesystem::path(home) / ".duckdb" / "extensions" / "anofox" / "ner" / "model_quantized.onnx";
-        return path.string();
+        return std::filesystem::path(home) / ".duckdb" / "extensions" / "anofox" / "ner";
     }
 #endif
-    return "";
+    return {};
+}
+
+/**
+ * Per-model asset directory derived from the metadata registry:
+ * <base>/<model name> (issue #56: one directory per model so tokenizer and
+ * model assets always form a matched pair).
+ */
+static std::filesystem::path NERModelDir(const ModelMetadata &metadata) {
+    auto base = NERModelBaseDir();
+    if (base.empty()) {
+        return {};
+    }
+    return base / metadata.name;
+}
+
+/**
+ * Versions before issue #56 stored the DistilBERT assets directly in the
+ * base directory. Move them into the per-model directory so existing
+ * installations do not re-download ~66 MB.
+ */
+static void MigrateLegacyAssets(const ModelMetadata &metadata,
+                                const std::filesystem::path &model_dir) {
+    if (metadata.name != "distilbert-en" || model_dir.empty()) {
+        return;
+    }
+    namespace fs = std::filesystem;
+    try {
+        const auto base = model_dir.parent_path();
+        const auto legacy_model = base / metadata.model_file;
+        const auto legacy_tokenizer = base / metadata.tokenizer_file;
+        const auto new_model = model_dir / metadata.model_file;
+        const auto new_tokenizer = model_dir / metadata.tokenizer_file;
+        if (fs::exists(legacy_model) && fs::exists(legacy_tokenizer) &&
+            !fs::exists(new_model) && !fs::exists(new_tokenizer)) {
+            fs::create_directories(model_dir);
+            fs::rename(legacy_model, new_model);
+            fs::rename(legacy_tokenizer, new_tokenizer);
+            AnofoxTrace(AnofoxLogLevel::Info,
+                        "[anofox] ner: Migrated legacy model assets to " + model_dir.string());
+        }
+    } catch (const std::exception &e) {
+        AnofoxTrace(AnofoxLogLevel::Warn,
+                    std::string("[anofox] ner: Legacy asset migration failed: ") + e.what());
+    }
+}
+
+std::string NERModelManager::DefaultModelPath() {
+    const auto *metadata = GetModelMetadata(GetCurrentModelName());
+    if (!metadata) {
+        return "";
+    }
+    auto model_dir = NERModelDir(*metadata);
+    if (model_dir.empty()) {
+        return "";
+    }
+    return (model_dir / metadata->model_file).string();
 }
 
 std::string NERModelManager::GetModelPath() const {
@@ -530,24 +568,47 @@ void NERModelManager::LoadModel() {
 #if HAVE_OPENVINO
     AnofoxTrace(AnofoxLogLevel::Info, "[anofox] ner: Loading NER model...");
 
-    const std::string model_path = GetModelPath();
+    // Resolve the configured model in the metadata registry; all asset paths
+    // and download URLs are derived from the metadata (issue #56)
+    const std::string model_name = GetCurrentModelName();
+    const ModelMetadata *metadata = GetModelMetadata(model_name);
+    if (!metadata) {
+        status_.store(NERStatus::FAILED);
+        SetStatusMessage("Unknown NER model '" + model_name + "'. Valid models: " + GetValidModelNames());
+        AnofoxTrace(AnofoxLogLevel::Error, "[anofox] ner: Unknown model: " + model_name);
+        return;
+    }
+
+    const std::filesystem::path model_dir = NERModelDir(*metadata);
+    if (model_dir.empty()) {
+        status_.store(NERStatus::FAILED);
+        SetStatusMessage("Cannot determine NER model directory (HOME/USERPROFILE not set)");
+        AnofoxTrace(AnofoxLogLevel::Error, "[anofox] ner: Cannot determine model directory");
+        return;
+    }
+    const std::string model_path = (model_dir / metadata->model_file).string();
+    const std::string tokenizer_path = (model_dir / metadata->tokenizer_file).string();
     const std::string device_name = GetDevice();
     {
         std::lock_guard<std::mutex> lock(state_mutex_);
         model_path_ = model_path;
+        current_model_name_ = model_name;
     }
 
-    // Check if model file exists
-    if (!std::filesystem::exists(model_path)) {
-        AnofoxTrace(AnofoxLogLevel::Info, "[anofox] ner: Model not found, attempting download...");
+    // Reuse assets downloaded by older versions into the flat base directory
+    MigrateLegacyAssets(*metadata, model_dir);
+
+    // Model and tokenizer must be present as a matched pair; if either is
+    // missing, (re-)download both from the metadata URLs
+    if (!std::filesystem::exists(model_path) || !std::filesystem::exists(tokenizer_path)) {
+        AnofoxTrace(AnofoxLogLevel::Info, "[anofox] ner: Model assets not found, attempting download...");
         status_.store(NERStatus::DOWNLOADING);
         SetStatusMessage("Downloading model from HuggingFace...");
 
         // Create directory if it doesn't exist
-        std::filesystem::path dir_path = std::filesystem::path(model_path).parent_path();
-        std::filesystem::create_directories(dir_path);
+        std::filesystem::create_directories(model_dir);
 
-        if (!DownloadModel(model_path)) {
+        if (!DownloadModel(*metadata, model_path, tokenizer_path)) {
             status_.store(NERStatus::FAILED);
             SetStatusMessage("Failed to download model");
             AnofoxTrace(AnofoxLogLevel::Error, "[anofox] ner: Model download failed");
@@ -594,40 +655,42 @@ void NERModelManager::LoadModel() {
         // a single ov::InferRequest is stateful and must not be shared
         // across DuckDB worker threads (issue #50)
 
-        // Create and load tokenizer based on model type
-        std::string model_name = GetCurrentModelName();
-        auto* metadata = GetModelMetadata(model_name);
-
-        if (metadata && metadata->tokenizer_type == "wordpiece") {
+        // Create and load the tokenizer matching the model's metadata. A
+        // model without a working tokenizer must not report LOADED, otherwise
+        // inference silently returns no entities (issue #56)
+        if (metadata->tokenizer_type == "wordpiece") {
             // DistilBERT uses WordPiece tokenizer (tokenizer.json)
             tokenizer_ = std::make_unique<WordPieceTokenizer>();
-            auto tokenizer_path = std::filesystem::path(model_path_).parent_path() / "tokenizer.json";
-            if (!tokenizer_->Load(tokenizer_path.string())) {
-                AnofoxTrace(AnofoxLogLevel::Warn, "[anofox] ner: Failed to load tokenizer vocabulary, NER may not work correctly");
-            }
         }
 #if HAVE_SENTENCEPIECE
-        else if (metadata && metadata->tokenizer_type == "openvino") {
-            // XLM-RoBERTa uses SentencePiece tokenizer
+        else if (metadata->tokenizer_type == "sentencepiece") {
+            // XLM-RoBERTa class models use SentencePiece tokenizers
             tokenizer_ = std::make_unique<SentencePieceTokenizer>();
-            auto tokenizer_path = std::filesystem::path(model_path_).parent_path() / "sentencepiece.bpe.model";
-            if (!tokenizer_->Load(tokenizer_path.string())) {
-                AnofoxTrace(AnofoxLogLevel::Warn, "[anofox] ner: Failed to load SentencePiece model, NER may not work correctly");
-            }
         }
 #endif
         else {
-            // Default to WordPiece for backward compatibility
-            tokenizer_ = std::make_unique<WordPieceTokenizer>();
-            auto tokenizer_path = std::filesystem::path(model_path_).parent_path() / "tokenizer.json";
-            if (!tokenizer_->Load(tokenizer_path.string())) {
-                AnofoxTrace(AnofoxLogLevel::Warn, "[anofox] ner: Failed to load tokenizer vocabulary, NER may not work correctly");
-            }
+            status_.store(NERStatus::FAILED);
+            SetStatusMessage("Tokenizer type '" + metadata->tokenizer_type +
+                             "' is not supported in this build");
+            AnofoxTrace(AnofoxLogLevel::Error,
+                        "[anofox] ner: Unsupported tokenizer type: " + metadata->tokenizer_type);
+            return;
         }
+
+        if (!tokenizer_->Load(tokenizer_path)) {
+            status_.store(NERStatus::FAILED);
+            SetStatusMessage("Failed to load tokenizer from " + tokenizer_path);
+            AnofoxTrace(AnofoxLogLevel::Error,
+                        "[anofox] ner: Failed to load tokenizer: " + tokenizer_path);
+            return;
+        }
+
+        // Bound inputs at the model's maximum sequence length (issue #56);
+        // written before LOADED is published, immutable afterwards
+        max_seq_length_ = metadata->max_seq_length;
 
         {
             std::lock_guard<std::mutex> lock(state_mutex_);
-            current_model_name_ = model_name;
             status_message_ = "Model loaded successfully (" + model_name + ", device: " + exec_dev_str + ")";
         }
         // Publish LOADED last: readers that observe LOADED are guaranteed to
@@ -650,26 +713,95 @@ void NERModelManager::LoadModel() {
 #endif
 }
 
-bool NERModelManager::DownloadModel(const std::string &dest_path) {
-    // HuggingFace URLs for the DistilBERT NER model
-    static const std::string MODEL_URL =
-        "https://huggingface.co/onnx-community/distilbert-base-cased-finetuned-conll03-english-ONNX/resolve/main/onnx/model_quantized.onnx";
-    static const std::string TOKENIZER_URL =
-        "https://huggingface.co/onnx-community/distilbert-base-cased-finetuned-conll03-english-ONNX/resolve/main/tokenizer.json";
+namespace {
 
-    std::filesystem::path model_dir = std::filesystem::path(dest_path).parent_path();
-    std::string tokenizer_path = (model_dir / "tokenizer.json").string();
+// RAII wrappers for the C resources used during download (issue #56)
+struct FileDeleter {
+    void operator()(std::FILE *file) const noexcept {
+        if (file) {
+            fclose(file);
+        }
+    }
+};
+using FileHandle = std::unique_ptr<std::FILE, FileDeleter>;
 
-    // Download both files
+struct CurlDeleter {
+    void operator()(CURL *curl) const noexcept {
+        if (curl) {
+            curl_easy_cleanup(curl);
+        }
+    }
+};
+using CurlHandle = std::unique_ptr<CURL, CurlDeleter>;
+
+/**
+ * Download `url` into a `<dest>.tmp` file and atomically rename it to `dest`
+ * on success, so a partially written file can never be mistaken for a valid
+ * asset. Returns an empty string on success, an error description otherwise.
+ */
+std::string DownloadToFileAtomic(const std::string &url, const std::string &dest) {
+    const std::string tmp_path = dest + ".tmp";
+
+    {
+        FileHandle file(fopen(tmp_path.c_str(), "wb"));
+        if (!file) {
+            return "failed to open file for writing: " + tmp_path;
+        }
+
+        CurlHandle curl(curl_easy_init());
+        if (!curl) {
+            return "failed to initialize curl";
+        }
+
+        curl_easy_setopt(curl.get(), CURLOPT_URL, url.c_str());
+        curl_easy_setopt(curl.get(), CURLOPT_WRITEFUNCTION, WriteDataToFile);
+        curl_easy_setopt(curl.get(), CURLOPT_WRITEDATA, file.get());
+        curl_easy_setopt(curl.get(), CURLOPT_FOLLOWLOCATION, 1L);
+        curl_easy_setopt(curl.get(), CURLOPT_CONNECTTIMEOUT, 30L);
+        curl_easy_setopt(curl.get(), CURLOPT_TIMEOUT, 600L);  // 10 minute timeout for large model
+        curl_easy_setopt(curl.get(), CURLOPT_FAILONERROR, 1L);
+        curl_easy_setopt(curl.get(), CURLOPT_SSL_VERIFYPEER, 1L);
+        curl_easy_setopt(curl.get(), CURLOPT_SSL_VERIFYHOST, 2L);
+        curl_easy_setopt(curl.get(), CURLOPT_USERAGENT, "anofox-tabular/1.0");
+
+        CURLcode res = curl_easy_perform(curl.get());
+        long http_code = 0;
+        curl_easy_getinfo(curl.get(), CURLINFO_RESPONSE_CODE, &http_code);
+
+        if (res != CURLE_OK) {
+            std::error_code ignored;
+            std::filesystem::remove(tmp_path, ignored);
+            return std::string(curl_easy_strerror(res)) + " (HTTP " + std::to_string(http_code) + ")";
+        }
+        // FileHandle goes out of scope here, flushing and closing the file
+        // before the rename below
+    }
+
+    try {
+        std::filesystem::rename(tmp_path, dest);
+    } catch (const std::exception &e) {
+        std::error_code ignored;
+        std::filesystem::remove(tmp_path, ignored);
+        return std::string("failed to rename downloaded file: ") + e.what();
+    }
+    return "";
+}
+
+} // anonymous namespace
+
+bool NERModelManager::DownloadModel(const ModelMetadata &metadata, const std::string &model_dest,
+                                    const std::string &tokenizer_dest) {
+    // Download both assets of the model described by the metadata registry;
+    // URLs are never hard-coded here (issue #56)
     struct FileToDownload {
         std::string url;
         std::string dest;
         std::string name;
     };
 
-    std::vector<FileToDownload> files = {
-        {TOKENIZER_URL, tokenizer_path, "tokenizer.json"},
-        {MODEL_URL, dest_path, "model_quantized.onnx"}
+    const std::vector<FileToDownload> files = {
+        {metadata.tokenizer_url, tokenizer_dest, metadata.tokenizer_file},
+        {metadata.model_url, model_dest, metadata.model_file}
     };
 
     const int max_retries = 3;
@@ -687,52 +819,13 @@ bool NERModelManager::DownloadModel(const std::string &dest_path) {
 
             SetStatusMessage("Downloading " + file.name + "...");
 
-            // Open file for writing
-            FILE *fp = fopen(file.dest.c_str(), "wb");
-            if (!fp) {
-                AnofoxTrace(AnofoxLogLevel::Error, "[anofox] ner: Failed to open file for writing: " + file.dest);
-                return false;
-            }
-
-            // Initialize curl
-            CURL *curl = curl_easy_init();
-            if (!curl) {
-                fclose(fp);
-                AnofoxTrace(AnofoxLogLevel::Error, "[anofox] ner: Failed to initialize curl");
-                return false;
-            }
-
-            // Configure curl options
-            curl_easy_setopt(curl, CURLOPT_URL, file.url.c_str());
-            curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, WriteDataToFile);
-            curl_easy_setopt(curl, CURLOPT_WRITEDATA, fp);
-            curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);
-            curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT, 30L);
-            curl_easy_setopt(curl, CURLOPT_TIMEOUT, 600L);  // 10 minute timeout for large model
-            curl_easy_setopt(curl, CURLOPT_FAILONERROR, 1L);
-            curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 1L);
-            curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 2L);
-            curl_easy_setopt(curl, CURLOPT_USERAGENT, "anofox-tabular/1.0");
-
-            // Perform download
-            CURLcode res = curl_easy_perform(curl);
-            long http_code = 0;
-            curl_easy_getinfo(curl, CURLINFO_RESPONSE_CODE, &http_code);
-
-            curl_easy_cleanup(curl);
-            fclose(fp);
-
-            if (res == CURLE_OK) {
+            std::string error = DownloadToFileAtomic(file.url, file.dest);
+            if (error.empty()) {
                 download_success = true;
                 AnofoxTrace(AnofoxLogLevel::Info, "[anofox] ner: Download complete: " + file.name);
             } else {
-                const char *error_msg = curl_easy_strerror(res);
                 AnofoxTrace(AnofoxLogLevel::Warn,
-                    "[anofox] ner: Download attempt " + std::to_string(attempt) + " failed: " +
-                    std::string(error_msg) + " (HTTP " + std::to_string(http_code) + ")");
-
-                // Remove partial file
-                std::filesystem::remove(file.dest);
+                    "[anofox] ner: Download attempt " + std::to_string(attempt) + " failed: " + error);
 
                 if (attempt < max_retries) {
                     int wait_time = 1 << attempt;
@@ -749,6 +842,14 @@ bool NERModelManager::DownloadModel(const std::string &dest_path) {
             SetStatusMessage("Failed to download " + file.name);
             return false;
         }
+    }
+
+    // Both assets must exist as a matched pair before declaring success
+    if (!std::filesystem::exists(model_dest) || !std::filesystem::exists(tokenizer_dest)) {
+        AnofoxTrace(AnofoxLogLevel::Error,
+            "[anofox] ner: Download finished but assets are incomplete (model/tokenizer pair mismatch)");
+        SetStatusMessage("Download incomplete: model/tokenizer asset pair mismatch");
+        return false;
     }
 
     SetStatusMessage("Download complete");
@@ -781,6 +882,16 @@ std::vector<NEREntity> NERModelManager::RunSingleInference(const std::string &te
         TokenizedInput tokenized = tokenizer_->Encode(text);
         if (tokenized.ids.empty()) {
             return {};
+        }
+
+        // Bound the sequence at the model's maximum length (issue #56).
+        // Truncation drops whole tokens only, so the retained byte offsets
+        // are still valid; text beyond the limit is ignored.
+        if (tokenized.ids.size() > max_seq_length_) {
+            AnofoxTrace(AnofoxLogLevel::Debug,
+                "[anofox] ner: Truncating input from " + std::to_string(tokenized.ids.size()) +
+                " to " + std::to_string(max_seq_length_) + " tokens (model limit)");
+            TruncateTokenizedInput(tokenized, max_seq_length_, tokenizer_->SequenceEndTokenId());
         }
 
         size_t actual_length = tokenized.ids.size();
@@ -823,8 +934,11 @@ std::vector<NEREntity> NERModelManager::RunSingleInference(const std::string &te
         // Run inference
         infer_request.infer();
 
-        // Get output tensor
+        // Get output tensor and validate its shape before reading any logits;
+        // a mismatch would mean an out-of-bounds read (issue #56)
         ov::Tensor output_tensor = infer_request.get_output_tensor(0);
+        const ov::Shape &output_shape = output_tensor.get_shape();
+        ValidateLogitsShape(output_shape, seq_length, static_cast<size_t>(NUM_LABELS));
         const float* logits_data = output_tensor.data<float>();
 
         std::vector<float> logits(logits_data, logits_data + seq_length * NUM_LABELS);
@@ -1142,20 +1256,31 @@ void SetNERModelOption(ClientContext &context, SetScope scope, Value &parameter)
     }
     auto model_name = StringValue::Get(parameter);
 
-    // Validate model name
+    // Validate model name against the metadata registry: only models whose
+    // assets are actually downloadable are listed (issue #56)
     if (!GetModelMetadata(model_name)) {
         throw InvalidInputException(
             "Unsupported NER model: " + model_name + ". Valid models: " + GetValidModelNames());
     }
 
-    // Store the new model name
+    // Switching models after the model has been loaded (or while a load is in
+    // progress) is rejected instead of silently doing nothing: the #50
+    // architecture treats compiled model and tokenizer as immutable once
+    // LOADED is published, so a hot swap is not safe (issue #56)
+    auto snapshot = NERModelManager::Instance().GetStatusSnapshot();
+    const bool load_active = snapshot.status == NERStatus::LOADED ||
+                             snapshot.status == NERStatus::DOWNLOADING;
+    if (load_active && model_name != snapshot.model_name) {
+        throw InvalidInputException(
+            "anofox_ner_model cannot be changed after the NER model has been loaded "
+            "(currently '" + snapshot.model_name + "'). Restart the process to switch models.");
+    }
+
+    // Store the new model name; it takes effect on the first model load
     SetCurrentModelName(model_name);
 
     AnofoxTrace(AnofoxLogLevel::Info,
-                "[anofox] ner: Model set to '" + model_name + "' (reload required for changes to take effect)");
-
-    // Note: Actual model reload will happen on next EnsureInitialized() call
-    // TODO: Implement NERModelManager::ReloadModel() for immediate reload
+                "[anofox] ner: Model set to '" + model_name + "' (takes effect on first model load)");
 }
 
 void SetNERDeviceOption(ClientContext &context, SetScope scope, Value &parameter) {
@@ -1178,7 +1303,7 @@ void RegisterNEROptions(ExtensionLoader &loader) {
                               SetNERCacheSizeOption);
 
     config.AddExtensionOption("anofox_ner_model",
-                              "NER model to use: distilbert-en (fast, English) or xlm-roberta-multi (multilingual)",
+                              "NER model to use (supported: distilbert-en); must be set before the model is first loaded",
                               LogicalTypeId::VARCHAR,
                               Value("distilbert-en"),
                               SetNERModelOption);

--- a/src/include/anofox_ner.hpp
+++ b/src/include/anofox_ner.hpp
@@ -4,10 +4,13 @@
 #include <vector>
 #include <memory>
 #include <atomic>
+#include <cctype>
 #include <mutex>
 #include <unordered_map>
 #include <list>
 #include <optional>
+#include <stdexcept>
+#include <utility>
 
 #include "duckdb/main/extension/extension_loader.hpp"
 
@@ -175,6 +178,118 @@ struct TokenizedInput {
     std::vector<std::pair<size_t, size_t>> offsets;
 };
 
+// ============================================================================
+// Input bounding helpers (issue #56)
+//
+// Header-only so they can be unit-tested in anofox_tabular_cpp_tests without
+// linking OpenVINO or the rest of the extension.
+// ============================================================================
+
+/**
+ * Maximum number of tokens (including special tokens) fed into the NER model.
+ * BERT-class models such as DistilBERT have max_position_embeddings = 512;
+ * longer sequences fail shape inference inside OpenVINO.
+ */
+constexpr size_t NER_MAX_SEQ_LENGTH = 512;
+
+/**
+ * Bound a tokenized input at the model's maximum sequence length.
+ *
+ * Sequences longer than max_seq_length are truncated at a token boundary:
+ * the first max_seq_length - 1 tokens are kept and the trailing special
+ * end-of-sequence token (final_token_id) is re-appended so the model still
+ * sees a well-formed sequence. Text beyond the limit is ignored (documented
+ * truncation semantics; no sliding window).
+ *
+ * UTF-8 safety: truncation only drops whole tokens, so every retained offset
+ * pair is exactly one produced by the tokenizer — no new byte offsets that
+ * could cut into a multibyte character are ever introduced. The re-appended
+ * end token carries an empty offset range (special tokens have no position).
+ *
+ * A max_seq_length of 0 means "unbounded" and leaves the input untouched.
+ */
+inline void TruncateTokenizedInput(TokenizedInput &input, size_t max_seq_length,
+                                   int64_t final_token_id) {
+    if (max_seq_length == 0 || input.ids.size() <= max_seq_length) {
+        return;
+    }
+    input.ids.resize(max_seq_length - 1);
+    input.offsets.resize(max_seq_length - 1);
+    const size_t last_end = input.offsets.empty() ? 0 : input.offsets.back().second;
+    input.ids.push_back(final_token_id);
+    input.offsets.push_back({last_end, last_end});
+}
+
+/**
+ * Validate the shape of the model output tensor before reading any logits.
+ *
+ * The NER model must emit exactly seq_length * num_labels logits, laid out as
+ * [1, seq_length, num_labels] (or the squeezed [seq_length, num_labels]).
+ * Reading a differently shaped buffer would be out-of-bounds, so a mismatch
+ * raises a clear std::runtime_error instead.
+ */
+inline void ValidateLogitsShape(const std::vector<size_t> &shape, size_t seq_length,
+                                size_t num_labels) {
+    size_t total_elements = shape.empty() ? 0 : 1;
+    for (size_t dim : shape) {
+        total_elements *= dim;
+    }
+    const bool valid = !shape.empty() && shape.back() == num_labels &&
+                       total_elements == seq_length * num_labels;
+    if (!valid) {
+        std::string actual;
+        for (size_t i = 0; i < shape.size(); ++i) {
+            if (i > 0) {
+                actual += "x";
+            }
+            actual += std::to_string(shape[i]);
+        }
+        throw std::runtime_error(
+            "NER output tensor shape mismatch: got [" + actual + "], expected " +
+            std::to_string(seq_length) + "x" + std::to_string(num_labels) +
+            " logits (1x" + std::to_string(seq_length) + "x" + std::to_string(num_labels) + ")");
+    }
+}
+
+/**
+ * Basic word splitting used by the hand-written WordPiece tokenizer: split on
+ * ASCII whitespace and keep ASCII punctuation as separate single-char tokens.
+ *
+ * Documented limitation (issue #56): classification is per byte via
+ * std::isspace/std::ispunct, so only ASCII separators are recognized. UTF-8
+ * multibyte sequences are never split apart (continuation bytes are neither
+ * space nor punctuation), but non-ASCII punctuation/whitespace does NOT act
+ * as a word boundary. The bundled DistilBERT model is English-only, so the
+ * tokenizer is intentionally ASCII-focused.
+ */
+inline std::vector<std::string> BasicWordSplit(const std::string &text) {
+    std::vector<std::string> words;
+    std::string current_word;
+
+    for (size_t i = 0; i < text.size(); ++i) {
+        char c = text[i];
+        if (std::isspace(static_cast<unsigned char>(c))) {
+            if (!current_word.empty()) {
+                words.push_back(current_word);
+                current_word.clear();
+            }
+        } else if (std::ispunct(static_cast<unsigned char>(c))) {
+            if (!current_word.empty()) {
+                words.push_back(current_word);
+                current_word.clear();
+            }
+            words.push_back(std::string(1, c));
+        } else {
+            current_word += c;
+        }
+    }
+    if (!current_word.empty()) {
+        words.push_back(current_word);
+    }
+
+    return words;
+}
+
 /**
  * Abstract base class for tokenizers.
  * Encode() is const and returns all per-call state by value, so a loaded
@@ -186,6 +301,12 @@ public:
     virtual bool Load(const std::string &model_path) = 0;
     virtual TokenizedInput Encode(const std::string &text) const = 0;
     virtual bool IsLoaded() const = 0;
+
+    /**
+     * Id of the special token that terminates a sequence ([SEP] / </s>).
+     * Used to keep truncated sequences well-formed (issue #56).
+     */
+    virtual int64_t SequenceEndTokenId() const = 0;
 };
 
 /**
@@ -212,10 +333,14 @@ public:
      */
     bool IsLoaded() const override { return !vocab_.empty(); }
 
+    /**
+     * BERT/DistilBERT [SEP] token id
+     */
+    int64_t SequenceEndTokenId() const override;
+
 private:
     std::unordered_map<std::string, int> vocab_;
 
-    static std::vector<std::string> Tokenize(const std::string &text);
     int TokenToId(const std::string &token) const;
 };
 
@@ -243,6 +368,11 @@ public:
      */
     bool IsLoaded() const override;
 
+    /**
+     * XLM-RoBERTa </s> (EOS) token id
+     */
+    int64_t SequenceEndTokenId() const override { return EOS_TOKEN_ID; }
+
 private:
     std::unique_ptr<::sentencepiece::SentencePieceProcessor> processor_;
 
@@ -252,6 +382,12 @@ private:
     static constexpr int PAD_TOKEN_ID = 1;  // <pad>
 };
 #endif
+
+/**
+ * Metadata describing a supported NER model (defined in anofox_ner.cpp).
+ * Drives on-disk asset paths and download URLs (issue #56).
+ */
+struct ModelMetadata;
 
 /**
  * Immutable snapshot of the NER model manager status.
@@ -379,7 +515,14 @@ private:
     NERModelManager& operator=(const NERModelManager&) = delete;
 
     void LoadModel();
-    bool DownloadModel(const std::string &dest_path);
+
+    /**
+     * Download the model + tokenizer asset pair described by `metadata`.
+     * Files are first written to .tmp paths and atomically renamed on
+     * success, so partial downloads never leave mismatched pairs (issue #56).
+     */
+    bool DownloadModel(const ModelMetadata &metadata, const std::string &model_dest,
+                       const std::string &tokenizer_dest);
     std::vector<NEREntity> PostProcess(
         const std::vector<float> &logits,
         size_t seq_length,
@@ -428,6 +571,10 @@ private:
     // immutable after LoadModel() publishes NERStatus::LOADED
     std::unique_ptr<ITokenizer> tokenizer_;
     std::string current_model_name_;  // Track which model is loaded (guarded by state_mutex_)
+
+    // Maximum sequence length of the loaded model (from ModelMetadata);
+    // written by LoadModel() before LOADED is published, immutable afterwards
+    size_t max_seq_length_ = NER_MAX_SEQ_LENGTH;
 
     // Result cache for repeated texts
     std::unique_ptr<LRUCache<std::string, std::vector<NEREntity>>> result_cache_;

--- a/test/cpp/test_ner_input_bounding.cpp
+++ b/test/cpp/test_ner_input_bounding.cpp
@@ -1,0 +1,182 @@
+//===----------------------------------------------------------------------===//
+// Catch2 unit tests for NER input bounding (issue #56).
+//
+// Covers the header-only helpers used by NERModelManager::RunSingleInference:
+//  - TruncateTokenizedInput: bounds token sequences at the model's maximum
+//    sequence length while keeping the trailing special token well-formed
+//  - ValidateLogitsShape: rejects output tensors whose shape does not match
+//    seq_length x NUM_LABELS before any logits are read
+//  - BasicWordSplit: documents the current ASCII-focused word splitting of
+//    the hand-written WordPiece tokenizer (UTF-8 bytes are kept intact inside
+//    words, but non-ASCII punctuation/whitespace is NOT recognized)
+//
+// Built into anofox_tabular_cpp_tests; no OpenVINO runtime required.
+//===----------------------------------------------------------------------===//
+
+#include "catch.hpp"
+
+#include "anofox_ner.hpp"
+
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+using duckdb::anofox::BasicWordSplit;
+using duckdb::anofox::NER_MAX_SEQ_LENGTH;
+using duckdb::anofox::TokenizedInput;
+using duckdb::anofox::TruncateTokenizedInput;
+using duckdb::anofox::ValidateLogitsShape;
+
+namespace {
+
+constexpr int64_t SEP_ID = 102;
+
+/// Build a tokenized input of `count` tokens with contiguous one-byte offsets,
+/// mimicking [CLS] tok ... tok [SEP] produced by the WordPiece tokenizer.
+TokenizedInput MakeSequence(size_t count) {
+    TokenizedInput input;
+    for (size_t i = 0; i < count; ++i) {
+        input.ids.push_back(static_cast<int64_t>(1000 + i));
+        input.offsets.push_back({i, i + 1});
+    }
+    if (!input.ids.empty()) {
+        input.ids.back() = SEP_ID;
+        input.offsets.back() = {count, count};
+    }
+    return input;
+}
+
+} // namespace
+
+TEST_CASE("TruncateTokenizedInput leaves short sequences untouched", "[ner][bounding]") {
+    auto input = MakeSequence(10);
+    auto expected_ids = input.ids;
+    auto expected_offsets = input.offsets;
+
+    TruncateTokenizedInput(input, NER_MAX_SEQ_LENGTH, SEP_ID);
+
+    REQUIRE(input.ids == expected_ids);
+    REQUIRE(input.offsets == expected_offsets);
+}
+
+TEST_CASE("TruncateTokenizedInput leaves exactly-max sequences untouched", "[ner][bounding]") {
+    auto input = MakeSequence(NER_MAX_SEQ_LENGTH);
+    auto expected_ids = input.ids;
+
+    TruncateTokenizedInput(input, NER_MAX_SEQ_LENGTH, SEP_ID);
+
+    REQUIRE(input.ids == expected_ids);
+    REQUIRE(input.offsets.size() == input.ids.size());
+}
+
+TEST_CASE("TruncateTokenizedInput bounds long sequences at max length", "[ner][bounding]") {
+    auto input = MakeSequence(NER_MAX_SEQ_LENGTH + 300);
+    auto original = input;
+
+    TruncateTokenizedInput(input, NER_MAX_SEQ_LENGTH, SEP_ID);
+
+    // Bounded to the model limit, ids and offsets stay aligned
+    REQUIRE(input.ids.size() == NER_MAX_SEQ_LENGTH);
+    REQUIRE(input.offsets.size() == NER_MAX_SEQ_LENGTH);
+
+    // The kept prefix is unchanged (truncation drops whole tokens only)
+    for (size_t i = 0; i + 1 < NER_MAX_SEQ_LENGTH; ++i) {
+        REQUIRE(input.ids[i] == original.ids[i]);
+        REQUIRE(input.offsets[i] == original.offsets[i]);
+    }
+
+    // The sequence still ends with the special end-of-sequence token, carrying
+    // an empty offset range (special tokens have no text position)
+    REQUIRE(input.ids.back() == SEP_ID);
+    REQUIRE(input.offsets.back().first == input.offsets.back().second);
+}
+
+TEST_CASE("TruncateTokenizedInput with max length 0 is a no-op", "[ner][bounding]") {
+    auto input = MakeSequence(8);
+    auto expected_ids = input.ids;
+
+    TruncateTokenizedInput(input, 0, SEP_ID);
+
+    REQUIRE(input.ids == expected_ids);
+}
+
+TEST_CASE("TruncateTokenizedInput is UTF-8 safe with multibyte offsets", "[ner][bounding][utf8]") {
+    // Offsets as produced for multibyte text: each token spans a multibyte
+    // character sequence; truncation must never invent offsets that cut into
+    // these spans — every retained offset pair must already exist in the input.
+    TokenizedInput input;
+    input.ids.push_back(101); // [CLS]
+    input.offsets.push_back({0, 0});
+    size_t pos = 0;
+    const size_t token_bytes = 7; // e.g. "Müller " = 7 bytes (ü is 2 bytes)
+    const size_t max_len = 16;
+    for (size_t i = 0; i < 40; ++i) {
+        input.ids.push_back(static_cast<int64_t>(2000 + i));
+        input.offsets.push_back({pos, pos + token_bytes});
+        pos += token_bytes;
+    }
+    input.ids.push_back(SEP_ID);
+    input.offsets.push_back({pos, pos});
+
+    auto original_offsets = input.offsets;
+    TruncateTokenizedInput(input, max_len, SEP_ID);
+
+    REQUIRE(input.ids.size() == max_len);
+    REQUIRE(input.offsets.size() == max_len);
+    // All content offsets are unchanged token-boundary pairs from the input
+    for (size_t i = 0; i + 1 < max_len; ++i) {
+        REQUIRE(input.offsets[i] == original_offsets[i]);
+    }
+    // Final token is the end-of-sequence marker with an empty range
+    REQUIRE(input.ids.back() == SEP_ID);
+    REQUIRE(input.offsets.back().first == input.offsets.back().second);
+}
+
+TEST_CASE("ValidateLogitsShape accepts matching shapes", "[ner][bounding]") {
+    REQUIRE_NOTHROW(ValidateLogitsShape({1, 16, 9}, 16, 9));
+    // Rank-2 outputs with the same element count are also acceptable
+    REQUIRE_NOTHROW(ValidateLogitsShape({16, 9}, 16, 9));
+}
+
+TEST_CASE("ValidateLogitsShape rejects mismatched shapes", "[ner][bounding]") {
+    // Wrong sequence length
+    REQUIRE_THROWS_AS(ValidateLogitsShape({1, 8, 9}, 16, 9), std::runtime_error);
+    // Wrong label count
+    REQUIRE_THROWS_AS(ValidateLogitsShape({1, 16, 10}, 16, 9), std::runtime_error);
+    // Empty shape
+    REQUIRE_THROWS_AS(ValidateLogitsShape({}, 16, 9), std::runtime_error);
+    // Unexpected batch dimension
+    REQUIRE_THROWS_AS(ValidateLogitsShape({2, 16, 9}, 16, 9), std::runtime_error);
+
+    // Error message names the actual and expected shape
+    try {
+        ValidateLogitsShape({1, 8, 9}, 16, 9);
+        FAIL("expected std::runtime_error");
+    } catch (const std::runtime_error &e) {
+        std::string message = e.what();
+        REQUIRE(message.find("shape") != std::string::npos);
+        REQUIRE(message.find("16") != std::string::npos);
+    }
+}
+
+TEST_CASE("BasicWordSplit splits ASCII words and punctuation", "[ner][tokenizer]") {
+    auto words = BasicWordSplit("John Smith, CEO of ACME Inc.");
+    std::vector<std::string> expected = {"John", "Smith", ",", "CEO", "of", "ACME", "Inc", "."};
+    REQUIRE(words == expected);
+}
+
+TEST_CASE("BasicWordSplit keeps UTF-8 multibyte sequences intact (documented limitation)",
+          "[ner][tokenizer][utf8]") {
+    // The splitter classifies single bytes with std::isspace/std::ispunct, so
+    // it only understands ASCII separators. UTF-8 continuation bytes are
+    // never split apart — multibyte words survive as complete byte sequences.
+    auto words = BasicWordSplit("Herr Müller wohnt in Köln");
+    std::vector<std::string> expected = {"Herr", "M\xC3\xBCller", "wohnt", "in", "K\xC3\xB6ln"};
+    REQUIRE(words == expected);
+
+    // Documented limitation: non-ASCII punctuation (here U+00AB) is NOT a
+    // word boundary — the surrounding text stays one token.
+    auto guillemet = BasicWordSplit("a\xC2\xABb");
+    REQUIRE(guillemet.size() == 1);
+    REQUIRE(guillemet[0] == "a\xC2\xABb");
+}

--- a/test/sql/anofox_ner_options.test
+++ b/test/sql/anofox_ner_options.test
@@ -181,20 +181,25 @@ SELECT current_setting('anofox_ner_model');
 ----
 distilbert-en
 
-# 21. SET to 'xlm-roberta-multi' (valid multilingual model) - accepted
-statement ok
+# 21. SET to 'xlm-roberta-multi' - rejected: no downloadable assets exist for
+# this model, so advertising it would be a silent no-op (issue #56). The error
+# lists the supported models.
+statement error
 SET anofox_ner_model = 'xlm-roberta-multi';
+----
+Unsupported NER model
 
 query T
 SELECT current_setting('anofox_ner_model');
 ----
-xlm-roberta-multi
+distilbert-en
 
-# 22. SET to 'invalid-model' - throws (model name validated at SET time)
+# 22. SET to 'invalid-model' - throws (model name validated at SET time);
+# the error message lists the valid model names
 statement error
 SET anofox_ner_model = 'invalid-model';
 ----
-Unsupported NER model
+Valid models: distilbert-en
 
 # 23. SET to 'DISTILBERT-EN' (wrong case) - throws (case-sensitive validation)
 statement error

--- a/test/sql/anofox_ner_truncation.test
+++ b/test/sql/anofox_ner_truncation.test
@@ -1,0 +1,48 @@
+# name: test/sql/anofox_ner_truncation.test
+# description: NER long-input truncation tests (requires OpenVINO + model assets)
+# group: [anofox_tabular]
+
+# Inputs longer than the model's maximum sequence length (512 tokens for
+# DistilBERT) must be truncated at a token boundary instead of failing inside
+# OpenVINO (issue #56). Entities within the first ~512 tokens are still
+# detected; text beyond the limit is ignored (documented truncation).
+require-env OPENVINO_AVAILABLE
+
+require anofox_tabular
+
+statement ok
+LOAD anofox_tabular
+
+# Short input baseline: NER detects the organization
+query I
+SELECT list_contains(
+    list_transform(pii_detect('John Smith works at Microsoft in Seattle.'), x -> x.type),
+    'ORGANIZATION');
+----
+true
+
+# Long input (~1200 tokens): entity in the leading text must still be found.
+# Without truncation this threw inside OpenVINO and returned no NER entities.
+query I
+SELECT list_contains(
+    list_transform(
+        pii_detect('John Smith works at Microsoft in Seattle. ' ||
+                   repeat('Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore. ', 60)),
+        x -> x.type),
+    'ORGANIZATION');
+----
+true
+
+# Long input must not break subsequent short inputs (no corrupted state)
+query I
+SELECT list_contains(
+    list_transform(pii_detect('Maria Garcia visited the Eiffel Tower in Paris.'), x -> x.type),
+    'LOCATION');
+----
+true
+
+# Re-setting the currently loaded model name after load stays a no-op success
+# (switching to a different model after load is rejected; only one supported
+# model exists today, see issue #56)
+statement ok
+SET anofox_ner_model = 'distilbert-en';


### PR DESCRIPTION
Closes #56. **Stacked on PR #67** (`fix/50-ner-thread-safety`) — only the last two commits belong to this PR; it will auto-retarget to `main` when #67 merges.

## Summary

The NER module advertised model selection it could not deliver, fed unbounded inputs into a 512-token model, trusted the output tensor blindly, and downloaded assets non-atomically with raw C handles. This PR makes model management honest, bounds inputs, validates output shapes, and makes downloads atomic.

### Model management honesty (MED)
- All asset paths and download URLs are now derived from the `ModelMetadata` registry, **one directory per model** (`~/.duckdb/extensions/anofox/ner/<model>/`). Assets downloaded by older versions into the flat base directory are migrated automatically (no ~66 MB re-download).
- **`xlm-roberta-multi` removed from the supported models.** Verified its HuggingFace URLs return HTTP 401 (the `Davlan/xlm-roberta-large-finetuned-conll03-english` repo has no ONNX export), and SentencePiece is disabled in the build — selecting it silently loaded the DistilBERT assets with mismatched configuration. `SET anofox_ner_model = 'xlm-roberta-multi'` now errors listing the supported models. No URLs were invented; the metadata registry and SentencePiece tokenizer remain in place for when real assets exist.
- **Decision: restart-required instead of hot reload.** Changing `anofox_ner_model` after the model is loaded (or while a load is in flight) is rejected with a clear error. The #50 architecture publishes `compiled_model_`/`tokenizer_` as immutable once `LOADED` is stored and reads them lock-free on the inference hot path; an atomic swap would require per-call snapshotting and cache invalidation for a feature that currently has a single valid value. Documented in code and docs.
- A model whose tokenizer fails to load now reports `FAILED` instead of `LOADED` with silently empty results.

### Input bounding + output validation (MED)
- Inputs are truncated at the model limit (512 tokens for DistilBERT, from metadata) at a **token boundary**, re-appending the sequence-end token (`ITokenizer::SequenceEndTokenId()`). Previously >512-token inputs threw inside OpenVINO shape inference and **all** NER entities were lost. Truncation only drops whole tokens, so byte offsets stay UTF-8-safe; text beyond the limit is ignored (documented; no sliding window).
- `ValidateLogitsShape()` checks the output tensor against `seq_length x NUM_LABELS` before any logits are read (clear `runtime_error` on mismatch instead of a potential out-of-bounds read).
- Helpers (`TruncateTokenizedInput`, `ValidateLogitsShape`, `BasicWordSplit`) are header-only so they are unit-testable without OpenVINO.

### Atomic downloads with RAII (LOW)
- `FILE*`/`CURL*` wrapped in `unique_ptr` custom deleters; downloads go to `.tmp` files and are atomically renamed on success; the model/tokenizer pair is verified to exist before success is declared. Partial downloads can no longer leave mismatched asset pairs.

### Tokenizer (documented constraint)
- Full `tokenizer.json` semantics remain out of scope (per issue). The ASCII-focused word splitting is factored into `BasicWordSplit`, unit-tested (UTF-8 multibyte sequences stay intact; non-ASCII punctuation is not a boundary), and the limitation is documented in README and `docs/API_REFERENCE.md`.

## Red/green TDD

First commit is tests-only. Red evidence:

- `anofox_ner_options.test` — `SET anofox_ner_model='xlm-roberta-multi'` was accepted (functional no-op):
  ```
  test/sql/anofox_ner_options.test:187: FAILED
  assertions: 35 | 34 passed | 1 failed
  ```
- `anofox_ner_truncation.test` (gated on `OPENVINO_AVAILABLE`) — long input lost all NER entities; OpenVINO threw:
  ```
  [anofox] ner: OpenVINO inference error: ... [CPU] PowerStatic node with name 'Multiply_10560'
  Check 'input_shape[j] == 1' failed ... Eltwise shape infer input shapes dim index: 1 mismatch
  test/sql/anofox_ner_truncation.test:26: FAILED (long_org = false, expected true)
  ```
- `test/cpp/test_ner_input_bounding.cpp` — failed to compile (helpers did not exist):
  ```
  error: 'TruncateTokenizedInput' has not been declared in 'duckdb::anofox'
  error: 'ValidateLogitsShape' has not been declared in 'duckdb::anofox'
  error: 'BasicWordSplit' has not been declared in 'duckdb::anofox'
  ```

## Test status

- `make test`: all pass (1624 assertions, 16 test cases; 3 skipped behind `OPENVINO_AVAILABLE`)
- `anofox_tabular_cpp_tests`: all pass (1085 assertions, 14 test cases)
- Gated runs with local model assets (`OPENVINO_AVAILABLE=1`): `anofox_ner_truncation.test` (5/5), `anofox_pii_ner.test` (68/68), `anofox_pii_extensive.test` (325/325) — all assertions pass. Note: `anofox_pii_ner.test`/`anofox_pii_extensive.test` segfault **during process teardown after all tests pass**; verified this teardown crash exists identically on the base branch (`fix/50-ner-thread-safety`) and is unrelated to this change (OpenVINO static-destruction order).
