### PR TITLE
chore: RAII sweep, algorithm hot-path cleanups, cctype leftovers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -304,6 +304,7 @@ if(NOT CLANG_TIDY AND NOT EMSCRIPTEN AND CMAKE_VERSION VERSION_GREATER_EQUAL "3.
     add_library(anofox_tabular_unittest_tests OBJECT
         test/cpp/test_anofox_dbscan.cpp
         test/cpp/test_anofox_isolation_forest.cpp
+        test/cpp/test_anofox_outlier_tree.cpp
         test/cpp/test_email_internal.cpp
     )
     target_compile_features(anofox_tabular_unittest_tests PRIVATE cxx_std_17)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -338,6 +338,7 @@ if(EXISTS "${DUCKDB_CATCH_DIR}/catch.hpp")
     add_executable(anofox_tabular_cpp_tests
         test/cpp/test_ner_lru_cache.cpp
         test/cpp/test_ner_input_bounding.cpp
+        test/cpp/test_anofox_raii.cpp
     )
     target_include_directories(anofox_tabular_cpp_tests PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/src/include

--- a/src/anofox_dbscan.cpp
+++ b/src/anofox_dbscan.cpp
@@ -47,14 +47,15 @@ double DBSCAN::ComputeDensityScore(size_t neighbor_count, size_t max_neighbors) 
 	return std::min(1.0, static_cast<double>(neighbor_count) / static_cast<double>(max_neighbors));
 }
 
-std::vector<size_t> DBSCAN::RegionQuery(
+void DBSCAN::RegionQuery(
 	const std::vector<std::vector<double>>& data,
-	size_t point_idx
+	size_t point_idx,
+	std::vector<size_t>& neighbors
 ) const {
-	std::vector<size_t> neighbors;
+	neighbors.clear();
 
 	if (point_idx >= data.size()) {
-		return neighbors;
+		return;
 	}
 
 	const auto& query_point = data[point_idx];
@@ -67,8 +68,6 @@ std::vector<size_t> DBSCAN::RegionQuery(
 			}
 		}
 	}
-
-	return neighbors;
 }
 
 void DBSCAN::ExpandCluster(
@@ -90,6 +89,9 @@ void DBSCAN::ExpandCluster(
 		queue.push(seed_idx);
 	}
 
+	// Scratch buffer reused across all region queries of this expansion (issue #60)
+	std::vector<size_t> current_neighbors;
+
 	while (!queue.empty()) {
 		size_t current_idx = queue.front();
 		queue.pop();
@@ -109,7 +111,7 @@ void DBSCAN::ExpandCluster(
 		results_[current_idx].cluster_id = cluster_id;
 
 		// Find neighbors of current point
-		std::vector<size_t> current_neighbors = RegionQuery(data, current_idx);
+		RegionQuery(data, current_idx, current_neighbors);
 		results_[current_idx].neighbor_count = current_neighbors.size();
 
 		// Standard minPts semantics: the eps-neighborhood includes the point itself
@@ -158,13 +160,16 @@ void DBSCAN::Fit(const std::vector<std::vector<double>>& data) {
 	std::vector<PointType> point_types(n_points, PointType::UNVISITED);
 	int32_t cluster_id = 0;
 
+	// Scratch buffer reused across all region queries of the fit (issue #60)
+	std::vector<size_t> neighbors;
+
 	// Main DBSCAN loop
 	for (size_t i = 0; i < n_points; ++i) {
 		if (!visited[i]) {
 			visited[i] = true;
 
 			// Find neighbors of point i
-			std::vector<size_t> neighbors = RegionQuery(data, i);
+			RegionQuery(data, i, neighbors);
 			results_[i].neighbor_count = neighbors.size();
 
 			// Standard minPts semantics: the eps-neighborhood includes the point itself

--- a/src/anofox_email_dns.cpp
+++ b/src/anofox_email_dns.cpp
@@ -14,6 +14,7 @@
 #include <unordered_map>
 #include <vector>
 #include "anofox_email_logging.hpp"
+#include "anofox_raii.hpp"
 #include "duckdb/common/string_util.hpp"
 
 #ifdef _WIN32
@@ -392,19 +393,32 @@ DnsResult DnsResolver::Resolve(const std::string &domain) {
 	resolver_options.sock_state_cb = OnSocketState;
 	resolver_options.sock_state_cb_data = &tracker;
 
-	ares_channel_t *channel = nullptr;
-	int init_rc = ares_init_options(&channel, &resolver_options,
+	// Declared before the channel guard: destroying the channel can still fire
+	// callbacks that touch these states (and the socket tracker above), so the
+	// guard must be torn down first on every exit path.
+	int pending = 0;
+	MxQueryState mx_state;
+	mx_state.pending = &pending;
+	AddrInfoState addrinfo_state;
+	addrinfo_state.pending = &pending;
+
+	ares_channel_t *raw_channel = nullptr;
+	int init_rc = ares_init_options(&raw_channel, &resolver_options,
 	                                ARES_OPT_TIMEOUTMS | ARES_OPT_TRIES | ARES_OPT_SOCK_STATE_CB);
 	if (init_rc != ARES_SUCCESS) {
 		result.reason = MapAresStatus(init_rc);
 		return result;
 	}
+	// RAII channel ownership (issue #60): released on every exit path.
+	struct AresChannelDestroyer {
+		void operator()(ares_channel_t *channel) const {
+			ares_destroy(channel);
+		}
+	};
+	UniqueHandle<ares_channel_t *, AresChannelDestroyer, nullptr> channel(raw_channel);
 
-	int pending = 0;
-	MxQueryState mx_state;
-	mx_state.pending = &pending;
-
-	auto mx_rc = ares_query_dnsrec(channel, domain.c_str(), ARES_CLASS_IN, ARES_REC_TYPE_MX, OnMxQuery, &mx_state, nullptr);
+	auto mx_rc = ares_query_dnsrec(channel.Get(), domain.c_str(), ARES_CLASS_IN, ARES_REC_TYPE_MX, OnMxQuery,
+	                               &mx_state, nullptr);
 	if (mx_rc == ARES_SUCCESS) {
 		pending++;
 	} else {
@@ -412,16 +426,13 @@ DnsResult DnsResolver::Resolve(const std::string &domain) {
 		mx_state.error = ares_strerror(static_cast<int>(mx_rc));
 	}
 
-	AddrInfoState addrinfo_state;
-	addrinfo_state.pending = &pending;
-
 	ares_addrinfo_hints hints;
 	std::memset(&hints, 0, sizeof(hints));
 	hints.ai_family = AF_UNSPEC;
 	hints.ai_socktype = SOCK_STREAM;
 
 	pending++;
-	ares_getaddrinfo(channel, domain.c_str(), nullptr, &hints, OnAddrInfo, &addrinfo_state);
+	ares_getaddrinfo(channel.Get(), domain.c_str(), nullptr, &hints, OnAddrInfo, &addrinfo_state);
 
 	std::string loop_error;
 	uint32_t loop_timeout_ms = DnsOptions::MAX_TIMEOUT_MS;
@@ -434,10 +445,9 @@ DnsResult DnsResolver::Resolve(const std::string &domain) {
 	if (total_timeout < loop_timeout_ms) {
 		loop_timeout_ms = static_cast<uint32_t>(total_timeout);
 	}
-	bool loop_ok = RunEventLoop(channel, tracker, pending, loop_error, loop_timeout_ms);
-	if (channel) {
-		ares_destroy(channel);
-	}
+	bool loop_ok = RunEventLoop(channel.Get(), tracker, pending, loop_error, loop_timeout_ms);
+	// Cancel outstanding queries now so the states above are settled before use.
+	channel.Reset();
 
 	if (!loop_ok) {
 		result.reason = loop_error.empty() ? "dns_loop_failure" : loop_error;

--- a/src/anofox_email_smtp.cpp
+++ b/src/anofox_email_smtp.cpp
@@ -18,6 +18,7 @@
 #include <ares.h>
 
 #include "anofox_email_logging.hpp"
+#include "anofox_raii.hpp"
 
 #ifdef _WIN32
 #include <winsock2.h>
@@ -113,16 +114,25 @@ std::string SocketErrorMessage(int err) {
 #endif
 }
 
-void CloseSocketHandle(socket_handle sock) {
-	if (sock == INVALID_SOCKET_HANDLE) {
-		return;
-	}
+//! Stateless closers for the RAII guards below (issue #60): socket handles and
+//! c-ares channels are owned by UniqueHandle so every exit path cleans up.
+struct SocketHandleCloser {
+	void operator()(socket_handle sock) const {
 #ifdef _WIN32
-	closesocket(sock);
+		closesocket(sock);
 #else
-	close(sock);
+		close(sock);
 #endif
-}
+	}
+};
+using SocketGuard = UniqueHandle<socket_handle, SocketHandleCloser, INVALID_SOCKET_HANDLE>;
+
+struct AresChannelDestroyer {
+	void operator()(ares_channel_t *channel) const {
+		ares_destroy(channel);
+	}
+};
+using AresChannelGuard = UniqueHandle<ares_channel_t *, AresChannelDestroyer, nullptr>;
 
 bool SetNonBlocking(socket_handle sock, bool enable) {
 #ifdef _WIN32
@@ -509,18 +519,22 @@ bool ResolveHostEndpoints(const std::string &host, uint16_t port, std::chrono::m
 	resolver_options.sock_state_cb = ResolverOnSocketState;
 	resolver_options.sock_state_cb_data = &tracker;
 
-	ares_channel_t *channel = nullptr;
-	int init_rc = ares_init_options(&channel, &resolver_options,
+	// Declared before the channel guard: destroying the channel can still fire
+	// callbacks that touch `state` (and the socket tracker above), so the guard
+	// must be torn down first on every exit path.
+	int pending = 0;
+	AddressResolveState state;
+	state.pending = &pending;
+
+	ares_channel_t *raw_channel = nullptr;
+	int init_rc = ares_init_options(&raw_channel, &resolver_options,
 	                                ARES_OPT_TIMEOUTMS | ARES_OPT_TRIES | ARES_OPT_SOCK_STATE_CB);
 	if (init_rc != ARES_SUCCESS) {
 		result.reason = "smtp_" + DnsStatusToReason(init_rc);
         EmailTrace(AnofoxLogLevel::Warn, "ResolveHostEndpoints init options failed reason=" + result.reason);
 		return false;
 	}
-
-	int pending = 0;
-	AddressResolveState state;
-	state.pending = &pending;
+	AresChannelGuard channel(raw_channel);
 
 	std::string service = std::to_string(port);
 	ares_addrinfo_hints hints;
@@ -529,13 +543,13 @@ bool ResolveHostEndpoints(const std::string &host, uint16_t port, std::chrono::m
 	hints.ai_socktype = SOCK_STREAM;
 
 	pending++;
-	ares_getaddrinfo(channel, host.c_str(), service.c_str(), &hints, OnAddressResolved, &state);
+	ares_getaddrinfo(channel.Get(), host.c_str(), service.c_str(), &hints, OnAddressResolved, &state);
 
 	std::string loop_error;
-	bool loop_ok = RunResolverLoop(channel, tracker, pending, loop_error, timeout);
-	if (channel) {
-		ares_destroy(channel);
-	}
+	bool loop_ok = RunResolverLoop(channel.Get(), tracker, pending, loop_error, timeout);
+	// Cancel outstanding queries before `state`/`tracker` leave scope; the
+	// guard would otherwise destroy the channel only at function exit.
+	channel.Reset();
 
 	if (!loop_ok) {
 		result.reason = loop_error.empty() ? "smtp_dns_timeout" : loop_error;
@@ -810,16 +824,17 @@ SmtpResult AttemptHost(const std::string &email, const std::string &host, const 
     EmailTrace(AnofoxLogLevel::Info,
                "SMTP attempting " + std::to_string(endpoints.size()) + " endpoints for host=" + host);
 	for (auto &endpoint : endpoints) {
-		socket_handle sock = socket(endpoint.address.ss_family, SOCK_STREAM, 0);
-		if (sock == INVALID_SOCKET_HANDLE) {
+		// RAII socket ownership (issue #60): the guard closes the descriptor on
+		// every continue/return below, so no manual close calls are needed.
+		SocketGuard sock(socket(endpoint.address.ss_family, SOCK_STREAM, 0));
+		if (!sock.IsValid()) {
 			attempt.transcript.push_back({"Socket creation failed: " + SocketErrorMessage(LastSocketError())});
             EmailTrace(AnofoxLogLevel::Warn,
                        "SMTP socket creation failed endpoint=" + endpoint.description);
 			continue;
 		}
-		if (!SetNonBlocking(sock, true)) {
+		if (!SetNonBlocking(sock.Get(), true)) {
 			attempt.transcript.push_back({"Failed to set non-blocking mode: " + SocketErrorMessage(LastSocketError())});
-			CloseSocketHandle(sock);
             EmailTrace(AnofoxLogLevel::Warn,
                        "SMTP failed to set non-blocking endpoint=" + endpoint.description);
 			continue;
@@ -830,9 +845,8 @@ SmtpResult AttemptHost(const std::string &email, const std::string &host, const 
 		}
 
 		std::string endpoint_str;
-		if (!ConnectSocket(sock, reinterpret_cast<const sockaddr *>(&endpoint.address), endpoint.length, connect_timeout,
-		                   deadline, endpoint_str, attempt)) {
-			CloseSocketHandle(sock);
+		if (!ConnectSocket(sock.Get(), reinterpret_cast<const sockaddr *>(&endpoint.address), endpoint.length,
+		                   connect_timeout, deadline, endpoint_str, attempt)) {
             EmailTrace(AnofoxLogLevel::Warn,
                        "SMTP connect failed endpoint=" + endpoint.description + " reason=" + attempt.reason);
 			if (!attempt.reason.empty()) {
@@ -846,79 +860,68 @@ SmtpResult AttemptHost(const std::string &email, const std::string &host, const 
 		read_buffer.clear();
 
 		int code = 0;
-		if (!ReadResponse(sock, read_buffer, io_timeout, deadline, attempt, code, "smtp_greeting_timeout",
+		if (!ReadResponse(sock.Get(), read_buffer, io_timeout, deadline, attempt, code, "smtp_greeting_timeout",
 		                  "smtp_greeting_error")) {
-			CloseSocketHandle(sock);
             EmailTrace(AnofoxLogLevel::Warn,
                        "SMTP greeting read failed reason=" + attempt.reason);
 			return attempt;
 		}
 		if (code / 100 != 2) {
 			attempt.reason = "smtp_invalid_greeting";
-			CloseSocketHandle(sock);
             EmailTrace(AnofoxLogLevel::Warn,
                        "SMTP greeting invalid code=" + std::to_string(code));
 			return attempt;
 		}
 
-		if (!SendCommand(sock, "EHLO " + options.helo_domain, io_timeout, deadline, attempt)) {
-			CloseSocketHandle(sock);
+		if (!SendCommand(sock.Get(), "EHLO " + options.helo_domain, io_timeout, deadline, attempt)) {
             EmailTrace(AnofoxLogLevel::Warn,
                        "SMTP EHLO send failed reason=" + attempt.reason);
 			return attempt;
 		}
-		if (!ReadResponse(sock, read_buffer, io_timeout, deadline, attempt, code, "smtp_read_timeout",
+		if (!ReadResponse(sock.Get(), read_buffer, io_timeout, deadline, attempt, code, "smtp_read_timeout",
 		                  "smtp_read_error")) {
-			CloseSocketHandle(sock);
             EmailTrace(AnofoxLogLevel::Warn,
                        "SMTP EHLO response failed reason=" + attempt.reason);
 			return attempt;
 		}
 		if (code / 100 != 2) {
 			attempt.reason = "smtp_helo_rejected";
-			CloseSocketHandle(sock);
             EmailTrace(AnofoxLogLevel::Warn,
                        "SMTP EHLO rejected code=" + std::to_string(code));
 			return attempt;
 		}
 
-		if (!SendCommand(sock, "MAIL FROM:<" + options.mail_from + ">", io_timeout, deadline, attempt)) {
-			CloseSocketHandle(sock);
+		if (!SendCommand(sock.Get(), "MAIL FROM:<" + options.mail_from + ">", io_timeout, deadline, attempt)) {
             EmailTrace(AnofoxLogLevel::Warn,
                        "SMTP MAIL FROM send failed reason=" + attempt.reason);
 			return attempt;
 		}
-		if (!ReadResponse(sock, read_buffer, io_timeout, deadline, attempt, code, "smtp_read_timeout",
+		if (!ReadResponse(sock.Get(), read_buffer, io_timeout, deadline, attempt, code, "smtp_read_timeout",
 		                  "smtp_read_error")) {
-			CloseSocketHandle(sock);
             EmailTrace(AnofoxLogLevel::Warn,
                        "SMTP MAIL FROM response failed reason=" + attempt.reason);
 			return attempt;
 		}
 		if (code / 100 != 2) {
 			attempt.reason = "smtp_mail_from_rejected";
-			CloseSocketHandle(sock);
             EmailTrace(AnofoxLogLevel::Warn,
                        "SMTP MAIL FROM rejected code=" + std::to_string(code));
 			return attempt;
 		}
 
-		if (!SendCommand(sock, "RCPT TO:<" + email + ">", io_timeout, deadline, attempt)) {
-			CloseSocketHandle(sock);
+		if (!SendCommand(sock.Get(), "RCPT TO:<" + email + ">", io_timeout, deadline, attempt)) {
             EmailTrace(AnofoxLogLevel::Warn,
                        "SMTP RCPT TO send failed reason=" + attempt.reason);
 			return attempt;
 		}
-		if (!ReadResponse(sock, read_buffer, io_timeout, deadline, attempt, code, "smtp_read_timeout",
+		if (!ReadResponse(sock.Get(), read_buffer, io_timeout, deadline, attempt, code, "smtp_read_timeout",
 		                  "smtp_read_error")) {
-			CloseSocketHandle(sock);
             EmailTrace(AnofoxLogLevel::Warn,
                        "SMTP RCPT TO response failed reason=" + attempt.reason);
 			return attempt;
 		}
 		if (code / 100 != 2) {
 			attempt.reason = "smtp_recipient_rejected";
-			CloseSocketHandle(sock);
             EmailTrace(AnofoxLogLevel::Warn,
                        "SMTP RCPT TO rejected code=" + std::to_string(code));
 			return attempt;
@@ -926,8 +929,7 @@ SmtpResult AttemptHost(const std::string &email, const std::string &host, const 
 
 		attempt.success = true;
 		attempt.reason.clear();
-		SendCommand(sock, "QUIT", io_timeout, deadline, attempt);
-		CloseSocketHandle(sock);
+		SendCommand(sock.Get(), "QUIT", io_timeout, deadline, attempt);
         EmailTrace(AnofoxLogLevel::Info, "SMTP verification success host=" + host);
 		return attempt;
 	}

--- a/src/anofox_isolation_forest.cpp
+++ b/src/anofox_isolation_forest.cpp
@@ -6,6 +6,32 @@
 namespace duckdb {
 namespace anofox {
 
+/**
+ * Reusable scratch buffers for one mixed-type tree build (issue #60).
+ * The feature partition is computed once per tree; the value/projection
+ * buffers are reused across every split candidate of every node so candidate
+ * generation does not reallocate per candidate.
+ */
+struct TreeBuildScratch {
+    // Per-tree constants
+    std::vector<size_t> numeric_features;
+
+    // Numeric axis-aligned candidate buffers
+    std::vector<double> left_values;
+    std::vector<double> right_values;
+    std::vector<double> all_values;
+
+    // Hyperplane candidate buffers
+    std::vector<size_t> shuffled_numeric;
+    std::vector<double> min_vals;
+    std::vector<double> max_vals;
+    std::vector<double> coefficients;
+    std::vector<double> projections;
+    std::vector<double> left_projs;
+    std::vector<double> right_projs;
+    std::vector<double> all_projs;
+};
+
 // ============================================================================
 // SCiForest Helper Functions
 // ============================================================================
@@ -81,7 +107,8 @@ static bool GenerateNumericSplitCandidate(
     const std::vector<size_t>& sample_indices,
     size_t feature_idx,
     std::mt19937& rng,
-    SplitCandidate& candidate
+    SplitCandidate& candidate,
+    TreeBuildScratch& scratch
 ) {
     const ColumnData& col = data[feature_idx];
 
@@ -105,11 +132,14 @@ static bool GenerateNumericSplitCandidate(
     std::uniform_real_distribution<double> split_dist(min_val, max_val);
     double split_value = split_dist(rng);
 
-    // Partition samples
+    // Partition samples (value buffers reused across candidates, issue #60)
     candidate.left_indices.clear();
     candidate.right_indices.clear();
 
-    std::vector<double> left_values, right_values;
+    auto& left_values = scratch.left_values;
+    auto& right_values = scratch.right_values;
+    left_values.clear();
+    right_values.clear();
 
     for (size_t idx : sample_indices) {
         double val = col.numeric_values[idx];
@@ -136,7 +166,8 @@ static bool GenerateNumericSplitCandidate(
     candidate.split_value = split_value;
 
     // Compute gain
-    std::vector<double> all_values;
+    auto& all_values = scratch.all_values;
+    all_values.clear();
     for (size_t idx : sample_indices) {
         double val = col.numeric_values[idx];
         if (!std::isnan(val)) {
@@ -234,20 +265,23 @@ static bool GenerateHyperplaneSplitCandidate(
     const std::vector<ColumnData>& data,
     const std::vector<ColumnInfo>& column_info,
     const std::vector<size_t>& sample_indices,
-    const std::vector<size_t>& numeric_features,
     size_t effective_ndim,
     CoefType coef_type,
     std::mt19937& rng,
-    SplitCandidate& candidate
+    SplitCandidate& candidate,
+    TreeBuildScratch& scratch
 ) {
-    // Select ndim features for the hyperplane
-    std::vector<size_t> shuffled_numeric = numeric_features;
+    // Select ndim features for the hyperplane (buffer reused, issue #60)
+    auto& shuffled_numeric = scratch.shuffled_numeric;
+    shuffled_numeric.assign(scratch.numeric_features.begin(), scratch.numeric_features.end());
     std::shuffle(shuffled_numeric.begin(), shuffled_numeric.end(), rng);
     shuffled_numeric.resize(effective_ndim);
 
     // Compute min/max for each selected feature
-    std::vector<double> min_vals(effective_ndim);
-    std::vector<double> max_vals(effective_ndim);
+    auto& min_vals = scratch.min_vals;
+    auto& max_vals = scratch.max_vals;
+    min_vals.assign(effective_ndim, 0.0);
+    max_vals.assign(effective_ndim, 0.0);
     bool all_constant = true;
 
     for (size_t i = 0; i < effective_ndim; i++) {
@@ -274,7 +308,8 @@ static bool GenerateHyperplaneSplitCandidate(
     }
 
     // Generate coefficients
-    std::vector<double> coefficients(effective_ndim);
+    auto& coefficients = scratch.coefficients;
+    coefficients.assign(effective_ndim, 0.0);
     std::normal_distribution<double> normal_dist(0.0, 1.0);
 
     for (size_t i = 0; i < effective_ndim; i++) {
@@ -294,7 +329,8 @@ static bool GenerateHyperplaneSplitCandidate(
     // Compute projections
     double min_proj = std::numeric_limits<double>::max();
     double max_proj = std::numeric_limits<double>::lowest();
-    std::vector<double> projections(sample_indices.size());
+    auto& projections = scratch.projections;
+    projections.resize(sample_indices.size());
 
     for (size_t s = 0; s < sample_indices.size(); s++) {
         size_t idx = sample_indices[s];
@@ -328,10 +364,13 @@ static bool GenerateHyperplaneSplitCandidate(
     std::uniform_real_distribution<double> intercept_dist(min_proj, max_proj);
     double intercept = intercept_dist(rng);
 
-    // Partition samples
+    // Partition samples (projection buffers reused, issue #60)
     candidate.left_indices.clear();
     candidate.right_indices.clear();
-    std::vector<double> left_projs, right_projs;
+    auto& left_projs = scratch.left_projs;
+    auto& right_projs = scratch.right_projs;
+    left_projs.clear();
+    right_projs.clear();
 
     for (size_t s = 0; s < sample_indices.size(); s++) {
         if (std::isnan(projections[s]) || projections[s] < intercept) {
@@ -357,11 +396,12 @@ static bool GenerateHyperplaneSplitCandidate(
     for (size_t i = 0; i < effective_ndim; i++) {
         candidate.hyperplane_features[i] = static_cast<uint16_t>(shuffled_numeric[i]);
     }
-    candidate.hyperplane_coefficients = std::move(coefficients);
+    candidate.hyperplane_coefficients = coefficients;
     candidate.hyperplane_intercept = intercept;
 
     // Compute gain based on projection variance reduction
-    std::vector<double> all_projs;
+    auto& all_projs = scratch.all_projs;
+    all_projs.clear();
     for (size_t s = 0; s < projections.size(); s++) {
         if (!std::isnan(projections[s])) {
             all_projs.push_back(projections[s]);
@@ -538,6 +578,33 @@ void IsolationTree::BuildTreeMixed(
         root_idx_ = 0;
     }
 
+    // The numeric-feature partition depends only on column_info, so it is
+    // computed once per tree; the scratch value buffers are reused across all
+    // split candidates of all nodes (issue #60).
+    TreeBuildScratch scratch;
+    for (size_t i = 0; i < data.size(); i++) {
+        if (column_info[i].type == FeatureType::NUMERIC) {
+            scratch.numeric_features.push_back(i);
+        }
+    }
+
+    BuildTreeMixedNode(data, column_info, sample_indices, current_depth, max_depth, rng,
+                       ndim, coef_type, ntry, prob_pick_avg_gain, scratch);
+}
+
+void IsolationTree::BuildTreeMixedNode(
+    const std::vector<ColumnData>& data,
+    const std::vector<ColumnInfo>& column_info,
+    const std::vector<size_t>& sample_indices,
+    size_t current_depth,
+    size_t max_depth,
+    std::mt19937& rng,
+    size_t ndim,
+    CoefType coef_type,
+    size_t ntry,
+    double prob_pick_avg_gain,
+    TreeBuildScratch& scratch
+) {
     size_t n_samples = sample_indices.size();
     size_t n_features = data.size();
 
@@ -551,20 +618,9 @@ void IsolationTree::BuildTreeMixed(
         return;
     }
 
-    // Count numeric and categorical features
-    std::vector<size_t> numeric_features;
-    std::vector<size_t> categorical_features;
-    for (size_t i = 0; i < n_features; i++) {
-        if (column_info[i].type == FeatureType::NUMERIC) {
-            numeric_features.push_back(i);
-        } else {
-            categorical_features.push_back(i);
-        }
-    }
-
     // Extended IF (ndim > 1): use hyperplane splits for numeric features only
-    size_t effective_ndim = std::min(ndim, numeric_features.size());
-    bool use_hyperplane = (effective_ndim > 1 && numeric_features.size() >= 2);
+    size_t effective_ndim = std::min(ndim, scratch.numeric_features.size());
+    bool use_hyperplane = (effective_ndim > 1 && scratch.numeric_features.size() >= 2);
 
     // Generate ntry split candidates
     std::vector<SplitCandidate> candidates;
@@ -577,8 +633,8 @@ void IsolationTree::BuildTreeMixed(
         if (use_hyperplane) {
             // Extended IF: hyperplane split
             success = GenerateHyperplaneSplitCandidate(
-                data, column_info, sample_indices, numeric_features,
-                effective_ndim, coef_type, rng, candidate);
+                data, column_info, sample_indices,
+                effective_ndim, coef_type, rng, candidate, scratch);
         } else {
             // Standard axis-aligned split: randomly select feature
             std::uniform_int_distribution<size_t> feat_dist(0, n_features - 1);
@@ -586,7 +642,7 @@ void IsolationTree::BuildTreeMixed(
 
             if (column_info[split_feature].type == FeatureType::NUMERIC) {
                 success = GenerateNumericSplitCandidate(
-                    data, sample_indices, split_feature, rng, candidate);
+                    data, sample_indices, split_feature, rng, candidate, scratch);
             } else {
                 success = GenerateCategoricalSplitCandidate(
                     data, sample_indices, split_feature, rng, candidate);
@@ -665,12 +721,12 @@ void IsolationTree::BuildTreeMixed(
 
     // Recursively build subtrees
     nodes_[node_idx].left_child = static_cast<int32_t>(nodes_.size());
-    BuildTreeMixed(data, column_info, selected.left_indices, current_depth + 1,
-                   max_depth, rng, ndim, coef_type, ntry, prob_pick_avg_gain);
+    BuildTreeMixedNode(data, column_info, selected.left_indices, current_depth + 1,
+                       max_depth, rng, ndim, coef_type, ntry, prob_pick_avg_gain, scratch);
 
     nodes_[node_idx].right_child = static_cast<int32_t>(nodes_.size());
-    BuildTreeMixed(data, column_info, selected.right_indices, current_depth + 1,
-                   max_depth, rng, ndim, coef_type, ntry, prob_pick_avg_gain);
+    BuildTreeMixedNode(data, column_info, selected.right_indices, current_depth + 1,
+                       max_depth, rng, ndim, coef_type, ntry, prob_pick_avg_gain, scratch);
 }
 
 double IsolationTree::ComputePathLengthMixed(

--- a/src/anofox_ner.cpp
+++ b/src/anofox_ner.cpp
@@ -1,4 +1,5 @@
 #include "anofox_ner.hpp"
+#include "anofox_raii.hpp"
 #include "anofox_trace.hpp"
 #include "yyjson.hpp"
 #include "duckdb.hpp"
@@ -168,16 +169,21 @@ bool WordPieceTokenizer::Load(const std::string &vocab_path) {
     std::string json_str = buffer.str();
     file.close();
 
-    // Parse JSON using yyjson
-    yyjson_doc *doc = yyjson_read(json_str.c_str(), json_str.size(), 0);
+    // Parse JSON using yyjson; the RAII guard frees the document on every
+    // exit path (issue #60).
+    struct YyjsonDocFree {
+        void operator()(yyjson_doc *doc_handle) const {
+            yyjson_doc_free(doc_handle);
+        }
+    };
+    UniqueHandle<yyjson_doc *, YyjsonDocFree, nullptr> doc(yyjson_read(json_str.c_str(), json_str.size(), 0));
     if (!doc) {
         AnofoxTrace(AnofoxLogLevel::Error, "ner: Failed to parse tokenizer JSON");
         return false;
     }
 
-    yyjson_val *root = yyjson_doc_get_root(doc);
+    yyjson_val *root = yyjson_doc_get_root(doc.Get());
     if (!root) {
-        yyjson_doc_free(doc);
         AnofoxTrace(AnofoxLogLevel::Error, "ner: Empty tokenizer JSON");
         return false;
     }
@@ -185,14 +191,12 @@ bool WordPieceTokenizer::Load(const std::string &vocab_path) {
     // Navigate to model.vocab
     yyjson_val *model = yyjson_obj_get(root, "model");
     if (!model) {
-        yyjson_doc_free(doc);
         AnofoxTrace(AnofoxLogLevel::Error, "ner: No 'model' key in tokenizer JSON");
         return false;
     }
 
     yyjson_val *vocab = yyjson_obj_get(model, "vocab");
     if (!vocab) {
-        yyjson_doc_free(doc);
         AnofoxTrace(AnofoxLogLevel::Error, "ner: No 'model.vocab' key in tokenizer JSON");
         return false;
     }
@@ -208,8 +212,6 @@ bool WordPieceTokenizer::Load(const std::string &vocab_path) {
             vocab_[std::string(token_str)] = token_id;
         }
     }
-
-    yyjson_doc_free(doc);
 
     AnofoxTrace(AnofoxLogLevel::Info, "ner: Loaded vocabulary with " + std::to_string(vocab_.size()) + " tokens");
     return !vocab_.empty();

--- a/src/anofox_outlier_tree.cpp
+++ b/src/anofox_outlier_tree.cpp
@@ -103,39 +103,54 @@ void OutlierTree::BuildTreeForColumn(
         return;
     }
 
-    // Find best split among all predictor columns
+    // Cache the parent-cluster statistic once: it depends only on the target
+    // column and the current row subset, so it is identical for every
+    // candidate split evaluated below (issue #60).
+    const bool numeric_target = column_info[target_col].type == FeatureType::NUMERIC;
+    double current_target_metric;
+    if (numeric_target) {
+        current_target_metric = ComputeVariance(data[target_col], row_indices);
+    } else {
+        auto stats = ComputeCategoricalStats(data[target_col], column_info[target_col], row_indices);
+        current_target_metric = ComputeEntropy(stats.category_counts, stats.n_samples);
+    }
+
+    // Find best split among all predictor columns. The partitions of the best
+    // split are kept so the winning split is not partitioned a second time.
     std::optional<SplitCondition> best_split;
     double best_gain = 0.0;
+    std::vector<size_t> left_indices, right_indices;            // per-candidate scratch
+    std::vector<size_t> best_left_indices, best_right_indices;  // partitions of best_split
 
     for (size_t pred_col = 0; pred_col < data.size(); ++pred_col) {
         if (pred_col == target_col) continue;  // Skip target column
 
         std::optional<SplitCondition> split;
         if (column_info[pred_col].type == FeatureType::NUMERIC) {
-            split = FindBestNumericSplit(data, column_info, pred_col, target_col, row_indices);
+            split = FindBestNumericSplit(data, column_info, pred_col, target_col, row_indices,
+                                         current_target_metric);
         } else {
-            split = FindBestCategoricalSplit(data, column_info, pred_col, target_col, row_indices);
+            split = FindBestCategoricalSplit(data, column_info, pred_col, target_col, row_indices,
+                                             current_target_metric);
         }
 
         if (split) {
             // Compute gain for this split
-            std::vector<size_t> left_indices, right_indices;
             PartitionRows(data, *split, row_indices, left_indices, right_indices);
 
             double gain = 0.0;
-            if (column_info[target_col].type == FeatureType::NUMERIC) {
-                double current_var = ComputeVariance(data[target_col], row_indices);
-                gain = ComputeVarianceGain(left_indices, right_indices, data[target_col], current_var);
+            if (numeric_target) {
+                gain = ComputeVarianceGain(left_indices, right_indices, data[target_col], current_target_metric);
             } else {
-                auto stats = ComputeCategoricalStats(data[target_col], column_info[target_col], row_indices);
-                double current_entropy = ComputeEntropy(stats.category_counts, stats.n_samples);
                 gain = ComputeInfoGain(left_indices, right_indices, data[target_col],
-                                       column_info[target_col], current_entropy);
+                                       column_info[target_col], current_target_metric);
             }
 
             if (gain > best_gain) {
                 best_gain = gain;
                 best_split = split;
+                best_left_indices.swap(left_indices);
+                best_right_indices.swap(right_indices);
             }
         }
     }
@@ -144,10 +159,6 @@ void OutlierTree::BuildTreeForColumn(
     if (!best_split) {
         return;
     }
-
-    // Partition and recurse
-    std::vector<size_t> left_indices, right_indices;
-    PartitionRows(data, *best_split, row_indices, left_indices, right_indices);
 
     // Create conditions for left and right branches
     std::vector<SplitCondition> left_conditions = current_conditions;
@@ -165,12 +176,12 @@ void OutlierTree::BuildTreeForColumn(
     right_conditions.push_back(right_condition);
 
     // Recurse on both branches
-    if (left_indices.size() >= min_size) {
-        BuildTreeForColumn(data, column_info, target_col, left_indices,
+    if (best_left_indices.size() >= min_size) {
+        BuildTreeForColumn(data, column_info, target_col, best_left_indices,
                           left_conditions, current_depth + 1, outliers);
     }
-    if (right_indices.size() >= min_size) {
-        BuildTreeForColumn(data, column_info, target_col, right_indices,
+    if (best_right_indices.size() >= min_size) {
+        BuildTreeForColumn(data, column_info, target_col, best_right_indices,
                           right_conditions, current_depth + 1, outliers);
     }
 }
@@ -336,7 +347,8 @@ std::optional<SplitCondition> OutlierTree::FindBestNumericSplit(
     const std::vector<ColumnInfo>& column_info,
     size_t predictor_col,
     size_t target_col,
-    const std::vector<size_t>& row_indices
+    const std::vector<size_t>& row_indices,
+    double current_target_metric
 ) {
     if (row_indices.size() < 2 * params_.min_size_numeric) {
         return std::nullopt;
@@ -375,8 +387,14 @@ std::optional<SplitCondition> OutlierTree::FindBestNumericSplit(
         }
     }
 
+    // Scratch buffers reused across candidate split points (issue #60)
+    std::vector<size_t> left_idx, right_idx;
+    left_idx.reserve(values.size());
+    right_idx.reserve(values.size());
+
     for (double split_val : candidates) {
-        std::vector<size_t> left_idx, right_idx;
+        left_idx.clear();
+        right_idx.clear();
         for (const auto& [val, idx] : values) {
             if (val <= split_val) {
                 left_idx.push_back(idx);
@@ -389,15 +407,14 @@ std::optional<SplitCondition> OutlierTree::FindBestNumericSplit(
             continue;
         }
 
+        // The parent statistic is supplied by the caller; it is constant for
+        // all candidates of this (target, row subset) pair.
         double gain = 0.0;
         if (column_info[target_col].type == FeatureType::NUMERIC) {
-            double current_var = ComputeVariance(data[target_col], row_indices);
-            gain = ComputeVarianceGain(left_idx, right_idx, data[target_col], current_var);
+            gain = ComputeVarianceGain(left_idx, right_idx, data[target_col], current_target_metric);
         } else {
-            auto stats = ComputeCategoricalStats(data[target_col], column_info[target_col], row_indices);
-            double current_entropy = ComputeEntropy(stats.category_counts, stats.n_samples);
             gain = ComputeInfoGain(left_idx, right_idx, data[target_col],
-                                   column_info[target_col], current_entropy);
+                                   column_info[target_col], current_target_metric);
         }
 
         if (gain > best_gain) {
@@ -425,7 +442,8 @@ std::optional<SplitCondition> OutlierTree::FindBestCategoricalSplit(
     const std::vector<ColumnInfo>& column_info,
     size_t predictor_col,
     size_t target_col,
-    const std::vector<size_t>& row_indices
+    const std::vector<size_t>& row_indices,
+    double current_target_metric
 ) {
     if (row_indices.size() < 2 * params_.min_size_categ) {
         return std::nullopt;
@@ -471,16 +489,13 @@ std::optional<SplitCondition> OutlierTree::FindBestCategoricalSplit(
         return std::nullopt;
     }
 
-    // Compute gain
+    // Compute gain against the caller-supplied parent statistic (issue #60)
     double gain = 0.0;
     if (column_info[target_col].type == FeatureType::NUMERIC) {
-        double current_var = ComputeVariance(data[target_col], row_indices);
-        gain = ComputeVarianceGain(left_idx, right_idx, data[target_col], current_var);
+        gain = ComputeVarianceGain(left_idx, right_idx, data[target_col], current_target_metric);
     } else {
-        auto stats = ComputeCategoricalStats(data[target_col], column_info[target_col], row_indices);
-        double current_entropy = ComputeEntropy(stats.category_counts, stats.n_samples);
         gain = ComputeInfoGain(left_idx, right_idx, data[target_col],
-                               column_info[target_col], current_entropy);
+                               column_info[target_col], current_target_metric);
     }
 
     if (gain <= 0) {

--- a/src/anofox_postal.cpp
+++ b/src/anofox_postal.cpp
@@ -15,6 +15,7 @@
 #include "duckdb/main/config.hpp"
 #include "duckdb/parser/parsed_data/create_scalar_function_info.hpp"
 
+#include "anofox_raii.hpp"
 #include "anofox_trace.hpp"
 #include "duckdb/common/string_util.hpp"
 
@@ -187,40 +188,60 @@ std::string PostalManager::GetDataDirectory() const {
 
 std::vector<PostalComponent> PostalManager::ParseAddress(const std::string &input) {
 	libpostal_address_parser_options_t options = libpostal_get_address_parser_default_options();
-	libpostal_address_parser_response_t *parsed = libpostal_parse_address(const_cast<char *>(input.c_str()), options);
+	// RAII (issue #60): the response is destroyed even if building the result
+	// strings throws.
+	struct ParserResponseDestroy {
+		void operator()(libpostal_address_parser_response_t *response) const {
+			libpostal_address_parser_response_destroy(response);
+		}
+	};
+	UniqueHandle<libpostal_address_parser_response_t *, ParserResponseDestroy, nullptr> parsed(
+	    libpostal_parse_address(const_cast<char *>(input.c_str()), options));
 	if (!parsed) {
 		AnofoxTrace(AnofoxLogLevel::Warn, "Postal parse failed");
 		throw IOException("libpostal_parse_address failed");
 	}
 	AnofoxTrace(AnofoxLogLevel::Debug,
-	           "Postal parsed address components=" + std::to_string(parsed->num_components) + " ");
+	           "Postal parsed address components=" + std::to_string(parsed.Get()->num_components) + " ");
 
 	std::vector<PostalComponent> components;
-	components.reserve(parsed->num_components);
-	for (size_t i = 0; i < parsed->num_components; i++) {
-		components.push_back({parsed->labels[i], parsed->components[i]});
+	components.reserve(parsed.Get()->num_components);
+	for (size_t i = 0; i < parsed.Get()->num_components; i++) {
+		components.push_back({parsed.Get()->labels[i], parsed.Get()->components[i]});
 	}
-	libpostal_address_parser_response_destroy(parsed);
 	return components;
 }
 
 std::vector<std::string> PostalManager::ExpandAddress(const std::string &input) {
 	libpostal_normalize_options_t options = libpostal_get_default_options();
-	size_t num_expansions = 0;
-	char **expansions = libpostal_expand_address(const_cast<char *>(input.c_str()), options, &num_expansions);
-	if (!expansions) {
+	// RAII (issue #60): the expansion array destroy call needs the element
+	// count, so a small dedicated guard owns both.
+	struct ExpansionArrayGuard {
+		char **expansions = nullptr;
+		size_t count = 0;
+		~ExpansionArrayGuard() {
+			if (expansions) {
+				libpostal_expansion_array_destroy(expansions, count);
+			}
+		}
+		ExpansionArrayGuard() = default;
+		ExpansionArrayGuard(const ExpansionArrayGuard &) = delete;
+		ExpansionArrayGuard &operator=(const ExpansionArrayGuard &) = delete;
+	};
+	ExpansionArrayGuard guard;
+	guard.expansions = libpostal_expand_address(const_cast<char *>(input.c_str()), options, &guard.count);
+	if (!guard.expansions) {
 		AnofoxTrace(AnofoxLogLevel::Warn, "Postal expand failed");
 		throw IOException("libpostal_expand_address failed");
 	}
 	AnofoxTrace(AnofoxLogLevel::Debug,
-	           "Postal expand generated " + std::to_string(num_expansions) + " variants");
+	           "Postal expand generated " + std::to_string(guard.count) + " variants");
 
 	std::vector<std::string> result;
-	result.reserve(num_expansions);
-	for (size_t i = 0; i < num_expansions; i++) {
-		result.emplace_back(expansions[i]);
+	result.reserve(guard.count);
+	for (size_t i = 0; i < guard.count; i++) {
+		result.emplace_back(guard.expansions[i]);
 	}
-	libpostal_expansion_array_destroy(expansions, num_expansions);
 	return result;
 }
 

--- a/src/include/anofox_dbscan.hpp
+++ b/src/include/anofox_dbscan.hpp
@@ -68,11 +68,14 @@ private:
 	 * Find all neighbors within epsilon radius
 	 * @param data: All data points
 	 * @param point_idx: Index of query point
-	 * @return Indices of neighbor points
+	 * @param neighbors: Output - indices of neighbor points; cleared first.
+	 *        Passed in so callers can reuse one scratch buffer across the
+	 *        many region queries of a fit (issue #60).
 	 */
-	std::vector<size_t> RegionQuery(
+	void RegionQuery(
 		const std::vector<std::vector<double>>& data,
-		size_t point_idx
+		size_t point_idx,
+		std::vector<size_t>& neighbors
 	) const;
 
 	/**

--- a/src/include/anofox_isolation_forest.hpp
+++ b/src/include/anofox_isolation_forest.hpp
@@ -163,6 +163,14 @@ struct SplitCandidate {
 };
 
 /**
+ * Reusable scratch buffers for one mixed-type tree build (issue #60).
+ * Holds the per-tree feature partition and the per-candidate value/projection
+ * buffers so split-candidate generation does not reallocate per candidate.
+ * Defined in the implementation file.
+ */
+struct TreeBuildScratch;
+
+/**
  * Single isolation tree
  * Builds recursively with random splits to isolate anomalies
  */
@@ -280,6 +288,24 @@ public:
     const IsoNode& GetRootNode() const { return nodes_[root_idx_]; }
 
 private:
+    /**
+     * Recursive node builder behind BuildTreeMixed; threads the per-tree
+     * scratch buffers through the recursion (issue #60).
+     */
+    void BuildTreeMixedNode(
+        const std::vector<ColumnData>& data,
+        const std::vector<ColumnInfo>& column_info,
+        const std::vector<size_t>& sample_indices,
+        size_t current_depth,
+        size_t max_depth,
+        std::mt19937& rng,
+        size_t ndim,
+        CoefType coef_type,
+        size_t ntry,
+        double prob_pick_avg_gain,
+        TreeBuildScratch& scratch
+    );
+
     /**
      * Recursive path traversal helper (numeric only)
      */

--- a/src/include/anofox_outlier_tree.hpp
+++ b/src/include/anofox_outlier_tree.hpp
@@ -355,6 +355,9 @@ private:
      * @param predictor_col: Index of predictor column
      * @param target_col: Index of target column
      * @param row_indices: Indices of rows in current subset
+     * @param current_target_metric: Cached parent statistic of the target
+     *        column over row_indices (variance for numeric targets, entropy
+     *        for categorical targets)
      * @return Best split condition, or nullopt if no good split found
      */
     std::optional<SplitCondition> FindBestNumericSplit(
@@ -362,7 +365,8 @@ private:
         const std::vector<ColumnInfo>& column_info,
         size_t predictor_col,
         size_t target_col,
-        const std::vector<size_t>& row_indices
+        const std::vector<size_t>& row_indices,
+        double current_target_metric
     );
 
     /**
@@ -372,6 +376,9 @@ private:
      * @param predictor_col: Index of predictor column
      * @param target_col: Index of target column
      * @param row_indices: Indices of rows in current subset
+     * @param current_target_metric: Cached parent statistic of the target
+     *        column over row_indices (variance for numeric targets, entropy
+     *        for categorical targets)
      * @return Best split condition, or nullopt if no good split found
      */
     std::optional<SplitCondition> FindBestCategoricalSplit(
@@ -379,7 +386,8 @@ private:
         const std::vector<ColumnInfo>& column_info,
         size_t predictor_col,
         size_t target_col,
-        const std::vector<size_t>& row_indices
+        const std::vector<size_t>& row_indices,
+        double current_target_metric
     );
 
     /**

--- a/src/include/anofox_raii.hpp
+++ b/src/include/anofox_raii.hpp
@@ -1,0 +1,81 @@
+#pragma once
+
+//===----------------------------------------------------------------------===//
+// Generic RAII ownership for C-style resources (issue #60).
+//
+// Modules wrapping C libraries (sockets, c-ares channels, CURL*, FILE*)
+// declare a small stateless closer and alias UniqueHandle instead of pairing
+// every acquisition with manual cleanup calls on each exit path.
+//===----------------------------------------------------------------------===//
+
+namespace duckdb {
+namespace anofox {
+
+/**
+ * Move-only RAII owner for a C-style handle.
+ *
+ * @tparam HandleT        Handle type (e.g. int fd, SOCKET, ares_channel_t*).
+ * @tparam Closer         Stateless function object; `Closer{}(handle)` releases
+ *                        the resource. Invoked exactly once per owned handle.
+ * @tparam INVALID_HANDLE Sentinel marking the empty state; never passed to the
+ *                        closer, so double closes are impossible by design.
+ */
+template <typename HandleT, typename Closer, HandleT INVALID_HANDLE>
+class UniqueHandle {
+public:
+	UniqueHandle() noexcept : handle_(INVALID_HANDLE) {
+	}
+	explicit UniqueHandle(HandleT handle) noexcept : handle_(handle) {
+	}
+
+	~UniqueHandle() {
+		Reset();
+	}
+
+	UniqueHandle(const UniqueHandle &) = delete;
+	UniqueHandle &operator=(const UniqueHandle &) = delete;
+
+	UniqueHandle(UniqueHandle &&other) noexcept : handle_(other.Release()) {
+	}
+
+	UniqueHandle &operator=(UniqueHandle &&other) noexcept {
+		if (this != &other) {
+			Reset(other.Release());
+		}
+		return *this;
+	}
+
+	//! Current handle value; ownership stays with the guard.
+	HandleT Get() const noexcept {
+		return handle_;
+	}
+
+	bool IsValid() const noexcept {
+		return handle_ != INVALID_HANDLE;
+	}
+
+	explicit operator bool() const noexcept {
+		return IsValid();
+	}
+
+	//! Gives up ownership without closing and returns the handle.
+	HandleT Release() noexcept {
+		HandleT handle = handle_;
+		handle_ = INVALID_HANDLE;
+		return handle;
+	}
+
+	//! Closes the currently owned handle (if any) and adopts `handle`.
+	void Reset(HandleT handle = INVALID_HANDLE) noexcept {
+		if (handle_ != INVALID_HANDLE) {
+			Closer {}(handle_);
+		}
+		handle_ = handle;
+	}
+
+private:
+	HandleT handle_;
+};
+
+} // namespace anofox
+} // namespace duckdb

--- a/test/cpp/test_anofox_isolation_forest.cpp
+++ b/test/cpp/test_anofox_isolation_forest.cpp
@@ -153,3 +153,85 @@ TEST_CASE("test/cpp/anofox_isolation_forest_mixed_shape_validation", "[anofox]")
 		REQUIRE_THROWS_AS(forest.Score({1.0, 2.0}), std::invalid_argument);
 	}
 }
+
+namespace {
+
+//! Mixed fixture with two numeric columns (enables hyperplane splits) and one
+//! categorical column, plus one obvious outlier row (issue #60).
+void MakeWideMixedData(std::vector<ColumnData> &data, std::vector<ColumnInfo> &info) {
+	ColumnInfo x_info(FeatureType::NUMERIC, "x");
+	ColumnInfo y_info(FeatureType::NUMERIC, "y");
+	ColumnInfo c_info(FeatureType::CATEGORICAL, "c");
+	ColumnData x_col(FeatureType::NUMERIC);
+	ColumnData y_col(FeatureType::NUMERIC);
+	ColumnData c_col(FeatureType::CATEGORICAL);
+
+	for (int i = 0; i < 80; i++) {
+		x_col.numeric_values.push_back(0.5 * i + (i % 7));
+		y_col.numeric_values.push_back(100.0 - 0.25 * i + (i % 3));
+		c_col.category_indices.push_back(c_info.AddCategory(i % 5 == 0 ? "a" : (i % 3 == 0 ? "b" : "c")));
+	}
+	x_col.numeric_values.push_back(5000.0);
+	y_col.numeric_values.push_back(-4000.0);
+	c_col.category_indices.push_back(c_info.AddCategory("rare"));
+
+	data = {x_col, y_col, c_col};
+	info = {x_info, y_info, c_info};
+}
+
+} // namespace
+
+TEST_CASE("test/cpp/anofox_isolation_forest_sciforest_path", "[anofox]") {
+	// SCiForest configuration: several split candidates per node with
+	// gain-guided selection (exercises the candidate generators).
+	std::vector<ColumnData> data;
+	std::vector<ColumnInfo> info;
+	MakeWideMixedData(data, info);
+
+	IsolationForest forest(50, 40, 0.1, 99, 1, CoefType::Uniform, ScoringMetric::Depth, 4, 0.5);
+	forest.FitMixed(data, info);
+	auto scores = forest.ScoreBatchMixed(data);
+	REQUIRE(scores.size() == data[0].size());
+
+	// The planted outlier (last row) gets the highest anomaly score
+	size_t outlier_row = scores.size() - 1;
+	for (size_t i = 0; i < outlier_row; i++) {
+		CHECK(scores[i] < scores[outlier_row]);
+	}
+
+	// Same seed and parameters reproduce identical scores
+	IsolationForest twin(50, 40, 0.1, 99, 1, CoefType::Uniform, ScoringMetric::Depth, 4, 0.5);
+	twin.FitMixed(data, info);
+	auto twin_scores = twin.ScoreBatchMixed(data);
+	REQUIRE(twin_scores.size() == scores.size());
+	for (size_t i = 0; i < scores.size(); i++) {
+		REQUIRE(scores[i] == twin_scores[i]);
+	}
+}
+
+TEST_CASE("test/cpp/anofox_isolation_forest_hyperplane_path", "[anofox]") {
+	// Extended isolation forest: ndim=2 hyperplane splits over the numeric
+	// columns with normal coefficients (exercises the projection scratch).
+	std::vector<ColumnData> data;
+	std::vector<ColumnInfo> info;
+	MakeWideMixedData(data, info);
+
+	IsolationForest forest(50, 40, 0.1, 7, 2, CoefType::Normal, ScoringMetric::Depth, 3, 0.7);
+	forest.FitMixed(data, info);
+	auto scores = forest.ScoreBatchMixed(data);
+	REQUIRE(scores.size() == data[0].size());
+
+	size_t outlier_row = scores.size() - 1;
+	for (size_t i = 0; i < outlier_row; i++) {
+		CHECK(scores[i] < scores[outlier_row]);
+	}
+
+	// Same seed and parameters reproduce identical scores
+	IsolationForest twin(50, 40, 0.1, 7, 2, CoefType::Normal, ScoringMetric::Depth, 3, 0.7);
+	twin.FitMixed(data, info);
+	auto twin_scores = twin.ScoreBatchMixed(data);
+	REQUIRE(twin_scores.size() == scores.size());
+	for (size_t i = 0; i < scores.size(); i++) {
+		REQUIRE(scores[i] == twin_scores[i]);
+	}
+}

--- a/test/cpp/test_anofox_outlier_tree.cpp
+++ b/test/cpp/test_anofox_outlier_tree.cpp
@@ -1,0 +1,158 @@
+//===----------------------------------------------------------------------===//
+// Catch2 pin tests for the OutlierTree implementation (issue #60).
+//
+// OutlierTree is fully deterministic (no RNG), so these tests pin the exact
+// findings on a fixed mixed-type fixture. They guard the hot-path refactor
+// (cached parent statistics, partition reuse): outputs must stay identical.
+//===----------------------------------------------------------------------===//
+
+#include "catch.hpp"
+
+#include "anofox_outlier_tree.hpp"
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+using namespace duckdb::anofox;
+
+namespace {
+
+//! 40-row fixture with a categorical group column, a numeric value column
+//! whose distribution depends on the group (one extreme value per group), and
+//! a categorical flag column with a rare category.
+void MakeOutlierTreeFixture(std::vector<ColumnData> &data, std::vector<ColumnInfo> &info) {
+	ColumnInfo grp_info(FeatureType::CATEGORICAL, "grp");
+	ColumnInfo val_info(FeatureType::NUMERIC, "val");
+	ColumnInfo flag_info(FeatureType::CATEGORICAL, "flag");
+
+	ColumnData grp_col(FeatureType::CATEGORICAL);
+	ColumnData val_col(FeatureType::NUMERIC);
+	ColumnData flag_col(FeatureType::CATEGORICAL);
+
+	for (int i = 0; i < 40; i++) {
+		bool group_a = i < 20;
+		grp_col.category_indices.push_back(grp_info.AddCategory(group_a ? "A" : "B"));
+
+		double value = group_a ? 10.0 + 0.1 * i : 100.0 + 0.1 * (i - 20);
+		if (i == 5) {
+			value = 200.0; // extreme within group A
+		}
+		if (i == 25) {
+			value = -50.0; // extreme within group B
+		}
+		val_col.numeric_values.push_back(value);
+
+		bool rare = (i == 7 || i == 30);
+		flag_col.category_indices.push_back(flag_info.AddCategory(rare ? "y" : "x"));
+	}
+
+	data = {grp_col, val_col, flag_col};
+	info = {grp_info, val_info, flag_info};
+}
+
+OutlierTreeParams MakeFixtureParams() {
+	// max_depth=2, max 10% outliers per cluster, small min cluster sizes,
+	// z_norm=2.67, z_outlier=4.0
+	return OutlierTreeParams(2, 0.1, 5, 5, 2.67, 4.0);
+}
+
+std::vector<OutlierExplanation> RunFixture(OutlierTree &tree) {
+	std::vector<ColumnData> data;
+	std::vector<ColumnInfo> info;
+	MakeOutlierTreeFixture(data, info);
+	auto outliers = tree.FitPredict(data, info);
+	std::sort(outliers.begin(), outliers.end(), [](const OutlierExplanation &a, const OutlierExplanation &b) {
+		return std::tie(a.row_idx, a.target_column_idx) < std::tie(b.row_idx, b.target_column_idx);
+	});
+	return outliers;
+}
+
+} // namespace
+
+TEST_CASE("test/cpp/anofox_outlier_tree_fixture_pin", "[anofox]") {
+	OutlierTree tree(MakeFixtureParams());
+	auto outliers = RunFixture(tree);
+
+	// Six findings: the two extreme numeric values (per-group), their group
+	// labels (rare within the value-conditioned clusters), and the two rows
+	// carrying the rare flag category.
+	REQUIRE(outliers.size() == 6);
+
+	// row 5: group label rare within the value-split cluster
+	CHECK(outliers[0].row_idx == 5);
+	CHECK(outliers[0].target_column_name == "grp");
+	CHECK(outliers[0].z_score == Approx(4.4721359549995796).epsilon(1e-12));
+	CHECK(outliers[0].outlier_score == Approx(0.05).epsilon(1e-12));
+	CHECK(outliers[0].cluster_size == 20);
+	REQUIRE(outliers[0].conditions.size() == 1);
+	CHECK(outliers[0].conditions[0].column_name == "val");
+
+	// row 5: extreme numeric value within group A
+	CHECK(outliers[1].row_idx == 5);
+	CHECK(outliers[1].target_column_name == "val");
+	CHECK(std::get<double>(outliers[1].outlier_value) == 200.0);
+	CHECK(outliers[1].z_score == Approx(254.82260893025767).epsilon(1e-12));
+	CHECK(outliers[1].outlier_score == Approx(1.5400119271780761e-05).epsilon(1e-12));
+	CHECK(outliers[1].cluster_size == 20);
+	REQUIRE(outliers[1].conditions.size() == 1);
+	CHECK(outliers[1].conditions[0].column_name == "grp");
+
+	// row 7: rare flag category in the full table
+	CHECK(outliers[2].row_idx == 7);
+	CHECK(outliers[2].target_column_name == "flag");
+	CHECK(outliers[2].GetOutlierValueString() == "y");
+	CHECK(outliers[2].z_score == Approx(4.4721359549995796).epsilon(1e-12));
+	CHECK(outliers[2].outlier_score == Approx(0.05).epsilon(1e-12));
+	CHECK(outliers[2].cluster_size == 40);
+	CHECK(outliers[2].conditions.empty());
+
+	// row 25: group label rare within the value-split cluster
+	CHECK(outliers[3].row_idx == 25);
+	CHECK(outliers[3].target_column_name == "grp");
+	CHECK(outliers[3].z_score == Approx(4.4721359549995796).epsilon(1e-12));
+	CHECK(outliers[3].outlier_score == Approx(0.05).epsilon(1e-12));
+	CHECK(outliers[3].cluster_size == 20);
+	REQUIRE(outliers[3].conditions.size() == 1);
+	CHECK(outliers[3].conditions[0].column_name == "val");
+
+	// row 25: extreme numeric value within group B
+	CHECK(outliers[4].row_idx == 25);
+	CHECK(outliers[4].target_column_name == "val");
+	CHECK(std::get<double>(outliers[4].outlier_value) == -50.0);
+	CHECK(outliers[4].z_score == Approx(-169.74684113494476).epsilon(1e-12));
+	CHECK(outliers[4].outlier_score == Approx(3.4705363519143227e-05).epsilon(1e-12));
+	CHECK(outliers[4].cluster_size == 20);
+	REQUIRE(outliers[4].conditions.size() == 1);
+	CHECK(outliers[4].conditions[0].column_name == "grp");
+
+	// row 30: rare flag category in the full table
+	CHECK(outliers[5].row_idx == 30);
+	CHECK(outliers[5].target_column_name == "flag");
+	CHECK(outliers[5].GetOutlierValueString() == "y");
+	CHECK(outliers[5].z_score == Approx(4.4721359549995796).epsilon(1e-12));
+	CHECK(outliers[5].outlier_score == Approx(0.05).epsilon(1e-12));
+	CHECK(outliers[5].cluster_size == 40);
+	CHECK(outliers[5].conditions.empty());
+
+	// Tree exploration shape
+	CHECK(tree.GetClustersEvaluated() == 15);
+	CHECK(tree.GetMaxDepthReached() == 2);
+}
+
+TEST_CASE("test/cpp/anofox_outlier_tree_repeated_fit_is_stable", "[anofox]") {
+	// Two FitPredict runs on the same instance must produce identical findings
+	// (no stale per-fit state).
+	OutlierTree tree(MakeFixtureParams());
+	auto first = RunFixture(tree);
+	auto second = RunFixture(tree);
+
+	REQUIRE(first.size() == second.size());
+	for (size_t i = 0; i < first.size(); i++) {
+		CHECK(first[i].row_idx == second[i].row_idx);
+		CHECK(first[i].target_column_idx == second[i].target_column_idx);
+		CHECK(first[i].z_score == second[i].z_score);
+		CHECK(first[i].outlier_score == second[i].outlier_score);
+		CHECK(first[i].explanation == second[i].explanation);
+	}
+}

--- a/test/cpp/test_anofox_raii.cpp
+++ b/test/cpp/test_anofox_raii.cpp
@@ -1,0 +1,162 @@
+//===----------------------------------------------------------------------===//
+// Catch2 unit tests for the UniqueHandle RAII wrapper (issue #60).
+//
+//  - Owned handles are closed exactly once (double-close safety).
+//  - Move construction/assignment transfers ownership without double closes.
+//  - Handles are closed during stack unwinding (cleanup on exception).
+//
+// Built as part of the standalone test binary (anofox_tabular_cpp_tests).
+// Run: ./build/release/extension/anofox_tabular/anofox_tabular_cpp_tests
+//===----------------------------------------------------------------------===//
+
+#include "catch.hpp"
+
+#include "anofox_raii.hpp"
+
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+using duckdb::anofox::UniqueHandle;
+
+namespace {
+
+constexpr int INVALID_FD = -1;
+
+//! Stateless closer that records every close in a static log so the tests can
+//! assert exactly which handles were closed, and how often.
+struct RecordingCloser {
+	static std::vector<int> closed;
+
+	void operator()(int handle) const {
+		closed.push_back(handle);
+	}
+
+	static void Clear() {
+		closed.clear();
+	}
+
+	static size_t CountFor(int handle) {
+		size_t count = 0;
+		for (int value : closed) {
+			if (value == handle) {
+				count++;
+			}
+		}
+		return count;
+	}
+};
+
+std::vector<int> RecordingCloser::closed;
+
+using TestHandle = UniqueHandle<int, RecordingCloser, INVALID_FD>;
+
+} // namespace
+
+TEST_CASE("UniqueHandle default state is invalid and never closes", "[raii]") {
+	RecordingCloser::Clear();
+	{
+		TestHandle guard;
+		REQUIRE(!guard.IsValid());
+		REQUIRE(!guard);
+		REQUIRE(guard.Get() == INVALID_FD);
+	}
+	REQUIRE(RecordingCloser::closed.empty());
+}
+
+TEST_CASE("UniqueHandle closes the owned handle exactly once on scope exit", "[raii]") {
+	RecordingCloser::Clear();
+	{
+		TestHandle guard(7);
+		REQUIRE(guard.IsValid());
+		REQUIRE(guard.Get() == 7);
+	}
+	REQUIRE(RecordingCloser::closed == std::vector<int> {7});
+}
+
+TEST_CASE("UniqueHandle Reset is double-close safe", "[raii]") {
+	RecordingCloser::Clear();
+	TestHandle guard(11);
+
+	guard.Reset();
+	REQUIRE(!guard.IsValid());
+	REQUIRE(RecordingCloser::CountFor(11) == 1);
+
+	// Second Reset and destruction must not close again
+	guard.Reset();
+	REQUIRE(RecordingCloser::CountFor(11) == 1);
+}
+
+TEST_CASE("UniqueHandle Reset with a new handle closes the old one", "[raii]") {
+	RecordingCloser::Clear();
+	{
+		TestHandle guard(3);
+		guard.Reset(4);
+		REQUIRE(guard.Get() == 4);
+		REQUIRE(RecordingCloser::closed == std::vector<int> {3});
+	}
+	REQUIRE(RecordingCloser::closed == (std::vector<int> {3, 4}));
+}
+
+TEST_CASE("UniqueHandle Release transfers ownership to the caller", "[raii]") {
+	RecordingCloser::Clear();
+	int released = INVALID_FD;
+	{
+		TestHandle guard(21);
+		released = guard.Release();
+		REQUIRE(!guard.IsValid());
+	}
+	REQUIRE(released == 21);
+	REQUIRE(RecordingCloser::closed.empty());
+}
+
+TEST_CASE("UniqueHandle move construction transfers ownership", "[raii]") {
+	RecordingCloser::Clear();
+	{
+		TestHandle source(5);
+		TestHandle target(std::move(source));
+		REQUIRE(!source.IsValid());
+		REQUIRE(target.Get() == 5);
+		REQUIRE(RecordingCloser::closed.empty());
+	}
+	// Only the surviving owner closes; exactly once
+	REQUIRE(RecordingCloser::closed == std::vector<int> {5});
+}
+
+TEST_CASE("UniqueHandle move assignment closes the replaced handle", "[raii]") {
+	RecordingCloser::Clear();
+	{
+		TestHandle source(8);
+		TestHandle target(9);
+		target = std::move(source);
+		REQUIRE(!source.IsValid());
+		REQUIRE(target.Get() == 8);
+		// The previously owned handle was closed by the assignment
+		REQUIRE(RecordingCloser::closed == std::vector<int> {9});
+	}
+	REQUIRE(RecordingCloser::closed == (std::vector<int> {9, 8}));
+}
+
+TEST_CASE("UniqueHandle self move assignment keeps the handle open", "[raii]") {
+	RecordingCloser::Clear();
+	{
+		TestHandle guard(13);
+		TestHandle &alias = guard;
+		guard = std::move(alias);
+		REQUIRE(guard.IsValid());
+		REQUIRE(guard.Get() == 13);
+		REQUIRE(RecordingCloser::closed.empty());
+	}
+	REQUIRE(RecordingCloser::closed == std::vector<int> {13});
+}
+
+TEST_CASE("UniqueHandle closes the handle during stack unwinding", "[raii]") {
+	RecordingCloser::Clear();
+	REQUIRE_THROWS_AS(
+	    [] {
+		    TestHandle guard(17);
+		    throw std::runtime_error("boom");
+	    }(),
+	    std::runtime_error);
+	REQUIRE(RecordingCloser::closed == std::vector<int> {17});
+}


### PR DESCRIPTION
Implements #60 (Phase 4 of the 2026-06 code review program). Builds on `integration/code-quality-2026-06`, the merge of PRs #62–#78.

## Audit results (re-verified against the integration base)

**Already clean (done by earlier issues, no changes needed):**
- Postal download path: `FILE*`/`CURL*` already RAII via module-local deleters (#48), `curl_global_init` already process-lifetime.
- NER model downloads: `FileHandle`/`CurlHandle` deleters already in place (#56).
- cctype: repo-wide grep for `isdigit/isalpha/isalnum/isspace/ispunct/isupper/islower/isxdigit/isprint/iscntrl/tolower/toupper` on plain `char` in `src/` and `test/cpp/` found **no remaining unguarded call sites** — #49/#53 swept pii/vat; `anofox_vat_country.cpp` iterates `unsigned char`, `anofox_email_smtp.cpp` already casts. No cctype commit needed.

**Survivors fixed here:**
- `anofox_email_smtp.cpp`: ~15 manual `CloseSocketHandle` calls across the SMTP attempt loop; manual `ares_destroy` in the endpoint resolver.
- `anofox_email_dns.cpp`: manual `ares_destroy` in `DnsResolver::Resolve`.
- `anofox_ner.cpp`: 4 manual `yyjson_doc_free` calls on tokenizer-load early returns.
- `anofox_postal.cpp`: libpostal parse/expand responses destroyed only on the success path (leak if result-string allocation throws).
- Hot paths: outlier tree recomputed parent variance/entropy per candidate and re-partitioned the winning split; isolation forest rebuilt value/projection vectors per split candidate and the feature partition per node; DBSCAN allocated a fresh neighbor vector per region query.

## Changes

**RAII (`src/include/anofox_raii.hpp`)**
- New generic `UniqueHandle<HandleT, Closer, INVALID_HANDLE>` move-only owner; 9 Catch2 unit tests (double-close safety, move semantics, Release, cleanup-on-exception) in the standalone harness.
- Email: `SocketGuard` + `AresChannelGuard` replace all manual closes/destroys. Resolver callback state is declared before the channel guard so teardown can never touch destroyed state.
- NER tokenizer load and libpostal parse/expand now use scoped guards (dedicated small guard for the counted expansion array).

**Algorithm hot paths (bit-identical outputs)**
- `anofox_outlier_tree.cpp`: parent target statistic computed once per node and threaded into `FindBestNumericSplit`/`FindBestCategoricalSplit`; best-split partitions kept via swap (no second `PartitionRows`); candidate partition buffers reused. Pinned by new deterministic fixture tests (exact rows, z-scores, scores, condition columns).
- `anofox_isolation_forest.cpp`: per-tree `TreeBuildScratch` (feature partition computed once per tree; value/projection buffers reused across all candidates) behind a private recursive node builder; public `BuildTreeMixed` signature unchanged. RNG consumption order untouched; verified bit-identical on legacy/SCiForest/hyperplane/weighted fixtures (`diff` of full 17-significant-digit score dumps before/after). The categorical candidate generator was deliberately left as-is: reusing its `unordered_set` could change iteration order and thus RNG-dependent results.
- `anofox_dbscan.cpp`: `RegionQuery` fills a caller-provided buffer; `Fit` and `ExpandCluster` reuse one scratch vector each. Verified bit-identical on all three distance metrics.

**Tests added**
- `test/cpp/test_anofox_raii.cpp` (standalone binary, 9 cases).
- `test/cpp/test_anofox_outlier_tree.cpp` (unittest harness): exact-findings pin on a 40-row mixed fixture + refit stability.
- SCiForest (`ntry>1`, gain-guided) and hyperplane (`ndim=2`) coverage in `test_anofox_isolation_forest.cpp` (previously untested paths).

## Test status
- `make test`: 40 cases, 2874 assertions, green (3 skipped: OPENVINO env).
- unittest `test/cpp/*`: 13 cases, 647 assertions, green.
- standalone `anofox_tabular_cpp_tests`: 23 cases, 1115 assertions, green.
- python: 253 passed.

Closes #60