### PR TITLE
fix: standard DBSCAN semantics and isolation forest refit/shape safety

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -286,6 +286,34 @@ if(UNIX AND NOT APPLE)
     target_link_options(${LOADABLE_EXTENSION_NAME} PRIVATE -Wl,--allow-multiple-definition)
 endif()
 
+# --- C++ unit tests (Catch2, compiled into DuckDB's test/unittest binary) ---
+
+# This CMakeLists is processed via add_subdirectory() from the DuckDB build
+# before duckdb/test/ creates the `unittest` target, so the test sources are
+# registered through a call deferred to the end of the top-level (DuckDB)
+# directory scope. The tests are compiled as an OBJECT library so that the
+# Catch2 auto-registration translation units are linked into the unittest
+# binary directly (archive members without referenced symbols would be
+# dropped by the linker).
+if(NOT CLANG_TIDY AND NOT EMSCRIPTEN AND CMAKE_VERSION VERSION_GREATER_EQUAL "3.19")
+    add_library(anofox_tabular_cpp_tests OBJECT
+        test/cpp/test_anofox_dbscan.cpp
+        test/cpp/test_anofox_isolation_forest.cpp
+    )
+    target_compile_features(anofox_tabular_cpp_tests PRIVATE cxx_std_17)
+    target_include_directories(anofox_tabular_cpp_tests PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/include
+        ${CMAKE_SOURCE_DIR}/third_party/catch
+    )
+
+    function(anofox_tabular_register_cpp_tests)
+        if(TARGET unittest)
+            target_sources(unittest PRIVATE $<TARGET_OBJECTS:anofox_tabular_cpp_tests>)
+        endif()
+    endfunction()
+    cmake_language(DEFER DIRECTORY ${CMAKE_SOURCE_DIR} CALL anofox_tabular_register_cpp_tests)
+endif()
+
 # --- Installation ---
 
 install(

--- a/src/anofox_dbscan.cpp
+++ b/src/anofox_dbscan.cpp
@@ -94,30 +94,39 @@ void DBSCAN::ExpandCluster(
 		size_t current_idx = queue.front();
 		queue.pop();
 
-		if (!visited[current_idx]) {
-			visited[current_idx] = true;
-			results_[current_idx].cluster_id = cluster_id;
-
-			// Find neighbors of current point
-			std::vector<size_t> current_neighbors = RegionQuery(data, current_idx);
-			results_[current_idx].neighbor_count = current_neighbors.size();
-
-			if (current_neighbors.size() >= min_pts_) {
-				// Current point is a core point
-				point_types[current_idx] = PointType::CORE;
-				results_[current_idx].point_type = PointType::CORE;
-
-				// Add neighbors to queue
-				for (size_t neighbor_idx : current_neighbors) {
-					if (!visited[neighbor_idx]) {
-						queue.push(neighbor_idx);
-					}
-				}
-			} else {
-				// Current point is a border point
+		if (visited[current_idx]) {
+			// A point provisionally labelled noise that is density-reachable from a
+			// core point becomes a border point of this cluster (standard DBSCAN).
+			if (point_types[current_idx] == PointType::NOISE) {
 				point_types[current_idx] = PointType::BORDER;
 				results_[current_idx].point_type = PointType::BORDER;
+				results_[current_idx].cluster_id = cluster_id;
 			}
+			continue;
+		}
+
+		visited[current_idx] = true;
+		results_[current_idx].cluster_id = cluster_id;
+
+		// Find neighbors of current point
+		std::vector<size_t> current_neighbors = RegionQuery(data, current_idx);
+		results_[current_idx].neighbor_count = current_neighbors.size();
+
+		// Standard minPts semantics: the eps-neighborhood includes the point itself
+		if (current_neighbors.size() + 1 >= min_pts_) {
+			// Current point is a core point
+			point_types[current_idx] = PointType::CORE;
+			results_[current_idx].point_type = PointType::CORE;
+
+			// Add neighbors to queue; already-visited noise points are promoted
+			// to border points when popped above.
+			for (size_t neighbor_idx : current_neighbors) {
+				queue.push(neighbor_idx);
+			}
+		} else {
+			// Current point is a border point
+			point_types[current_idx] = PointType::BORDER;
+			results_[current_idx].point_type = PointType::BORDER;
 		}
 	}
 }
@@ -158,7 +167,8 @@ void DBSCAN::Fit(const std::vector<std::vector<double>>& data) {
 			std::vector<size_t> neighbors = RegionQuery(data, i);
 			results_[i].neighbor_count = neighbors.size();
 
-			if (neighbors.size() < min_pts_) {
+			// Standard minPts semantics: the eps-neighborhood includes the point itself
+			if (neighbors.size() + 1 < min_pts_) {
 				// Mark as noise (for now; may become border point later)
 				point_types[i] = PointType::NOISE;
 				results_[i].cluster_id = -1;

--- a/src/anofox_isolation_forest.cpp
+++ b/src/anofox_isolation_forest.cpp
@@ -389,6 +389,12 @@ void IsolationTree::BuildTree(
     size_t max_depth,
     std::mt19937& rng
 ) {
+    // Root call of a (re)build: drop any state from a previous build
+    if (current_depth == 0) {
+        nodes_.clear();
+        root_idx_ = 0;
+    }
+
     size_t n_samples = sample_indices.size();
     size_t n_features = data[0].size();
 
@@ -526,6 +532,12 @@ void IsolationTree::BuildTreeMixed(
     size_t ntry,
     double prob_pick_avg_gain
 ) {
+    // Root call of a (re)build: drop any state from a previous build
+    if (current_depth == 0) {
+        nodes_.clear();
+        root_idx_ = 0;
+    }
+
     size_t n_samples = sample_indices.size();
     size_t n_features = data.size();
 
@@ -942,7 +954,33 @@ void IsolationForest::Fit(const std::vector<std::vector<double>>& data) {
         return;
     }
 
-    n_features_ = data[0].size();
+    // Validate input shape at the public API boundary
+    const size_t n_features = data[0].size();
+    if (n_features == 0) {
+        throw std::invalid_argument(
+            "IsolationForest::Fit: rows must contain at least one feature");
+    }
+    if (n_features > std::numeric_limits<uint16_t>::max()) {
+        throw std::invalid_argument(
+            "IsolationForest::Fit: too many features (maximum 65535)");
+    }
+    for (const auto& row : data) {
+        if (row.size() != n_features) {
+            throw std::invalid_argument(
+                "IsolationForest::Fit: all rows must have the same number of features");
+        }
+    }
+
+    // Reset all model state so a refit behaves exactly like a freshly
+    // constructed forest with the same parameters.
+    rng_.seed(static_cast<std::mt19937::result_type>(seed_));
+    trees_.assign(n_trees_, IsolationTree());
+    is_mixed_type_ = false;
+    column_info_.clear();
+    sample_weights_.clear();
+    total_volume_ = 0.0;
+
+    n_features_ = n_features;
 
     // Ensure sample_size doesn't exceed data size
     actual_sample_size_ = std::min(sample_size_, data.size());
@@ -950,9 +988,6 @@ void IsolationForest::Fit(const std::vector<std::vector<double>>& data) {
     // Compute max depth for trees
     // Default: ceil(log2(sample_size)) + 1
     size_t max_depth = static_cast<size_t>(std::ceil(std::log2(actual_sample_size_))) + 1;
-
-    // Build all trees
-    trees_.resize(n_trees_);
 
     for (size_t t = 0; t < n_trees_; t++) {
         // Create random subsample of indices
@@ -971,6 +1006,15 @@ void IsolationForest::Fit(const std::vector<std::vector<double>>& data) {
 double IsolationForest::Score(const std::vector<double>& point) const {
     if (trees_.empty()) {
         return 0.0;
+    }
+
+    if (is_mixed_type_) {
+        throw std::invalid_argument(
+            "IsolationForest::Score: forest was fitted on mixed-type data; use ScoreMixed");
+    }
+    if (point.size() != n_features_) {
+        throw std::invalid_argument(
+            "IsolationForest::Score: point width does not match the fitted feature count");
     }
 
     // Compute average path length across all trees
@@ -1119,16 +1163,45 @@ void IsolationForest::FitMixed(
     const std::vector<ColumnInfo>& column_info,
     const std::vector<double>& sample_weights
 ) {
+    // Validate input shape at the public API boundary
+    if (data.size() != column_info.size()) {
+        throw std::invalid_argument(
+            "IsolationForest::FitMixed: data and column_info must have the same number of columns");
+    }
     if (data.empty() || data[0].size() == 0) {
         return;
     }
+    if (data.size() > std::numeric_limits<uint16_t>::max()) {
+        throw std::invalid_argument(
+            "IsolationForest::FitMixed: too many columns (maximum 65535)");
+    }
+    if (ndim_ > std::numeric_limits<uint8_t>::max()) {
+        throw std::invalid_argument(
+            "IsolationForest::FitMixed: ndim exceeds the supported maximum (255)");
+    }
+
+    size_t n_rows = data[0].size();
+    for (size_t col = 0; col < data.size(); col++) {
+        if (data[col].type != column_info[col].type) {
+            throw std::invalid_argument(
+                "IsolationForest::FitMixed: column type mismatch between data and column_info");
+        }
+        if (data[col].size() != n_rows) {
+            throw std::invalid_argument(
+                "IsolationForest::FitMixed: all columns must have the same number of rows");
+        }
+    }
+
+    // Reset all model state so a refit behaves exactly like a freshly
+    // constructed forest with the same parameters.
+    rng_.seed(static_cast<std::mt19937::result_type>(seed_));
+    trees_.assign(n_trees_, IsolationTree());
+    total_volume_ = 0.0;
 
     n_features_ = data.size();
     column_info_ = column_info;
     is_mixed_type_ = true;
     sample_weights_ = sample_weights;
-
-    size_t n_rows = data[0].size();
 
     // Validate sample weights if provided
     if (!sample_weights_.empty()) {
@@ -1173,8 +1246,6 @@ void IsolationForest::FitMixed(
     size_t max_depth = static_cast<size_t>(std::ceil(std::log2(actual_sample_size_))) + 1;
 
     // Build all trees
-    trees_.resize(n_trees_);
-
     for (size_t t = 0; t < n_trees_; t++) {
         std::vector<size_t> sample_indices;
 
@@ -1201,6 +1272,15 @@ double IsolationForest::ScoreMixed(
 ) const {
     if (trees_.empty()) {
         return 0.0;
+    }
+
+    if (!is_mixed_type_) {
+        throw std::invalid_argument(
+            "IsolationForest::ScoreMixed: forest was fitted on numeric-only data; use Score");
+    }
+    if (numeric_values.size() != n_features_ || category_indices.size() != n_features_) {
+        throw std::invalid_argument(
+            "IsolationForest::ScoreMixed: point width does not match the fitted column count");
     }
 
     if (scoring_metric_ == ScoringMetric::Density) {
@@ -1263,6 +1343,13 @@ std::vector<double> IsolationForest::ScoreBatchMixed(
 
     size_t n_rows = data[0].size();
     size_t n_features = data.size();
+
+    for (size_t col = 0; col < n_features; col++) {
+        if (data[col].size() != n_rows) {
+            throw std::invalid_argument(
+                "IsolationForest::ScoreBatchMixed: all columns must have the same number of rows");
+        }
+    }
 
     std::vector<double> scores;
     scores.reserve(n_rows);

--- a/src/include/anofox_isolation_forest.hpp
+++ b/src/include/anofox_isolation_forest.hpp
@@ -334,6 +334,7 @@ private:
     size_t actual_sample_size_;  // Actual sample size used (min of sample_size_ and data size)
     size_t n_features_;
     double contamination_;
+    uint64_t seed_;       // Stored so refits reproduce a freshly constructed forest
     std::mt19937 rng_;
     std::vector<ColumnInfo> column_info_;  // Column metadata for mixed-type support
     bool is_mixed_type_;  // Whether the forest was trained with mixed-type data
@@ -395,6 +396,7 @@ public:
           actual_sample_size_(sample_size),
           n_features_(0),
           contamination_(contamination),
+          seed_(seed),
           rng_(seed),
           is_mixed_type_(false),
           ndim_(ndim > 0 ? ndim : 1),
@@ -406,15 +408,21 @@ public:
 
     /**
      * Fit forest to numeric-only data (legacy)
+     * Resets all model state, so refitting behaves exactly like fitting a
+     * freshly constructed forest with the same parameters.
      * @param data: Data where data[row][col] is column-major format
+     * @throws std::invalid_argument on ragged rows or rows without features
      */
     void Fit(const std::vector<std::vector<double>>& data);
 
     /**
      * Fit forest to mixed-type data
+     * Resets all model state, so refitting behaves exactly like fitting a
+     * freshly constructed forest with the same parameters.
      * @param data: Column data (mixed numeric/categorical)
      * @param column_info: Column metadata
      * @param sample_weights: Optional sample weights (empty = uniform sampling)
+     * @throws std::invalid_argument on column count/type/length mismatches
      */
     void FitMixed(
         const std::vector<ColumnData>& data,

--- a/test/cpp/test_anofox_dbscan.cpp
+++ b/test/cpp/test_anofox_dbscan.cpp
@@ -1,0 +1,85 @@
+//===----------------------------------------------------------------------===//
+// Catch2 unit tests for the DBSCAN implementation (issue #44)
+//
+// Standard DBSCAN semantics (Ester et al., 1996):
+//  - A point p is a core point if its eps-neighborhood *including p itself*
+//    contains at least min_pts points.
+//  - A point that was provisionally labelled noise but is density-reachable
+//    from a core point must be promoted to a border point of that cluster.
+//===----------------------------------------------------------------------===//
+
+#include "catch.hpp"
+
+#include "anofox_dbscan.hpp"
+
+#include <vector>
+
+using namespace duckdb::anofox;
+
+TEST_CASE("test/cpp/anofox_dbscan_minpts_counts_query_point", "[anofox]") {
+	// 1-D points 0.0, 1.0, 2.0 with eps = 1.0 and min_pts = 3.
+	//
+	// Standard semantics: the neighborhood of 1.0 is {0.0, 1.0, 2.0} (3 points,
+	// including itself) so 1.0 is a core point; 0.0 and 2.0 are border points of
+	// the same cluster. There is no noise.
+	std::vector<std::vector<double>> data = {{0.0}, {1.0}, {2.0}};
+
+	DBSCAN dbscan(1.0, 3, DistanceMetric::EUCLIDEAN);
+	dbscan.Fit(data);
+
+	const auto &results = dbscan.GetResults();
+	REQUIRE(results.size() == 3);
+
+	CHECK(dbscan.GetClusterCount() == 1);
+	CHECK(dbscan.GetNoiseCount() == 0);
+
+	CHECK(results[0].point_type == PointType::BORDER);
+	CHECK(results[1].point_type == PointType::CORE);
+	CHECK(results[2].point_type == PointType::BORDER);
+
+	for (const auto &pt : results) {
+		CHECK(pt.cluster_id == 0);
+	}
+}
+
+TEST_CASE("test/cpp/anofox_dbscan_noise_promoted_to_border", "[anofox]") {
+	// 1-D points with eps = 1.0 and min_pts = 3.
+	//
+	// eps-neighborhoods (excluding the point itself):
+	//   p0 = 2.0  -> {p3}            not core (2 incl. self < 3)
+	//   p1 = 0.0  -> {p2}            not core
+	//   p2 = 0.9  -> {p1, p3}        core (3 incl. self)
+	//   p3 = 1.1  -> {p2, p0}        core
+	//   p4 = 10.0 -> {}              noise
+	//
+	// p0 and p1 are visited before any core point, so a naive implementation
+	// labels them noise and the `visited` check prevents the later cluster
+	// expansion from claiming them. Standard DBSCAN promotes both to border
+	// points of cluster 0.
+	std::vector<std::vector<double>> data = {{2.0}, {0.0}, {0.9}, {1.1}, {10.0}};
+
+	DBSCAN dbscan(1.0, 3, DistanceMetric::EUCLIDEAN);
+	dbscan.Fit(data);
+
+	const auto &results = dbscan.GetResults();
+	REQUIRE(results.size() == 5);
+
+	CHECK(dbscan.GetClusterCount() == 1);
+	CHECK(dbscan.GetNoiseCount() == 1);
+
+	// Reachable points promoted to border members of cluster 0
+	CHECK(results[0].point_type == PointType::BORDER);
+	CHECK(results[0].cluster_id == 0);
+	CHECK(results[1].point_type == PointType::BORDER);
+	CHECK(results[1].cluster_id == 0);
+
+	// Core points
+	CHECK(results[2].point_type == PointType::CORE);
+	CHECK(results[2].cluster_id == 0);
+	CHECK(results[3].point_type == PointType::CORE);
+	CHECK(results[3].cluster_id == 0);
+
+	// Genuine noise stays noise
+	CHECK(results[4].point_type == PointType::NOISE);
+	CHECK(results[4].cluster_id == -1);
+}

--- a/test/cpp/test_anofox_isolation_forest.cpp
+++ b/test/cpp/test_anofox_isolation_forest.cpp
@@ -1,0 +1,155 @@
+//===----------------------------------------------------------------------===//
+// Catch2 unit tests for the IsolationForest implementation (issue #44)
+//
+//  - Refitting the same forest instance must behave exactly like fitting a
+//    fresh instance constructed with the same parameters (no stale tree state).
+//  - The public Fit/Score APIs must validate input shapes and throw clear
+//    exceptions instead of reading out of bounds.
+//===----------------------------------------------------------------------===//
+
+#include "catch.hpp"
+
+#include "anofox_isolation_forest.hpp"
+
+#include <stdexcept>
+#include <vector>
+
+using namespace duckdb::anofox;
+
+namespace {
+
+std::vector<std::vector<double>> MakeNumericData(double offset, double scale) {
+	std::vector<std::vector<double>> data;
+	for (int i = 0; i < 64; i++) {
+		data.push_back({offset + scale * static_cast<double>(i), offset - scale * static_cast<double>(i)});
+	}
+	// Obvious outlier
+	data.push_back({offset + scale * 1000.0, offset - scale * 1000.0});
+	return data;
+}
+
+void MakeMixedData(std::vector<ColumnData> &data, std::vector<ColumnInfo> &info, double offset) {
+	ColumnInfo num_info(FeatureType::NUMERIC, "x");
+	ColumnInfo cat_info(FeatureType::CATEGORICAL, "c");
+	ColumnData num_col(FeatureType::NUMERIC);
+	ColumnData cat_col(FeatureType::CATEGORICAL);
+
+	for (int i = 0; i < 40; i++) {
+		num_col.numeric_values.push_back(offset + static_cast<double>(i));
+		cat_col.category_indices.push_back(cat_info.AddCategory(i % 4 == 0 ? "a" : "b"));
+	}
+	// Obvious outlier with a rare category
+	num_col.numeric_values.push_back(offset + 5000.0);
+	cat_col.category_indices.push_back(cat_info.AddCategory("rare"));
+
+	data = {num_col, cat_col};
+	info = {num_info, cat_info};
+}
+
+} // namespace
+
+TEST_CASE("test/cpp/anofox_isolation_forest_refit_equals_fresh_fit", "[anofox]") {
+	auto first_data = MakeNumericData(0.0, 1.0);
+	auto second_data = MakeNumericData(500.0, 3.0);
+
+	// Fit, then refit on different data: the refitted model must not score
+	// through stale trees from the first fit.
+	IsolationForest refit_forest(50, 32, 0.1, 42);
+	refit_forest.Fit(first_data);
+	refit_forest.Fit(second_data);
+	auto refit_scores = refit_forest.ScoreBatch(second_data);
+
+	IsolationForest fresh_forest(50, 32, 0.1, 42);
+	fresh_forest.Fit(second_data);
+	auto fresh_scores = fresh_forest.ScoreBatch(second_data);
+
+	REQUIRE(refit_scores.size() == fresh_scores.size());
+	for (size_t i = 0; i < fresh_scores.size(); i++) {
+		REQUIRE(refit_scores[i] == fresh_scores[i]);
+	}
+}
+
+TEST_CASE("test/cpp/anofox_isolation_forest_mixed_refit_equals_fresh_fit", "[anofox]") {
+	std::vector<ColumnData> first_data, second_data;
+	std::vector<ColumnInfo> first_info, second_info;
+	MakeMixedData(first_data, first_info, 0.0);
+	MakeMixedData(second_data, second_info, 700.0);
+
+	IsolationForest refit_forest(50, 32, 0.1, 42);
+	refit_forest.FitMixed(first_data, first_info);
+	refit_forest.FitMixed(second_data, second_info);
+	auto refit_scores = refit_forest.ScoreBatchMixed(second_data);
+
+	IsolationForest fresh_forest(50, 32, 0.1, 42);
+	fresh_forest.FitMixed(second_data, second_info);
+	auto fresh_scores = fresh_forest.ScoreBatchMixed(second_data);
+
+	REQUIRE(refit_scores.size() == fresh_scores.size());
+	for (size_t i = 0; i < fresh_scores.size(); i++) {
+		REQUIRE(refit_scores[i] == fresh_scores[i]);
+	}
+}
+
+TEST_CASE("test/cpp/anofox_isolation_forest_shape_validation", "[anofox]") {
+	IsolationForest forest(10, 16, 0.1, 7);
+
+	SECTION("ragged rows throw") {
+		std::vector<std::vector<double>> ragged = {{1.0, 2.0}, {3.0}};
+		REQUIRE_THROWS_AS(forest.Fit(ragged), std::invalid_argument);
+	}
+
+	SECTION("rows without features throw") {
+		std::vector<std::vector<double>> empty_rows = {{}, {}};
+		REQUIRE_THROWS_AS(forest.Fit(empty_rows), std::invalid_argument);
+	}
+
+	SECTION("scoring with mismatching point width throws") {
+		std::vector<std::vector<double>> data;
+		for (int i = 0; i < 8; i++) {
+			data.push_back({static_cast<double>(i), static_cast<double>(-i)});
+		}
+		forest.Fit(data);
+
+		REQUIRE_THROWS_AS(forest.Score({1.0}), std::invalid_argument);
+		REQUIRE_THROWS_AS(forest.Score({1.0, 2.0, 3.0}), std::invalid_argument);
+		// Matching width must not throw
+		REQUIRE_NOTHROW(forest.Score({1.0, 2.0}));
+	}
+}
+
+TEST_CASE("test/cpp/anofox_isolation_forest_mixed_shape_validation", "[anofox]") {
+	IsolationForest forest(10, 16, 0.1, 7);
+
+	std::vector<ColumnData> data;
+	std::vector<ColumnInfo> info;
+	MakeMixedData(data, info, 0.0);
+
+	SECTION("column_info count mismatch throws") {
+		std::vector<ColumnInfo> short_info = {info[0]};
+		REQUIRE_THROWS_AS(forest.FitMixed(data, short_info), std::invalid_argument);
+	}
+
+	SECTION("mismatching column lengths throw") {
+		auto ragged = data;
+		ragged[0].numeric_values.pop_back();
+		REQUIRE_THROWS_AS(forest.FitMixed(ragged, info), std::invalid_argument);
+	}
+
+	SECTION("column type mismatch throws") {
+		auto swapped_info = info;
+		swapped_info[0].type = FeatureType::CATEGORICAL;
+		REQUIRE_THROWS_AS(forest.FitMixed(data, swapped_info), std::invalid_argument);
+	}
+
+	SECTION("scoring with mismatching widths throws") {
+		forest.FitMixed(data, info);
+
+		// Two features were fitted; one value per row is too few
+		REQUIRE_THROWS_AS(forest.ScoreMixed({1.0}, {-1}), std::invalid_argument);
+		// Inconsistent numeric/category widths
+		REQUIRE_THROWS_AS(forest.ScoreMixed({1.0, 2.0}, {-1}), std::invalid_argument);
+
+		// Numeric Score() on a mixed-type forest is a contract violation
+		REQUIRE_THROWS_AS(forest.Score({1.0, 2.0}), std::invalid_argument);
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the outlier-module algorithm correctness findings from the 2026-06 code review (section 2.5, Phase 1). TDD red/green: commit `3cb9f43` contains only the failing Catch2 tests (wired into DuckDB's `test/unittest` binary from `test/cpp/`), commit `bc44d1b` the fix.

### DBSCAN (`src/anofox_dbscan.cpp`)
- **Standard minPts semantics** (Ester et al., 1996): `RegionQuery` excludes the query point, so core-point checks now compare `neighbors.size() + 1 >= min_pts` in both `Fit` and `ExpandCluster`. Previously the implementation was one stricter than standard.
- **Border promotion**: points provisionally labelled noise that are density-reachable from a core point are now promoted to `BORDER` and assigned the cluster when the expansion reaches them; previously the `visited` check skipped them forever. `ExpandCluster` now enqueues all neighbors of a core point and handles already-visited noise on dequeue.

### IsolationForest (`src/anofox_isolation_forest.cpp`, header)
- **Refit == fresh fit**: `Fit`/`FitMixed` reset all model state (trees, RNG re-seeded from the stored constructor seed, mixed-type metadata, total volume) so refitting an instance produces exactly the same model as a freshly constructed forest. Previously `trees_.resize(n_trees_)` reused tree instances whose `BuildTree` appended to stale `nodes_`, and scoring walked the old root at node 0. `BuildTree`/`BuildTreeMixed` additionally clear `nodes_`/`root_idx_` at the root call as a guard against direct tree reuse.
- **Shape validation at the public API boundary**: ragged rows, rows without features, `data`/`column_info` count and type mismatches, inconsistent column lengths, score-point width mismatches, and numeric-vs-mixed scoring on the wrong forest kind now throw `std::invalid_argument` instead of underflowing `uniform_int_distribution(0, n_features - 1)` or reading out of bounds (the empty-feature case segfaulted, see red output below).
- **Narrowing safety**: feature counts are validated against `uint16_t` and `ndim` against `uint8_t` before being stored in the packed node fields.

## Red state (commit 3cb9f43 on the pre-fix implementation)

```
/test/cpp/test_anofox_dbscan.cpp:33: FAILED:
  CHECK( dbscan.GetClusterCount() == 1 )  with expansion: 0 == 1
/test/cpp/test_anofox_dbscan.cpp:34: FAILED:
  CHECK( dbscan.GetNoiseCount() == 0 )    with expansion: 3 == 0
/test/cpp/test_anofox_dbscan.cpp:72: FAILED:
  CHECK( results[0].cluster_id == 0 )     with expansion: -1 == 0
/test/cpp/test_anofox_isolation_forest.cpp:68: FAILED:
  REQUIRE( refit_scores[i] == fresh_scores[i] )
  with expansion: 0.6553853038 == 0.5876971526
/test/cpp/test_anofox_isolation_forest.cpp:98: FAILED:
  REQUIRE_THROWS_AS( forest.Fit(ragged), std::invalid_argument )
  because no exception was thrown where one was expected
/test/cpp/test_anofox_isolation_forest.cpp:101: FAILED:
  due to a fatal error condition: SIGSEGV - Segmentation violation signal

test cases:  5 |  5 failed
assertions: 28 | 6 passed | 22 failed
```

## After the fix

```
./build/release/test/unittest "[anofox]"
All tests passed (141 assertions in 6 test cases)

make test
All tests passed (1 skipped test, 1765 assertions in 22 test cases)
```

Full suite matches the pre-fix SQL baseline (1624 assertions in 16 SQL test cases, all passing) plus the 141 new C++ assertions. The existing `test/sql/anofox_dbscan.test` and `test/sql/anofox_isolation_forest.test` fixtures hold unchanged under the corrected semantics; the metric-level DBSCAN wiring from #52 composes with these class-level fixes (its fixtures were chosen to hold under both old and standard semantics). `src/anofox_metric.cpp` is untouched.

Closes #44