### PR TITLE
fix: alias copy-then-rename, telemetry opt-out honesty, trace serialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1343,7 +1343,7 @@ Anofox Tabular collects **anonymous usage data** to help improve the extension. 
 
 ### Disabling Telemetry
 
-**Option 1: Environment Variable** (recommended for CI/Docker)
+**Option 1: Environment Variable** (recommended — also suppresses the extension-load event)
 
 ```bash
 export DATAZOO_DISABLE_TELEMETRY=1
@@ -1353,6 +1353,19 @@ export DATAZOO_DISABLE_TELEMETRY=1
 
 ```sql
 SET anofox_telemetry_enabled = false;
+```
+
+Note: SQL `SET` can only run after the extension is loaded, so it disables all
+*subsequent* events (function executions) but cannot suppress the one-time
+extension-load event. To opt out of that event too, use the environment variable,
+or pre-set the option in the client configuration before loading the extension
+(requires `allow_unrecognized_options`), e.g. in Python:
+
+```python
+con = duckdb.connect(config={
+    "allow_unrecognized_options": True,
+    "anofox_telemetry_enabled": False,
+})
 ```
 
 ---

--- a/src/anofox_money.cpp
+++ b/src/anofox_money.cpp
@@ -803,7 +803,7 @@ void RegisterMoneyFunctions(ExtensionLoader &loader) {
         RegisterScalarFunctionWithAlias(loader, money_same_currency_func, "money_same_currency", {std::move(desc)});
     }
 
-    AnofoxTrace(AnofoxLogLevel::Info, "[anofox] Money module functions registered");
+    AnofoxTrace(AnofoxLogLevel::Info, "Money module functions registered");
 }
 
 } // namespace anofox

--- a/src/anofox_ner.cpp
+++ b/src/anofox_ner.cpp
@@ -148,12 +148,12 @@ WordPieceTokenizer::WordPieceTokenizer() = default;
 WordPieceTokenizer::~WordPieceTokenizer() = default;
 
 bool WordPieceTokenizer::Load(const std::string &vocab_path) {
-    AnofoxTrace(AnofoxLogLevel::Debug, "[anofox] ner: Loading tokenizer vocabulary from: " + vocab_path);
+    AnofoxTrace(AnofoxLogLevel::Debug, "ner: Loading tokenizer vocabulary from: " + vocab_path);
 
     // Read the tokenizer.json file
     std::ifstream file(vocab_path);
     if (!file.is_open()) {
-        AnofoxTrace(AnofoxLogLevel::Warn, "[anofox] ner: Cannot open tokenizer file: " + vocab_path);
+        AnofoxTrace(AnofoxLogLevel::Warn, "ner: Cannot open tokenizer file: " + vocab_path);
         return false;
     }
 
@@ -165,14 +165,14 @@ bool WordPieceTokenizer::Load(const std::string &vocab_path) {
     // Parse JSON using yyjson
     yyjson_doc *doc = yyjson_read(json_str.c_str(), json_str.size(), 0);
     if (!doc) {
-        AnofoxTrace(AnofoxLogLevel::Error, "[anofox] ner: Failed to parse tokenizer JSON");
+        AnofoxTrace(AnofoxLogLevel::Error, "ner: Failed to parse tokenizer JSON");
         return false;
     }
 
     yyjson_val *root = yyjson_doc_get_root(doc);
     if (!root) {
         yyjson_doc_free(doc);
-        AnofoxTrace(AnofoxLogLevel::Error, "[anofox] ner: Empty tokenizer JSON");
+        AnofoxTrace(AnofoxLogLevel::Error, "ner: Empty tokenizer JSON");
         return false;
     }
 
@@ -180,14 +180,14 @@ bool WordPieceTokenizer::Load(const std::string &vocab_path) {
     yyjson_val *model = yyjson_obj_get(root, "model");
     if (!model) {
         yyjson_doc_free(doc);
-        AnofoxTrace(AnofoxLogLevel::Error, "[anofox] ner: No 'model' key in tokenizer JSON");
+        AnofoxTrace(AnofoxLogLevel::Error, "ner: No 'model' key in tokenizer JSON");
         return false;
     }
 
     yyjson_val *vocab = yyjson_obj_get(model, "vocab");
     if (!vocab) {
         yyjson_doc_free(doc);
-        AnofoxTrace(AnofoxLogLevel::Error, "[anofox] ner: No 'model.vocab' key in tokenizer JSON");
+        AnofoxTrace(AnofoxLogLevel::Error, "ner: No 'model.vocab' key in tokenizer JSON");
         return false;
     }
 
@@ -205,7 +205,7 @@ bool WordPieceTokenizer::Load(const std::string &vocab_path) {
 
     yyjson_doc_free(doc);
 
-    AnofoxTrace(AnofoxLogLevel::Info, "[anofox] ner: Loaded vocabulary with " + std::to_string(vocab_.size()) + " tokens");
+    AnofoxTrace(AnofoxLogLevel::Info, "ner: Loaded vocabulary with " + std::to_string(vocab_.size()) + " tokens");
     return !vocab_.empty();
 }
 
@@ -251,7 +251,7 @@ std::vector<int64_t> WordPieceTokenizer::Encode(const std::string &text) {
     std::vector<int64_t> input_ids;
 
     if (vocab_.empty()) {
-        AnofoxTrace(AnofoxLogLevel::Warn, "[anofox] ner: Vocabulary not loaded, cannot encode");
+        AnofoxTrace(AnofoxLogLevel::Warn, "ner: Vocabulary not loaded, cannot encode");
         return {};
     }
 
@@ -329,17 +329,17 @@ SentencePieceTokenizer::SentencePieceTokenizer()
 SentencePieceTokenizer::~SentencePieceTokenizer() = default;
 
 bool SentencePieceTokenizer::Load(const std::string &model_path) {
-    AnofoxTrace(AnofoxLogLevel::Debug, "[anofox] ner: Loading SentencePiece model from: " + model_path);
+    AnofoxTrace(AnofoxLogLevel::Debug, "ner: Loading SentencePiece model from: " + model_path);
 
     auto status = processor_->Load(model_path);
     if (!status.ok()) {
         AnofoxTrace(AnofoxLogLevel::Error,
-                    "[anofox] ner: Failed to load SentencePiece model: " + std::string(status.message()));
+                    "ner: Failed to load SentencePiece model: " + std::string(status.message()));
         return false;
     }
 
     AnofoxTrace(AnofoxLogLevel::Info,
-                "[anofox] ner: Loaded SentencePiece model with " +
+                "ner: Loaded SentencePiece model with " +
                 std::to_string(processor_->GetPieceSize()) + " tokens");
     return true;
 }
@@ -360,7 +360,7 @@ std::vector<int64_t> SentencePieceTokenizer::Encode(const std::string &text) {
     auto status = processor_->Encode(text, &piece_ids);
     if (!status.ok()) {
         AnofoxTrace(AnofoxLogLevel::Error,
-                    "[anofox] ner: SentencePiece encoding error: " + std::string(status.message()));
+                    "ner: SentencePiece encoding error: " + std::string(status.message()));
         return {};
     }
 
@@ -495,13 +495,13 @@ void NERModelManager::EnsureInitialized() {
 
 void NERModelManager::LoadModel() {
 #if HAVE_OPENVINO
-    AnofoxTrace(AnofoxLogLevel::Info, "[anofox] ner: Loading NER model...");
+    AnofoxTrace(AnofoxLogLevel::Info, "ner: Loading NER model...");
 
     model_path_ = GetModelPath();
 
     // Check if model file exists
     if (!std::filesystem::exists(model_path_)) {
-        AnofoxTrace(AnofoxLogLevel::Info, "[anofox] ner: Model not found, attempting download...");
+        AnofoxTrace(AnofoxLogLevel::Info, "ner: Model not found, attempting download...");
         status_.store(NERStatus::DOWNLOADING);
         status_message_ = "Downloading model from HuggingFace...";
 
@@ -512,19 +512,19 @@ void NERModelManager::LoadModel() {
         if (!DownloadModel(model_path_)) {
             status_.store(NERStatus::FAILED);
             status_message_ = "Failed to download model";
-            AnofoxTrace(AnofoxLogLevel::Error, "[anofox] ner: Model download failed");
+            AnofoxTrace(AnofoxLogLevel::Error, "ner: Model download failed");
             return;
         }
     }
 
     try {
         // Read model (supports .onnx directly via ONNX frontend)
-        AnofoxTrace(AnofoxLogLevel::Info, "[anofox] ner: Reading ONNX model with OpenVINO...");
+        AnofoxTrace(AnofoxLogLevel::Info, "ner: Reading ONNX model with OpenVINO...");
         std::shared_ptr<ov::Model> model = core_->read_model(model_path_);
 
         // Reshape model to accept dynamic batch and sequence length
         // The ONNX model has dynamic shapes, but OpenVINO needs explicit configuration
-        AnofoxTrace(AnofoxLogLevel::Info, "[anofox] ner: Configuring dynamic input shapes...");
+        AnofoxTrace(AnofoxLogLevel::Info, "ner: Configuring dynamic input shapes...");
         ov::PartialShape dynamic_shape = {1, ov::Dimension::dynamic()};  // batch=1, seq=dynamic
         std::map<std::string, ov::PartialShape> input_shapes;
         input_shapes["input_ids"] = dynamic_shape;
@@ -535,10 +535,10 @@ void NERModelManager::LoadModel() {
         auto available = core_->get_available_devices();
         std::string dev_list;
         for (const auto &d : available) dev_list += d + " ";
-        AnofoxTrace(AnofoxLogLevel::Info, "[anofox] ner: Available OpenVINO devices: " + dev_list);
+        AnofoxTrace(AnofoxLogLevel::Info, "ner: Available OpenVINO devices: " + dev_list);
 
         // Compile model for configured device (default AUTO: selects GPU if available, falls back to CPU)
-        AnofoxTrace(AnofoxLogLevel::Info, "[anofox] ner: Compiling model for device: " + device_name_);
+        AnofoxTrace(AnofoxLogLevel::Info, "ner: Compiling model for device: " + device_name_);
         compiled_model_ = std::make_shared<ov::CompiledModel>(
             core_->compile_model(model, device_name_)
         );
@@ -550,7 +550,7 @@ void NERModelManager::LoadModel() {
             if (di > 0) exec_dev_str += ",";
             exec_dev_str += exec_devices[di];
         }
-        AnofoxTrace(AnofoxLogLevel::Info, "[anofox] ner: Executing on: " + exec_dev_str);
+        AnofoxTrace(AnofoxLogLevel::Info, "ner: Executing on: " + exec_dev_str);
 
         // Create inference request
         infer_request_ = std::make_shared<ov::InferRequest>(
@@ -566,7 +566,7 @@ void NERModelManager::LoadModel() {
             tokenizer_ = std::make_unique<WordPieceTokenizer>();
             auto tokenizer_path = std::filesystem::path(model_path_).parent_path() / "tokenizer.json";
             if (!tokenizer_->Load(tokenizer_path.string())) {
-                AnofoxTrace(AnofoxLogLevel::Warn, "[anofox] ner: Failed to load tokenizer vocabulary, NER may not work correctly");
+                AnofoxTrace(AnofoxLogLevel::Warn, "ner: Failed to load tokenizer vocabulary, NER may not work correctly");
             }
         }
 #if HAVE_SENTENCEPIECE
@@ -575,7 +575,7 @@ void NERModelManager::LoadModel() {
             tokenizer_ = std::make_unique<SentencePieceTokenizer>();
             auto tokenizer_path = std::filesystem::path(model_path_).parent_path() / "sentencepiece.bpe.model";
             if (!tokenizer_->Load(tokenizer_path.string())) {
-                AnofoxTrace(AnofoxLogLevel::Warn, "[anofox] ner: Failed to load SentencePiece model, NER may not work correctly");
+                AnofoxTrace(AnofoxLogLevel::Warn, "ner: Failed to load SentencePiece model, NER may not work correctly");
             }
         }
 #endif
@@ -584,23 +584,23 @@ void NERModelManager::LoadModel() {
             tokenizer_ = std::make_unique<WordPieceTokenizer>();
             auto tokenizer_path = std::filesystem::path(model_path_).parent_path() / "tokenizer.json";
             if (!tokenizer_->Load(tokenizer_path.string())) {
-                AnofoxTrace(AnofoxLogLevel::Warn, "[anofox] ner: Failed to load tokenizer vocabulary, NER may not work correctly");
+                AnofoxTrace(AnofoxLogLevel::Warn, "ner: Failed to load tokenizer vocabulary, NER may not work correctly");
             }
         }
 
         current_model_name_ = model_name;
         status_.store(NERStatus::LOADED);
         status_message_ = "Model loaded successfully (" + model_name + ", device: " + exec_dev_str + ")";
-        AnofoxTrace(AnofoxLogLevel::Info, "[anofox] ner: NER model loaded from: " + model_path_);
+        AnofoxTrace(AnofoxLogLevel::Info, "ner: NER model loaded from: " + model_path_);
 
     } catch (const ov::Exception &e) {
         status_.store(NERStatus::FAILED);
         status_message_ = std::string("OpenVINO error: ") + e.what();
-        AnofoxTrace(AnofoxLogLevel::Error, "[anofox] ner: Failed to load model: " + std::string(e.what()));
+        AnofoxTrace(AnofoxLogLevel::Error, "ner: Failed to load model: " + std::string(e.what()));
     } catch (const std::exception &e) {
         status_.store(NERStatus::FAILED);
         status_message_ = std::string("Error: ") + e.what();
-        AnofoxTrace(AnofoxLogLevel::Error, "[anofox] ner: Failed to load model: " + std::string(e.what()));
+        AnofoxTrace(AnofoxLogLevel::Error, "ner: Failed to load model: " + std::string(e.what()));
     }
 #else
     status_.store(NERStatus::NOT_AVAILABLE);
@@ -638,9 +638,9 @@ bool NERModelManager::DownloadModel(const std::string &dest_path) {
         for (int attempt = 1; attempt <= max_retries && !download_success; attempt++) {
             if (attempt > 1) {
                 AnofoxTrace(AnofoxLogLevel::Info,
-                    "[anofox] ner: Retrying download attempt " + std::to_string(attempt) + "/" + std::to_string(max_retries));
+                    "ner: Retrying download attempt " + std::to_string(attempt) + "/" + std::to_string(max_retries));
             } else {
-                AnofoxTrace(AnofoxLogLevel::Info, "[anofox] ner: Downloading " + file.name + " from HuggingFace...");
+                AnofoxTrace(AnofoxLogLevel::Info, "ner: Downloading " + file.name + " from HuggingFace...");
             }
 
             status_message_ = "Downloading " + file.name + "...";
@@ -648,7 +648,7 @@ bool NERModelManager::DownloadModel(const std::string &dest_path) {
             // Open file for writing
             FILE *fp = fopen(file.dest.c_str(), "wb");
             if (!fp) {
-                AnofoxTrace(AnofoxLogLevel::Error, "[anofox] ner: Failed to open file for writing: " + file.dest);
+                AnofoxTrace(AnofoxLogLevel::Error, "ner: Failed to open file for writing: " + file.dest);
                 return false;
             }
 
@@ -656,7 +656,7 @@ bool NERModelManager::DownloadModel(const std::string &dest_path) {
             CURL *curl = curl_easy_init();
             if (!curl) {
                 fclose(fp);
-                AnofoxTrace(AnofoxLogLevel::Error, "[anofox] ner: Failed to initialize curl");
+                AnofoxTrace(AnofoxLogLevel::Error, "ner: Failed to initialize curl");
                 return false;
             }
 
@@ -682,11 +682,11 @@ bool NERModelManager::DownloadModel(const std::string &dest_path) {
 
             if (res == CURLE_OK) {
                 download_success = true;
-                AnofoxTrace(AnofoxLogLevel::Info, "[anofox] ner: Download complete: " + file.name);
+                AnofoxTrace(AnofoxLogLevel::Info, "ner: Download complete: " + file.name);
             } else {
                 const char *error_msg = curl_easy_strerror(res);
                 AnofoxTrace(AnofoxLogLevel::Warn,
-                    "[anofox] ner: Download attempt " + std::to_string(attempt) + " failed: " +
+                    "ner: Download attempt " + std::to_string(attempt) + " failed: " +
                     std::string(error_msg) + " (HTTP " + std::to_string(http_code) + ")");
 
                 // Remove partial file
@@ -695,7 +695,7 @@ bool NERModelManager::DownloadModel(const std::string &dest_path) {
                 if (attempt < max_retries) {
                     int wait_time = 1 << attempt;
                     AnofoxTrace(AnofoxLogLevel::Info,
-                        "[anofox] ner: Waiting " + std::to_string(wait_time) + "s before retry");
+                        "ner: Waiting " + std::to_string(wait_time) + "s before retry");
                     std::this_thread::sleep_for(std::chrono::seconds(wait_time));
                 }
             }
@@ -703,7 +703,7 @@ bool NERModelManager::DownloadModel(const std::string &dest_path) {
 
         if (!download_success) {
             AnofoxTrace(AnofoxLogLevel::Error,
-                "[anofox] ner: Failed to download " + file.name + " after " + std::to_string(max_retries) + " attempts");
+                "ner: Failed to download " + file.name + " after " + std::to_string(max_retries) + " attempts");
             status_message_ = "Failed to download " + file.name;
             return false;
         }
@@ -723,7 +723,7 @@ std::vector<NEREntity> NERModelManager::ExtractEntities(const std::string &text)
     if (result_cache_ && result_cache_->Capacity() > 0) {
         auto cached = result_cache_->Get(text);
         if (cached) {
-            AnofoxTrace(AnofoxLogLevel::Debug, "[anofox] ner: Cache hit");
+            AnofoxTrace(AnofoxLogLevel::Debug, "ner: Cache hit");
             return *cached;
         }
     }
@@ -731,7 +731,7 @@ std::vector<NEREntity> NERModelManager::ExtractEntities(const std::string &text)
     try {
         // Tokenize input
         if (!tokenizer_ || !tokenizer_->IsLoaded()) {
-            AnofoxTrace(AnofoxLogLevel::Error, "[anofox] ner: Tokenizer not loaded");
+            AnofoxTrace(AnofoxLogLevel::Error, "ner: Tokenizer not loaded");
             return {};
         }
         auto input_ids = tokenizer_->Encode(text);
@@ -791,10 +791,10 @@ std::vector<NEREntity> NERModelManager::ExtractEntities(const std::string &text)
         return entities;
 
     } catch (const ov::Exception &e) {
-        AnofoxTrace(AnofoxLogLevel::Error, "[anofox] ner: OpenVINO inference error: " + std::string(e.what()));
+        AnofoxTrace(AnofoxLogLevel::Error, "ner: OpenVINO inference error: " + std::string(e.what()));
         return {};
     } catch (const std::exception &e) {
-        AnofoxTrace(AnofoxLogLevel::Error, "[anofox] ner: Inference error: " + std::string(e.what()));
+        AnofoxTrace(AnofoxLogLevel::Error, "ner: Inference error: " + std::string(e.what()));
         return {};
     }
 #else
@@ -987,21 +987,21 @@ void NERModelManager::SetCacheCapacity(size_t capacity) {
     if (result_cache_) {
         result_cache_->SetCapacity(capacity);
         AnofoxTrace(AnofoxLogLevel::Info,
-            "[anofox] ner: Cache capacity set to " + std::to_string(capacity));
+            "ner: Cache capacity set to " + std::to_string(capacity));
     }
 }
 
 void NERModelManager::ClearCache() {
     if (result_cache_) {
         result_cache_->Clear();
-        AnofoxTrace(AnofoxLogLevel::Debug, "[anofox] ner: Cache cleared");
+        AnofoxTrace(AnofoxLogLevel::Debug, "ner: Cache cleared");
     }
 }
 
 void NERModelManager::SetDevice(const std::string &device_name) {
     device_name_ = device_name;
     AnofoxTrace(AnofoxLogLevel::Info,
-                "[anofox] ner: Device set to '" + device_name + "' (reload required for changes to take effect)");
+                "ner: Device set to '" + device_name + "' (reload required for changes to take effect)");
 }
 
 std::string NERModelManager::GetDevice() const {
@@ -1047,7 +1047,7 @@ std::vector<std::vector<NEREntity>> NERModelManager::ExtractEntitiesBatch(
             auto cached = result_cache_->Get(text);
             if (cached) {
                 all_results[i] = *cached;
-                AnofoxTrace(AnofoxLogLevel::Debug, "[anofox] ner: Batch cache hit");
+                AnofoxTrace(AnofoxLogLevel::Debug, "ner: Batch cache hit");
                 continue;
             }
         }
@@ -1068,7 +1068,7 @@ std::vector<std::vector<NEREntity>> NERModelManager::ExtractEntitiesBatch(
     }
 
     AnofoxTrace(AnofoxLogLevel::Debug,
-                "[anofox] ner: Batch processing " + std::to_string(cache_miss_indices.size()) +
+                "ner: Batch processing " + std::to_string(cache_miss_indices.size()) +
                 " unique texts (" + std::to_string(texts.size()) + " total)");
 
     // Phase 2: Process cache misses sequentially (true batching would require dynamic model)
@@ -1142,10 +1142,10 @@ std::vector<std::vector<NEREntity>> NERModelManager::ExtractEntitiesBatch(
 
         } catch (const ov::Exception &e) {
             AnofoxTrace(AnofoxLogLevel::Error,
-                        "[anofox] ner: OpenVINO batch inference error: " + std::string(e.what()));
+                        "ner: OpenVINO batch inference error: " + std::string(e.what()));
         } catch (const std::exception &e) {
             AnofoxTrace(AnofoxLogLevel::Error,
-                        "[anofox] ner: Batch inference error: " + std::string(e.what()));
+                        "ner: Batch inference error: " + std::string(e.what()));
         }
     }
 
@@ -1188,7 +1188,7 @@ void SetNERModelOption(ClientContext &context, SetScope scope, Value &parameter)
     SetCurrentModelName(model_name);
 
     AnofoxTrace(AnofoxLogLevel::Info,
-                "[anofox] ner: Model set to '" + model_name + "' (reload required for changes to take effect)");
+                "ner: Model set to '" + model_name + "' (reload required for changes to take effect)");
 
     // Note: Actual model reload will happen on next EnsureInitialized() call
     // TODO: Implement NERModelManager::ReloadModel() for immediate reload

--- a/src/anofox_pii.cpp
+++ b/src/anofox_pii.cpp
@@ -1208,7 +1208,7 @@ std::vector<PIIMatch> NameRecognizer::FindMatches(const std::string &text) const
             }
         } catch (const std::exception &e) {
             AnofoxTrace(AnofoxLogLevel::Warn,
-                "[anofox] pii: NER extraction failed, falling back to dictionary: " + std::string(e.what()));
+                "pii: NER extraction failed, falling back to dictionary: " + std::string(e.what()));
         }
     }
 #endif
@@ -1350,13 +1350,13 @@ std::vector<PIIMatch> OrganizationRecognizer::FindMatches(const std::string &tex
                         entity.confidence
                     );
                     AnofoxTrace(AnofoxLogLevel::Debug,
-                        "[anofox] pii: Detected ORGANIZATION '" + entity.text +
+                        "pii: Detected ORGANIZATION '" + entity.text +
                         "' (confidence=" + std::to_string(entity.confidence) + ")");
                 }
             }
         } catch (const std::exception &e) {
             AnofoxTrace(AnofoxLogLevel::Warn,
-                "[anofox] pii: NER extraction failed for organizations: " + std::string(e.what()));
+                "pii: NER extraction failed for organizations: " + std::string(e.what()));
         }
     }
 #endif
@@ -1426,13 +1426,13 @@ std::vector<PIIMatch> LocationRecognizer::FindMatches(const std::string &text) c
                         entity.confidence
                     );
                     AnofoxTrace(AnofoxLogLevel::Debug,
-                        "[anofox] pii: Detected LOCATION '" + entity.text +
+                        "pii: Detected LOCATION '" + entity.text +
                         "' (confidence=" + std::to_string(entity.confidence) + ")");
                 }
             }
         } catch (const std::exception &e) {
             AnofoxTrace(AnofoxLogLevel::Warn,
-                "[anofox] pii: NER extraction failed for locations: " + std::string(e.what()));
+                "pii: NER extraction failed for locations: " + std::string(e.what()));
         }
     }
 #endif
@@ -1504,13 +1504,13 @@ std::vector<PIIMatch> MiscRecognizer::FindMatches(const std::string &text) const
                         entity.confidence
                     );
                     AnofoxTrace(AnofoxLogLevel::Debug,
-                        "[anofox] pii: Detected MISC entity '" + entity.text +
+                        "pii: Detected MISC entity '" + entity.text +
                         "' (confidence=" + std::to_string(entity.confidence) + ")");
                 }
             }
         } catch (const std::exception &e) {
             AnofoxTrace(AnofoxLogLevel::Warn,
-                "[anofox] pii: NER extraction failed for misc entities: " + std::string(e.what()));
+                "pii: NER extraction failed for misc entities: " + std::string(e.what()));
         }
     }
 #endif
@@ -1672,7 +1672,7 @@ std::vector<std::vector<PIIMatch>> PIIEngine::DetectBatch(
     auto &ner = NERModelManager::Instance();
     if (ner.IsAvailable()) {
         AnofoxTrace(AnofoxLogLevel::Debug,
-                    "[anofox] pii: Pre-warming NER cache for " + std::to_string(texts.size()) + " texts");
+                    "pii: Pre-warming NER cache for " + std::to_string(texts.size()) + " texts");
         ner.ExtractEntitiesBatch(texts);
     }
 
@@ -3298,7 +3298,7 @@ void RegisterPIIOptions(ExtensionLoader &loader) {
                               Value::BOOLEAN(false),
                               SetPIIDeepValidationOption);
 
-    AnofoxTrace(AnofoxLogLevel::Info, "[anofox] PII configuration options registered");
+    AnofoxTrace(AnofoxLogLevel::Info, "PII configuration options registered");
 }
 
 void RegisterPIIFunctions(ExtensionLoader &loader) {
@@ -3578,7 +3578,7 @@ void RegisterPIIFunctions(ExtensionLoader &loader) {
         RegisterTableFunctionWithAlias(loader, pii_config_func, "pii_config", {std::move(desc)});
     }
 
-    AnofoxTrace(AnofoxLogLevel::Info, "[anofox] PII detection functions registered");
+    AnofoxTrace(AnofoxLogLevel::Info, "PII detection functions registered");
 }
 
 } // namespace anofox

--- a/src/anofox_tabular_extension.cpp
+++ b/src/anofox_tabular_extension.cpp
@@ -16,9 +16,24 @@
 #include "anofox_ner.hpp"
 #include "telemetry.hpp"
 
+#include <cstdlib>
+
 namespace duckdb {
 
 namespace {
+
+// True if the DATAZOO_DISABLE_TELEMETRY environment variable requests an opt-out.
+// This mirrors the check posthog-telemetry performs at send time, but evaluating it
+// here lets us disable the singleton before any event is enqueued (and before the
+// background queue thread is ever started).
+bool IsTelemetryDisabledByEnv() {
+	const char *env = std::getenv("DATAZOO_DISABLE_TELEMETRY");
+	if (!env) {
+		return false;
+	}
+	const std::string value(env);
+	return value == "1" || value == "true" || value == "yes";
+}
 
 void OnTelemetryEnabled(ClientContext &context, SetScope scope, Value &parameter) {
 	if (parameter.IsNull()) {
@@ -41,9 +56,12 @@ void OnTelemetryKey(ClientContext &context, SetScope scope, Value &parameter) {
 static void RegisterTelemetryOptions(ExtensionLoader &loader) {
 	auto &config = DBConfig::GetConfig(loader.GetDatabaseInstance());
 
+	// The default reflects the DATAZOO_DISABLE_TELEMETRY environment variable so
+	// `current_setting('anofox_telemetry_enabled')` is honest about the effective state.
 	config.AddExtensionOption("anofox_telemetry_enabled",
 	                          "Enable or disable anonymous usage telemetry",
-	                          LogicalType::BOOLEAN, Value::BOOLEAN(true), OnTelemetryEnabled);
+	                          LogicalType::BOOLEAN, Value::BOOLEAN(!IsTelemetryDisabledByEnv()),
+	                          OnTelemetryEnabled);
 
 	config.AddExtensionOption("anofox_telemetry_key",
 	                          "PostHog API key for telemetry",
@@ -58,13 +76,29 @@ void LoadInternal(ExtensionLoader &loader) {
 	    "email, phone, postal address, VAT, PII detection/masking, "
 	    "money, diffing, profiling, and anomaly detection.");
 
-	// Register telemetry options FIRST (allows users to disable via SQL settings)
-	// Note: Environment variable DATAZOO_DISABLE_TELEMETRY is always checked by posthog-telemetry
+	// Register telemetry options first so they exist before any event is emitted.
 	RegisterTelemetryOptions(loader);
 
-	// Initialize and capture extension load event
+	// Determine the effective telemetry opt-out BEFORE emitting the load event.
+	// SQL `SET anofox_telemetry_enabled = false` can only run after the extension is
+	// loaded, so it cannot suppress this event; the pre-load opt-outs are:
+	//   - the DATAZOO_DISABLE_TELEMETRY environment variable, or
+	//   - pre-setting anofox_telemetry_enabled through DBConfig / client config
+	//     (with allow_unrecognized_options) — AddExtensionOption adopts such values
+	//     without invoking the SET callback, so read the effective value here.
+	auto &db = loader.GetDatabaseInstance();
+	bool telemetry_enabled = !IsTelemetryDisabledByEnv();
+	if (telemetry_enabled) {
+		Value enabled_value;
+		if (db.TryGetCurrentSetting("anofox_telemetry_enabled", enabled_value) && !enabled_value.IsNull()) {
+			telemetry_enabled = BooleanValue::Get(enabled_value.DefaultCastAs(LogicalType::BOOLEAN));
+		}
+	}
+
+	// Sync the singleton with the effective state so capture call sites are
+	// consistent with the configuration from the very start.
 	auto &telemetry = PostHogTelemetry::Instance();
-	telemetry.SetAPIKey("phc_t3wwRLtpyEmLHYaZCSszG0MqVr74J6wnCrj9D41zk2t");
+	telemetry.SetEnabled(telemetry_enabled);
 
 	std::string version;
 #ifdef EXT_VERSION_ANOFOX_TABULAR
@@ -72,7 +106,17 @@ void LoadInternal(ExtensionLoader &loader) {
 #else
 	version = "0.1.0";
 #endif
-	telemetry.CaptureExtensionLoad("anofox_tabular", version);
+	if (telemetry_enabled) {
+		Value key_value;
+		if (db.TryGetCurrentSetting("anofox_telemetry_key", key_value) && !key_value.IsNull()) {
+			telemetry.SetAPIKey(StringValue::Get(key_value.DefaultCastAs(LogicalType::VARCHAR)));
+		}
+		telemetry.CaptureExtensionLoad("anofox_tabular", version);
+	} else {
+		// Still record the extension name so later re-enabling via SQL produces
+		// correctly attributed function-execution events.
+		telemetry.SetExtensionName("anofox_tabular");
+	}
 
 #if HAVE_LIBPOSTAL
 	anofox::RegisterPostalOptions(loader);

--- a/src/anofox_trace.cpp
+++ b/src/anofox_trace.cpp
@@ -1,6 +1,7 @@
 #include "anofox_trace.hpp"
 
 #include <iostream>
+#include <mutex>
 #include <string>
 
 namespace duckdb {
@@ -72,13 +73,16 @@ std::string AnofoxTraceConfig::GetLevelString() const {
 
 void AnofoxTrace(AnofoxLogLevel level, const std::string &message) {
 	auto &config = AnofoxTraceConfig::Get();
-	if (!config.ShouldLog(level)) {
+	if (level == AnofoxLogLevel::Off || !config.ShouldLog(level)) {
 		return;
 	}
-	if (level == AnofoxLogLevel::Off) {
-		return;
-	}
-	std::cerr << "[anofox] " << message << std::endl;
+	// Compose the full line first (including the level of the message, not the
+	// configured threshold) and emit it as a single write guarded by a mutex so
+	// lines from parallel tasks cannot interleave (#51).
+	const std::string line = "[anofox] [" + LevelToString(level) + "] " + message + "\n";
+	static std::mutex output_mutex;
+	std::lock_guard<std::mutex> guard(output_mutex);
+	std::cerr << line << std::flush;
 }
 
 } // namespace anofox

--- a/src/include/anofox_function_alias.hpp
+++ b/src/include/anofox_function_alias.hpp
@@ -6,173 +6,104 @@
 #include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
 #include "duckdb/parser/parsed_data/create_table_function_info.hpp"
 
+#include <string>
+#include <vector>
+
 namespace duckdb {
 namespace anofox {
 
-// Helper to register a scalar function with an alias
-inline void RegisterScalarFunctionWithAlias(ExtensionLoader &loader, ScalarFunction func, const std::string &alias_name) {
-	// Register primary function
-	loader.RegisterFunction(func);
-	
-	// Register alias
-	ScalarFunction alias_func(alias_name, func.arguments, func.return_type, func.function);
-	alias_func.null_handling = func.null_handling;
-	alias_func.stability = func.stability;
-	alias_func.varargs = func.varargs;
-	alias_func.bind = func.bind;
+// Alias registration helpers (#51).
+//
+// Aliases are full copies of their primary function with only the name changed
+// (copy-then-rename). Reconstructing the function from a subset of fields would
+// silently drop metadata such as bind_replace, statistics propagation, pushdown
+// flags, serialization hooks, null handling and error modes — the alias must be
+// behaviorally identical to the primary.
+//
+// The optional descriptions parameter attaches the same FunctionDescription
+// metadata to both the primary and the alias catalog entries.
 
-	CreateScalarFunctionInfo alias_info(alias_func);
-	alias_info.alias_of = func.name;
+// Helper to register a scalar function with an alias
+inline void RegisterScalarFunctionWithAlias(ExtensionLoader &loader, ScalarFunction func,
+                                            const std::string &alias_name,
+                                            vector<FunctionDescription> descriptions = {}) {
+	// Register primary with metadata
+	CreateScalarFunctionInfo primary_info(func);
+	primary_info.descriptions = descriptions;
+	loader.RegisterFunction(primary_info);
+
+	// Register alias: copy-then-rename so all metadata survives
+	auto primary_name = func.name;
+	auto alias_func = std::move(func);
+	alias_func.name = alias_name;
+	CreateScalarFunctionInfo alias_info(std::move(alias_func));
+	alias_info.descriptions = std::move(descriptions);
+	alias_info.alias_of = primary_name;
 	loader.RegisterFunction(alias_info);
 }
 
 // Helper to register a scalar function set with an alias
-inline void RegisterScalarFunctionSetWithAlias(ExtensionLoader &loader, ScalarFunctionSet func_set, const std::string &alias_name) {
-	// Register primary function set
-	loader.RegisterFunction(func_set);
-	
-	// Register alias - create a new function set with alias name
+inline void RegisterScalarFunctionSetWithAlias(ExtensionLoader &loader, ScalarFunctionSet func_set,
+                                               const std::string &alias_name,
+                                               vector<FunctionDescription> descriptions = {}) {
+	// Register primary with metadata
+	CreateScalarFunctionInfo primary_info(func_set);
+	primary_info.descriptions = descriptions;
+	loader.RegisterFunction(primary_info);
+
+	// Register alias: copy-then-rename every overload so all metadata survives
 	ScalarFunctionSet alias_set(alias_name);
 	for (auto &func : func_set.functions) {
-		ScalarFunction alias_func(alias_name, func.arguments, func.return_type, func.function);
-		alias_func.null_handling = func.null_handling;
-		alias_func.stability = func.stability;
-		alias_func.varargs = func.varargs;
-		alias_func.bind = func.bind;
-		alias_set.AddFunction(alias_func);
+		auto alias_func = func;
+		alias_func.name = alias_name;
+		alias_set.AddFunction(std::move(alias_func));
 	}
-	
-	CreateScalarFunctionInfo alias_info(alias_set);
+	CreateScalarFunctionInfo alias_info(std::move(alias_set));
+	alias_info.descriptions = std::move(descriptions);
 	alias_info.alias_of = func_set.name;
 	loader.RegisterFunction(alias_info);
 }
 
 // Helper to register a table function with an alias
-inline void RegisterTableFunctionWithAlias(ExtensionLoader &loader, TableFunction func, const std::string &alias_name) {
-	// Register primary function
-	loader.RegisterFunction(func);
+inline void RegisterTableFunctionWithAlias(ExtensionLoader &loader, TableFunction func,
+                                           const std::string &alias_name,
+                                           vector<FunctionDescription> descriptions = {}) {
+	// Register primary with metadata
+	CreateTableFunctionInfo primary_info(func);
+	primary_info.descriptions = descriptions;
+	loader.RegisterFunction(primary_info);
 
-	// Register alias
-	TableFunction alias_func(alias_name, func.arguments, func.function, func.bind, func.init_global, func.init_local);
-	alias_func.init_global = func.init_global;
-	alias_func.init_local = func.init_local;
-	alias_func.bind_replace = func.bind_replace;
-	alias_func.named_parameters = func.named_parameters;
-
-	CreateTableFunctionInfo alias_info(alias_func);
-	alias_info.alias_of = func.name;
+	// Register alias: copy-then-rename so all metadata survives
+	auto primary_name = func.name;
+	auto alias_func = std::move(func);
+	alias_func.name = alias_name;
+	CreateTableFunctionInfo alias_info(std::move(alias_func));
+	alias_info.descriptions = std::move(descriptions);
+	alias_info.alias_of = primary_name;
 	loader.RegisterFunction(alias_info);
 }
 
 // Helper to register a table function set with an alias
-inline void RegisterTableFunctionSetWithAlias(ExtensionLoader &loader, TableFunctionSet func_set, const std::string &alias_name) {
-	// Register primary function set
-	loader.RegisterFunction(func_set);
+inline void RegisterTableFunctionSetWithAlias(ExtensionLoader &loader, TableFunctionSet func_set,
+                                              const std::string &alias_name,
+                                              vector<FunctionDescription> descriptions = {}) {
+	// Register primary with metadata
+	CreateTableFunctionInfo primary_info(func_set);
+	primary_info.descriptions = descriptions;
+	loader.RegisterFunction(primary_info);
 
-	// Register alias - create a new function set with alias name
+	// Register alias: copy-then-rename every overload so all metadata survives
 	TableFunctionSet alias_set(alias_name);
 	for (auto &func : func_set.functions) {
-		TableFunction alias_func(alias_name, func.arguments, func.function, func.bind, func.init_global, func.init_local);
-		alias_func.init_global = func.init_global;
-		alias_func.init_local = func.init_local;
-		alias_func.bind_replace = func.bind_replace;
-		alias_func.named_parameters = func.named_parameters;
-		alias_set.AddFunction(alias_func);
+		auto alias_func = func;
+		alias_func.name = alias_name;
+		alias_set.AddFunction(std::move(alias_func));
 	}
-
-	CreateTableFunctionInfo alias_info(alias_set);
+	CreateTableFunctionInfo alias_info(std::move(alias_set));
+	alias_info.descriptions = std::move(descriptions);
 	alias_info.alias_of = func_set.name;
 	loader.RegisterFunction(alias_info);
 }
 
-// Helper to register a scalar function with an alias and descriptions
-inline void RegisterScalarFunctionWithAlias(ExtensionLoader &loader, ScalarFunction func,
-                                            const std::string &alias_name,
-                                            std::vector<FunctionDescription> descriptions) {
-    // Register primary with metadata
-    CreateScalarFunctionInfo primary_info(func);
-    primary_info.descriptions = std::move(descriptions);
-    loader.RegisterFunction(primary_info);
-
-    // Register alias
-    ScalarFunction alias_func(alias_name, func.arguments, func.return_type, func.function);
-    alias_func.null_handling = func.null_handling;
-    alias_func.stability = func.stability;
-    alias_func.varargs = func.varargs;
-    alias_func.bind = func.bind;
-    CreateScalarFunctionInfo alias_info(alias_func);
-    alias_info.alias_of = func.name;
-    loader.RegisterFunction(alias_info);
-}
-
-// Helper to register a scalar function set with an alias and descriptions
-inline void RegisterScalarFunctionSetWithAlias(ExtensionLoader &loader, ScalarFunctionSet func_set,
-                                               const std::string &alias_name,
-                                               std::vector<FunctionDescription> descriptions) {
-    // Register primary with metadata
-    CreateScalarFunctionInfo primary_info(func_set);
-    primary_info.descriptions = std::move(descriptions);
-    loader.RegisterFunction(primary_info);
-
-    // Register alias
-    ScalarFunctionSet alias_set(alias_name);
-    for (auto &func : func_set.functions) {
-        ScalarFunction alias_func(alias_name, func.arguments, func.return_type, func.function);
-        alias_func.null_handling = func.null_handling;
-        alias_func.stability = func.stability;
-        alias_func.varargs = func.varargs;
-        alias_func.bind = func.bind;
-        alias_set.AddFunction(alias_func);
-    }
-    CreateScalarFunctionInfo alias_info(alias_set);
-    alias_info.alias_of = func_set.name;
-    loader.RegisterFunction(alias_info);
-}
-
-// Helper to register a table function with an alias and descriptions
-inline void RegisterTableFunctionWithAlias(ExtensionLoader &loader, TableFunction func,
-                                           const std::string &alias_name,
-                                           std::vector<FunctionDescription> descriptions) {
-    // Register primary with metadata
-    CreateTableFunctionInfo primary_info(func);
-    primary_info.descriptions = std::move(descriptions);
-    loader.RegisterFunction(primary_info);
-
-    // Register alias
-    TableFunction alias_func(alias_name, func.arguments, func.function, func.bind, func.init_global, func.init_local);
-    alias_func.init_global = func.init_global;
-    alias_func.init_local = func.init_local;
-    alias_func.bind_replace = func.bind_replace;
-    alias_func.named_parameters = func.named_parameters;
-    CreateTableFunctionInfo alias_info(alias_func);
-    alias_info.alias_of = func.name;
-    loader.RegisterFunction(alias_info);
-}
-
-// Helper to register a table function set with an alias and descriptions
-inline void RegisterTableFunctionSetWithAlias(ExtensionLoader &loader, TableFunctionSet func_set,
-                                              const std::string &alias_name,
-                                              std::vector<FunctionDescription> descriptions) {
-    // Register primary with metadata
-    CreateTableFunctionInfo primary_info(func_set);
-    primary_info.descriptions = std::move(descriptions);
-    loader.RegisterFunction(primary_info);
-
-    // Register alias
-    TableFunctionSet alias_set(alias_name);
-    for (auto &func : func_set.functions) {
-        TableFunction alias_func(alias_name, func.arguments, func.function, func.bind, func.init_global, func.init_local);
-        alias_func.init_global = func.init_global;
-        alias_func.init_local = func.init_local;
-        alias_func.bind_replace = func.bind_replace;
-        alias_func.named_parameters = func.named_parameters;
-        alias_set.AddFunction(alias_func);
-    }
-    CreateTableFunctionInfo alias_info(alias_set);
-    alias_info.alias_of = func_set.name;
-    loader.RegisterFunction(alias_info);
-}
-
 } // namespace anofox
 } // namespace duckdb
-

--- a/test/sql/anofox_alias_fidelity.test
+++ b/test/sql/anofox_alias_fidelity.test
@@ -1,0 +1,130 @@
+# name: test/sql/anofox_alias_fidelity.test
+# description: Aliases must be behaviorally and metadata-wise identical to their primary functions (#51)
+# group: [anofox_tabular]
+
+require anofox_tabular
+
+statement ok
+LOAD anofox_tabular
+
+# ============================================================================
+# Metadata fidelity
+# ============================================================================
+
+# Scalar alias is linked to its primary
+query I
+SELECT DISTINCT alias_of FROM duckdb_functions() WHERE function_name = 'vat';
+----
+anofox_tab_vat
+
+# Table function alias is linked to its primary
+query I
+SELECT DISTINCT alias_of FROM duckdb_functions() WHERE function_name = 'dbscan';
+----
+anofox_tab_dbscan
+
+# Primary scalar carries a description
+query I
+SELECT any_value(description) IS NOT NULL FROM duckdb_functions() WHERE function_name = 'anofox_tab_vat';
+----
+true
+
+# Scalar alias carries the same description as its primary
+# (RED on #51: the alias helpers drop the FunctionDescription metadata)
+query I
+SELECT (SELECT any_value(description) FROM duckdb_functions() WHERE function_name = 'vat')
+       IS NOT DISTINCT FROM
+       (SELECT any_value(description) FROM duckdb_functions() WHERE function_name = 'anofox_tab_vat');
+----
+true
+
+# Scalar function set alias carries the same description as its primary
+# (RED on #51)
+query I
+SELECT (SELECT any_value(description) FROM duckdb_functions() WHERE function_name = 'email_is_valid')
+       IS NOT DISTINCT FROM
+       (SELECT any_value(description) FROM duckdb_functions() WHERE function_name = 'anofox_tab_email_is_valid');
+----
+true
+
+# Table function alias carries the same description as its primary
+# (RED on #51)
+query I
+SELECT (SELECT any_value(description) FROM duckdb_functions() WHERE function_name = 'dbscan')
+       IS NOT DISTINCT FROM
+       (SELECT any_value(description) FROM duckdb_functions() WHERE function_name = 'anofox_tab_dbscan');
+----
+true
+
+# Table function set alias carries the same description as its primary
+# (RED on #51)
+query I
+SELECT (SELECT any_value(description) FROM duckdb_functions() WHERE function_name = 'pii_scan_table')
+       IS NOT DISTINCT FROM
+       (SELECT any_value(description) FROM duckdb_functions() WHERE function_name = 'anofox_tab_pii_scan_table');
+----
+true
+
+# A scalar set alias keeps all overloads of the primary set
+query I
+SELECT (SELECT count(*) FROM duckdb_functions() WHERE function_name = 'email_is_valid')
+     = (SELECT count(*) FROM duckdb_functions() WHERE function_name = 'anofox_tab_email_is_valid');
+----
+true
+
+# ============================================================================
+# Behavior fidelity: scalar functions (regression guard for copy-then-rename)
+# ============================================================================
+
+# Identical results through primary and alias
+query II
+SELECT anofox_tab_vat_is_valid_syntax('DE123456789'), vat_is_valid_syntax('DE123456789');
+----
+true	true
+
+query II
+SELECT anofox_tab_vat_is_valid_syntax('DE1'), vat_is_valid_syntax('DE1');
+----
+false	false
+
+# Identical NULL handling through primary and alias
+query II
+SELECT anofox_tab_vat_is_valid_syntax(NULL), vat_is_valid_syntax(NULL);
+----
+NULL	NULL
+
+# SPECIAL_HANDLING null behavior must survive aliasing (email_is_valid set)
+query II
+SELECT anofox_tab_email_is_valid(NULL, 'regex'), email_is_valid(NULL, 'regex');
+----
+NULL	NULL
+
+# Identical runtime error messages through primary and alias
+statement error
+SELECT anofox_tab_money(10.50, 'ZZZ');
+----
+Invalid currency code: ZZZ
+
+statement error
+SELECT money(10.50, 'ZZZ');
+----
+Invalid currency code: ZZZ
+
+# ============================================================================
+# Behavior fidelity: table functions (bind_replace must survive aliasing)
+# ============================================================================
+
+statement ok
+CREATE TABLE alias_fidelity_points(v DOUBLE);
+
+statement ok
+INSERT INTO alias_fidelity_points VALUES (1.0), (1.1), (1.2), (10.0);
+
+query I
+SELECT (SELECT count(*) FROM anofox_tab_dbscan('alias_fidelity_points', 'v', 0.5, 2, 'all'))
+     = (SELECT count(*) FROM dbscan('alias_fidelity_points', 'v', 0.5, 2, 'all'));
+----
+true
+
+statement ok
+DROP TABLE alias_fidelity_points;


### PR DESCRIPTION
Closes #51. Part of the 2026-06 code review program (section 2.11, Phase 1).

## Summary

- **Alias fidelity (MED):** `src/include/anofox_function_alias.hpp` no longer reconstructs `ScalarFunction`/`TableFunction` aliases from a hand-picked field subset. All four helpers now copy the primary function (every overload for the set variants) and only rename it, so `bind_replace`, statistics propagation, pushdown flags, serialization hooks, null handling, error modes and `FunctionDescription` metadata survive aliasing. The descriptions overloads were folded into a defaulted `vector<FunctionDescription>` parameter (call-compatible with both prior signatures) and the descriptions are now attached to the alias catalog entry as well.
- **Load-event honesty (MED):** `extension_load` fires during `LoadInternal`, before any SQL `SET anofox_telemetry_enabled = false` can possibly run. `LoadInternal` now reads the *effective* opt-out before emitting: the `DATAZOO_DISABLE_TELEMETRY` env var and a pre-set `anofox_telemetry_enabled` (DBConfig / client config with `allow_unrecognized_options` — `AddExtensionOption` adopts such values without invoking the SET callback). The singleton is synced to that state up front, the option default reflects the env var so `current_setting()` is honest, and the README now states that SQL `SET` only stops subsequent events and shows the pre-load config opt-out.
- **Trace serialization (LOW):** `AnofoxTrace` composes the full line first — now including the message's level string, which was previously dropped — and emits it as a single write guarded by a static mutex, so lines from parallel tasks cannot interleave. Callers in money/ner/pii that hardcoded a second `[anofox]` prefix (output read `[anofox] [anofox] ...`) were cleaned up.
- **Telemetry singleton sync (HIGH, partial — see submodule notes):** the SET callbacks already go through the mutex-guarded `SetEnabled`/`SetAPIKey`; in-repo we additionally sync the singleton with the effective configuration at load time and no longer enqueue (or start the background queue thread for) the load event when telemetry is disabled.

## Red evidence

First commit d47f1d0 contains only the failing tests. On its parent, `test/sql/anofox_alias_fidelity.test` fails at the description-fidelity check:

```
Wrong result in query! (test/sql/anofox_alias_fidelity.test:34)!
SELECT (SELECT any_value(description) FROM duckdb_functions() WHERE function_name = 'vat')
       IS NOT DISTINCT FROM
       (SELECT any_value(description) FROM duckdb_functions() WHERE function_name = 'anofox_tab_vat');
Expected result: true
Actual result:   0
assertions: 5 | 4 passed | 1 failed
```

The remaining behavioral checks (NULL handling, error messages, `bind_replace` row counts, overload counts) pass on main and act as regression guards: the field-subset copies happened to include the fields those paths exercise today, so the refactor is justified structurally — any field DuckDB adds or that we start using (e.g. error modes, statistics, serialization) is silently dropped by the old approach. Telemetry races and trace interleaving are not deterministically observable from SQL; they received structural fixes (see issue comment for verification notes).

## Submodule notes (posthog-telemetry)

Two findings live inside the `posthog-telemetry` submodule and cannot be fixed via this PR:

- `EnsureQueueInitialized()` lazily creates `_queue` without holding `_thread_lock` (`posthog-telemetry/src/telemetry.cpp:132-137`); two threads capturing concurrently can race the `unique_ptr` initialization.
- `CaptureExtensionLoad`/`CaptureFunctionExecution` copy `_api_key` without the lock (`telemetry.cpp:160,185`) while `SetAPIKey` writes it under `_thread_lock` — a read/write race on a `std::string`.

The fix (snapshot key + init queue under one `lock_guard`, enqueue outside) needs a PR against the submodule repo; details posted on #51. This PR reduces in-repo exposure: when telemetry is disabled (env or pre-set config) the queue thread is never started and no capture path is reached during load.

Known pre-existing standalone-shell exit segfault in the telemetry worker thread: it lives in submodule shutdown ordering and is not cured generally; however, with `DATAZOO_DISABLE_TELEMETRY=1` the worker thread now never starts, so that configuration is no longer exposed to it (verified clean exits locally).

## Heads-up: textual conflict with #63

PR #63 (money) independently added error-mode propagation to the alias helpers on its branch. The copy-then-rename rewrite here supersedes that (error modes are copied along with everything else), so expect a textual merge conflict in `src/include/anofox_function_alias.hpp` — resolve in favor of this version.

## Tests

- `test/sql/anofox_alias_fidelity.test` green.
- Full `make test`: All tests passed (1 skipped: `require-env OPENVINO_AVAILABLE`, 1647 assertions in 17 test cases).