### PR TITLE
perf: scalar function vectorization sweep

### DIFF
--- a/src/anofox_email.cpp
+++ b/src/anofox_email.cpp
@@ -15,6 +15,7 @@
 
 #include <algorithm>
 #include <string>
+#include <string_view>
 #include <limits>
 #include <mutex>
 #include <regex>
@@ -61,9 +62,9 @@ std::string NormalizeValidationMode(const std::string &value) {
 	return normalized;
 }
 
-std::string ExtractDomain(const std::string &email) {
+std::string_view ExtractDomain(std::string_view email) {
 	auto at_pos = email.rfind('@');
-	if (at_pos == std::string::npos) {
+	if (at_pos == std::string_view::npos) {
 		return {};
 	}
 	auto domain_offset = at_pos + 1;
@@ -235,10 +236,10 @@ private:
 	email::SmtpOptions smtp_options;
 };
 
-EmailValidationResult ValidateRegex(const std::string &email, const std::regex &regex) {
+EmailValidationResult ValidateRegex(std::string_view email, const std::regex &regex) {
 	EmailValidationResult result;
 	result.stage = EMAIL_STAGE_REGEX;
-	if (std::regex_match(email, regex)) {
+	if (std::regex_match(email.begin(), email.end(), regex)) {
 		result.valid = true;
 	} else {
 		result.valid = false;
@@ -247,20 +248,24 @@ EmailValidationResult ValidateRegex(const std::string &email, const std::regex &
 	return result;
 }
 
-EmailValidationResult ValidateEmailAddress(const std::string &email, const std::string &mode_input) {
-    EmailTrace(AnofoxLogLevel::Info,
-               "ValidateEmailAddress start email=" + email + " mode=" + mode_input);
-	auto normalized_mode = NormalizeValidationMode(mode_input);
-	auto regex_ptr = EmailConfig::Get().GetCompiledRegex();
-	if (!regex_ptr) {
-		throw InternalException("Email regex pattern is not initialized");
+//! Validates one email address. `normalized_mode` must already be normalized via
+//! NormalizeValidationMode and `regex` is the compiled pattern; both are hoisted
+//! out of the per-chunk row loops so the hot regex path does no per-row setup.
+EmailValidationResult ValidateEmailAddress(std::string_view email, const std::string &normalized_mode,
+                                           const std::regex &regex) {
+	// Trace message construction is guarded so disabled tracing costs nothing per row.
+	if (AnofoxTraceConfig::Get().ShouldLog(AnofoxLogLevel::Info)) {
+		EmailTrace(AnofoxLogLevel::Info,
+		           "ValidateEmailAddress start email=" + std::string(email) + " mode=" + normalized_mode);
 	}
-	auto regex_result = ValidateRegex(email, *regex_ptr);
+	auto regex_result = ValidateRegex(email, regex);
 	if (!regex_result.valid || normalized_mode == EMAIL_STAGE_REGEX) {
-        EmailTrace(AnofoxLogLevel::Info,
-                   std::string("Regex stage result valid=") + (regex_result.valid ? "true" : "false") +
-                       " reason=" +
-                       (regex_result.reason.empty() ? std::string("<none>") : regex_result.reason));
+		if (AnofoxTraceConfig::Get().ShouldLog(AnofoxLogLevel::Info)) {
+			EmailTrace(AnofoxLogLevel::Info,
+			           std::string("Regex stage result valid=") + (regex_result.valid ? "true" : "false") +
+			               " reason=" +
+			               (regex_result.reason.empty() ? std::string("<none>") : regex_result.reason));
+		}
 		return regex_result;
 	}
 
@@ -271,7 +276,7 @@ EmailValidationResult ValidateEmailAddress(const std::string &email, const std::
 		return result;
 	}
 
-	auto domain = ExtractDomain(email);
+	auto domain = std::string(ExtractDomain(email));
 	if (domain.empty()) {
 	EmailTrace(AnofoxLogLevel::Warn, "No domain extracted from email");
 		EmailValidationResult result;
@@ -318,7 +323,7 @@ EmailValidationResult ValidateEmailAddress(const std::string &email, const std::
 	EmailTrace(AnofoxLogLevel::Info,
 	           "Starting SMTP verification with " + std::to_string(smtp_hosts.size()) + " host candidates");
 	email::SmtpClient smtp_client(smtp_options);
-	auto smtp_result = smtp_client.Verify(email, smtp_hosts);
+	auto smtp_result = smtp_client.Verify(std::string(email), smtp_hosts);
 
 	EmailValidationResult smtp_stage;
 	smtp_stage.stage = EMAIL_STAGE_SMTP;
@@ -341,27 +346,47 @@ EmailValidationResult ValidateEmailAddress(const std::string &email, const std::
 	return smtp_stage;
 }
 
-std::string ExtractValidationMode(optional_ptr<Vector> vector_ptr, idx_t index, idx_t count) {
-	if (!vector_ptr) {
-		return EmailConfig::Get().GetDefaultValidation();
-	}
-	auto &vector = *vector_ptr;
-	if (vector.GetVectorType() == VectorType::CONSTANT_VECTOR) {
-		if (ConstantVector::IsNull(vector)) {
-			return EmailConfig::Get().GetDefaultValidation();
+//! Per-chunk view of the optional validation-mode argument. The mode is usually
+//! a constant vector (literal or absent), in which case it is normalized exactly
+//! once; only genuinely varying mode columns pay per-row normalization.
+struct ValidationModeArgument {
+	bool per_row = false;
+	std::string constant_mode;
+	std::string default_mode;
+	UnifiedVectorFormat data;
+
+	static ValidationModeArgument Prepare(DataChunk &args, idx_t mode_column) {
+		ValidationModeArgument arg;
+		arg.default_mode = EmailConfig::Get().GetDefaultValidation();
+		if (args.ColumnCount() <= mode_column) {
+			arg.constant_mode = arg.default_mode;
+			return arg;
 		}
-		auto value = ConstantVector::GetData<string_t>(vector)[0].GetString();
-		return NormalizeValidationMode(value);
+		auto &vector = args.data[mode_column];
+		if (vector.GetVectorType() == VectorType::CONSTANT_VECTOR) {
+			if (ConstantVector::IsNull(vector)) {
+				arg.constant_mode = arg.default_mode;
+			} else {
+				arg.constant_mode = NormalizeValidationMode(ConstantVector::GetData<string_t>(vector)[0].GetString());
+			}
+			return arg;
+		}
+		arg.per_row = true;
+		vector.ToUnifiedFormat(args.size(), arg.data);
+		return arg;
 	}
-	auto unified = UnifiedVectorFormat();
-	vector.ToUnifiedFormat(count, unified);
-	auto idx = unified.sel->get_index(index);
-	if (!unified.validity.RowIsValid(idx)) {
-		return EmailConfig::Get().GetDefaultValidation();
+
+	std::string Get(idx_t row) const {
+		if (!per_row) {
+			return constant_mode;
+		}
+		auto idx = data.sel->get_index(row);
+		if (!data.validity.RowIsValid(idx)) {
+			return default_mode;
+		}
+		return NormalizeValidationMode(UnifiedVectorFormat::GetData<string_t>(data)[idx].GetString());
 	}
-	auto value = reinterpret_cast<string_t *>(unified.data)[idx].GetString();
-	return NormalizeValidationMode(value);
-}
+};
 
 LogicalType GetEmailValidateReturnType() {
 	child_list_t<LogicalType> smtp_children;
@@ -377,6 +402,18 @@ LogicalType GetEmailValidateReturnType() {
 	return LogicalType::STRUCT(result_children);
 }
 
+//! Appends strings to a list vector without per-element Value construction.
+void AppendToListVector(Vector &list_vec, const std::vector<std::string> &values) {
+	auto offset = ListVector::GetListSize(list_vec);
+	ListVector::Reserve(list_vec, offset + values.size());
+	auto &child = ListVector::GetEntry(list_vec);
+	auto child_data = FlatVector::GetData<string_t>(child);
+	for (idx_t i = 0; i < values.size(); i++) {
+		child_data[offset + i] = StringVector::AddString(child, values[i]);
+	}
+	ListVector::SetListSize(list_vec, offset + values.size());
+}
+
 void EmailValidateFunction(DataChunk &args, ExpressionState &, Vector &result) {
 	result.SetVectorType(VectorType::FLAT_VECTOR);
 	auto &children = StructVector::GetEntries(result);
@@ -389,54 +426,56 @@ void EmailValidateFunction(DataChunk &args, ExpressionState &, Vector &result) {
 	auto &smtp_transcript_vec = *smtp_children[0];
 
 	auto valid_data = FlatVector::GetData<bool>(valid_vec);
+	auto stage_data = FlatVector::GetData<string_t>(stage_vec);
+	auto reason_data = FlatVector::GetData<string_t>(reason_vec);
 	auto mx_entries = FlatVector::GetData<list_entry_t>(mx_vec);
 	auto transcript_entries = FlatVector::GetData<list_entry_t>(smtp_transcript_vec);
 
 	ListVector::SetListSize(mx_vec, 0);
 	ListVector::SetListSize(smtp_transcript_vec, 0);
 
+	// Normalize the inputs and hoist all configuration exactly once per chunk.
+	UnifiedVectorFormat email_data;
+	args.data[0].ToUnifiedFormat(args.size(), email_data);
+	auto email_values = UnifiedVectorFormat::GetData<string_t>(email_data);
+	auto mode_arg = ValidationModeArgument::Prepare(args, 1);
+	auto regex_ptr = EmailConfig::Get().GetCompiledRegex();
+	if (!regex_ptr) {
+		throw InternalException("Email regex pattern is not initialized");
+	}
+
 	for (idx_t row = 0; row < args.size(); row++) {
-		auto email_value = args.GetValue(0, row);
-		if (email_value.IsNull()) {
+		auto email_idx = email_data.sel->get_index(row);
+		if (!email_data.validity.RowIsValid(email_idx)) {
 			FlatVector::SetNull(result, row, true);
 			continue;
 		}
 		FlatVector::SetNull(result, row, false);
 
-		optional_ptr<Vector> mode_vector;
-		if (args.ColumnCount() > 1) {
-			mode_vector = &args.data[1];
-		}
-		std::string mode = ExtractValidationMode(mode_vector, row, args.size());
-
-		auto validation = ValidateEmailAddress(email_value.ToString(), mode);
+		auto &email = email_values[email_idx];
+		auto validation =
+		    ValidateEmailAddress(std::string_view(email.GetData(), email.GetSize()), mode_arg.Get(row), *regex_ptr);
 
 		FlatVector::SetNull(valid_vec, row, false);
 		valid_data[row] = validation.valid;
 
 		FlatVector::SetNull(stage_vec, row, false);
-		FlatVector::GetData<string_t>(stage_vec)[row] =
-		    StringVector::AddString(stage_vec, validation.stage);
+		stage_data[row] = StringVector::AddString(stage_vec, validation.stage);
 
 		if (validation.reason.empty()) {
 			FlatVector::SetNull(reason_vec, row, true);
 		} else {
 			FlatVector::SetNull(reason_vec, row, false);
-			FlatVector::GetData<string_t>(reason_vec)[row] =
-			    StringVector::AddString(reason_vec, validation.reason);
+			reason_data[row] = StringVector::AddString(reason_vec, validation.reason);
 		}
 
 		mx_entries[row].offset = ListVector::GetListSize(mx_vec);
 		mx_entries[row].length = validation.mx_hosts.size();
-		for (auto &host : validation.mx_hosts) {
-			ListVector::PushBack(mx_vec, Value(host));
-		}
+		AppendToListVector(mx_vec, validation.mx_hosts);
 
 		transcript_entries[row].offset = ListVector::GetListSize(smtp_transcript_vec);
 		transcript_entries[row].length = validation.smtp_transcript.size();
-		for (auto &entry : validation.smtp_transcript) {
-			ListVector::PushBack(smtp_transcript_vec, Value(entry));
-		}
+		AppendToListVector(smtp_transcript_vec, validation.smtp_transcript);
 	}
 }
 
@@ -444,21 +483,27 @@ void EmailIsValidFunction(DataChunk &args, ExpressionState &, Vector &result) {
 	result.SetVectorType(VectorType::FLAT_VECTOR);
 	auto bool_data = FlatVector::GetData<bool>(result);
 
+	// Normalize the inputs and hoist all configuration exactly once per chunk.
+	UnifiedVectorFormat email_data;
+	args.data[0].ToUnifiedFormat(args.size(), email_data);
+	auto email_values = UnifiedVectorFormat::GetData<string_t>(email_data);
+	auto mode_arg = ValidationModeArgument::Prepare(args, 1);
+	auto regex_ptr = EmailConfig::Get().GetCompiledRegex();
+	if (!regex_ptr) {
+		throw InternalException("Email regex pattern is not initialized");
+	}
+
 	for (idx_t row = 0; row < args.size(); row++) {
-		auto email_value = args.GetValue(0, row);
-		if (email_value.IsNull()) {
+		auto email_idx = email_data.sel->get_index(row);
+		if (!email_data.validity.RowIsValid(email_idx)) {
 			FlatVector::SetNull(result, row, true);
 			continue;
 		}
 		FlatVector::SetNull(result, row, false);
 
-		optional_ptr<Vector> mode_vector;
-		if (args.ColumnCount() > 1) {
-			mode_vector = &args.data[1];
-		}
-		std::string mode = ExtractValidationMode(mode_vector, row, args.size());
-
-		auto validation = ValidateEmailAddress(email_value.ToString(), mode);
+		auto &email = email_values[email_idx];
+		auto validation =
+		    ValidateEmailAddress(std::string_view(email.GetData(), email.GetSize()), mode_arg.Get(row), *regex_ptr);
 		bool_data[row] = validation.valid;
 	}
 }

--- a/src/anofox_money.cpp
+++ b/src/anofox_money.cpp
@@ -148,7 +148,7 @@ static void AnofoxMoneyFunction(DataChunk &args, ExpressionState &state, Vector 
             auto &currency = LookupCurrencyOrThrow(registry, currency_code);
             // Store the canonical ISO code so that downstream comparisons work regardless of input case.
             // The DOUBLE input is validated (finite) and rounded to the exact DECIMAL(18,3) representation.
-            SetMoneyResult(builder, i, ScaledFromDouble(amount_values[amount_idx]), currency.iso_code, result);
+            SetMoneyResult(builder, i, ScaledFromDouble(amount_values[amount_idx]), currency.iso_code);
         }
     }
 }
@@ -184,7 +184,7 @@ static void AnofoxMoneyFromCentsFunction(DataChunk &args, ExpressionState &state
             auto &currency = LookupCurrencyOrThrow(registry, currency_code);
 
             // Convert the smallest-unit amount to major units exactly (e.g. 10050 cents -> 100.500 USD)
-            SetMoneyResult(builder, i, ScaledFromCents(cents_values[cents_idx], currency), currency.iso_code, result);
+            SetMoneyResult(builder, i, ScaledFromCents(cents_values[cents_idx], currency), currency.iso_code);
         }
     }
 }
@@ -341,7 +341,7 @@ static void AnofoxMoneyFormatFunction(DataChunk &args, ExpressionState &state, V
             FlatVector::SetNull(result, i, true);
         } else {
             auto scaled = data.Amount(i);
-            auto currency_code = data.Currency(i);
+            auto currency_code = data.Currency(i).GetString();
             auto format_style = style_values[style_idx].GetString();
 
             auto &currency = LookupCurrencyOrThrow(registry, currency_code);
@@ -417,7 +417,7 @@ static void AnofoxMoneyAbsFunction(DataChunk &args, ExpressionState &state, Vect
         } else {
             // The scaled amount is range-checked at construction, so negation cannot overflow
             auto scaled = data.Amount(i);
-            SetMoneyResult(builder, i, scaled < 0 ? -scaled : scaled, data.Currency(i), result);
+            SetMoneyResult(builder, i, scaled < 0 ? -scaled : scaled, data.Currency(i));
         }
     }
 }
@@ -429,8 +429,8 @@ static void AnofoxMoneyAbsFunction(DataChunk &args, ExpressionState &state, Vect
 static void AnofoxMoneyAddFunction(DataChunk &args, ExpressionState &state, Vector &result) {
     IterateBinaryMoneyOp(args, result, true, [](MoneyResultBuilder& builder, idx_t i,
                                                 int64_t scaled1, int64_t scaled2,
-                                                const std::string& currency, Vector& result) {
-        SetMoneyResult(builder, i, CheckedAddScaled(scaled1, scaled2), currency, result);
+                                                string_t currency) {
+        SetMoneyResult(builder, i, CheckedAddScaled(scaled1, scaled2), currency);
     });
 }
 
@@ -441,8 +441,8 @@ static void AnofoxMoneyAddFunction(DataChunk &args, ExpressionState &state, Vect
 static void AnofoxMoneySubtractFunction(DataChunk &args, ExpressionState &state, Vector &result) {
     IterateBinaryMoneyOp(args, result, true, [](MoneyResultBuilder& builder, idx_t i,
                                                 int64_t scaled1, int64_t scaled2,
-                                                const std::string& currency, Vector& result) {
-        SetMoneyResult(builder, i, CheckedSubtractScaled(scaled1, scaled2), currency, result);
+                                                string_t currency) {
+        SetMoneyResult(builder, i, CheckedSubtractScaled(scaled1, scaled2), currency);
     });
 }
 
@@ -469,7 +469,7 @@ static void AnofoxMoneyMultiplyFunction(DataChunk &args, ExpressionState &state,
             SetMoneyResultNull(result, i);
         } else {
             SetMoneyResult(builder, i, CheckedMultiplyFactor(data.Amount(i), factor_values[factor_idx]),
-                           data.Currency(i), result);
+                           data.Currency(i));
         }
     }
 }
@@ -529,7 +529,7 @@ static void AnofoxMoneySameCurrencyFunction(DataChunk &args, ExpressionState &st
         } else {
             // Canonical codes are stored at construction; compare case-insensitively so that
             // manually constructed structs with mixed-case codes behave consistently
-            result_data[i] = StringUtil::CIEquals(data1.Currency(i), data2.Currency(i));
+            result_data[i] = CurrencyCIEquals(data1.Currency(i), data2.Currency(i));
         }
     }
 }

--- a/src/anofox_pii.cpp
+++ b/src/anofox_pii.cpp
@@ -1851,74 +1851,85 @@ std::string PIIEngine::Mask(
 
 namespace {
 
+// Shared implementation for all detect-style scalars: runs Detect() with the
+// given type filter and writes the matches directly into the LIST(STRUCT)
+// result vector. The input is normalized once per chunk and match rows are
+// written into the list child vectors without per-row Value materialization.
+void ExecutePIIDetectToList(DataChunk &args, Vector &result, const std::vector<PIIType> &filter) {
+    auto &engine = PIIEngine::Instance();
+    // Snapshot the configuration once per chunk; all reads go through it
+    const auto config = PIIConfig::Get().Snapshot();
+    result.SetVectorType(VectorType::FLAT_VECTOR);
+
+    // Get list entries data and child struct vector
+    auto list_entries = FlatVector::GetData<list_entry_t>(result);
+    auto &child_struct = ListVector::GetEntry(result);
+    auto &struct_children = StructVector::GetEntries(child_struct);
+
+    // References to individual struct fields
+    auto &type_vec = *struct_children[0];       // VARCHAR: type
+    auto &text_vec = *struct_children[1];       // VARCHAR: text
+    auto &start_pos_vec = *struct_children[2];  // BIGINT: start_pos
+    auto &end_pos_vec = *struct_children[3];    // BIGINT: end_pos
+    auto &confidence_vec = *struct_children[4]; // DOUBLE: confidence
+
+    // Reset list size
+    ListVector::SetListSize(result, 0);
+
+    UnifiedVectorFormat input_data;
+    args.data[0].ToUnifiedFormat(args.size(), input_data);
+    auto input_values = UnifiedVectorFormat::GetData<string_t>(input_data);
+
+    for (idx_t row = 0; row < args.size(); row++) {
+        auto input_idx = input_data.sel->get_index(row);
+        if (!input_data.validity.RowIsValid(input_idx)) {
+            FlatVector::SetNull(result, row, true);
+            continue;
+        }
+        FlatVector::SetNull(result, row, false);
+
+        std::string text = input_values[input_idx].GetString();
+        auto matches = engine.Detect(text, filter, config);
+
+        // Set list entry for this row and reserve space in the child vector
+        auto offset = ListVector::GetListSize(result);
+        list_entries[row].offset = offset;
+        list_entries[row].length = matches.size();
+        ListVector::Reserve(result, offset + matches.size());
+
+        // Re-fetch the child data pointers after Reserve: growing the list may
+        // reallocate the child vectors.
+        auto type_data = FlatVector::GetData<string_t>(type_vec);
+        auto text_data = FlatVector::GetData<string_t>(text_vec);
+        auto start_data = FlatVector::GetData<int64_t>(start_pos_vec);
+        auto end_data = FlatVector::GetData<int64_t>(end_pos_vec);
+        auto confidence_data = FlatVector::GetData<double>(confidence_vec);
+
+        for (idx_t i = 0; i < matches.size(); i++) {
+            auto &match = matches[i];
+            auto child_idx = offset + i;
+            type_data[child_idx] = StringVector::AddString(type_vec, PIITypeToString(match.type));
+            text_data[child_idx] = StringVector::AddString(text_vec, match.matched_text);
+            start_data[child_idx] = static_cast<int64_t>(match.start_pos);
+            end_data[child_idx] = static_cast<int64_t>(match.end_pos);
+            confidence_data[child_idx] = match.confidence;
+        }
+        ListVector::SetListSize(result, offset + matches.size());
+    }
+
+    // Fix for constant folding: Convert to CONSTANT_VECTOR when all inputs are constant
+    // This prevents assertion failures in DuckDB's expression evaluator which expects
+    // constant input arguments to produce constant result vectors
+    if (args.AllConstant()) {
+        result.SetVectorType(VectorType::CONSTANT_VECTOR);
+    }
+}
+
 // anofox_tab_pii_detect(text) -> LIST(STRUCT(...)) of matches (alias: pii_detect)
 // Returns idiomatic DuckDB types that can be queried with unnest, dot notation, etc.
 struct PIIDetectFunction {
     static void Execute(DataChunk &args, ExpressionState &state, Vector &result) {
-        auto &engine = PIIEngine::Instance();
-        // Snapshot the configuration once per chunk; all reads go through it
-        const auto config = PIIConfig::Get().Snapshot();
-        result.SetVectorType(VectorType::FLAT_VECTOR);
-
-        // Get list entries data and child struct vector
-        auto list_entries = FlatVector::GetData<list_entry_t>(result);
-        auto &child_struct = ListVector::GetEntry(result);
-        auto &struct_children = StructVector::GetEntries(child_struct);
-
-        // References to individual struct fields
-        auto &type_vec = *struct_children[0];       // VARCHAR: type
-        auto &text_vec = *struct_children[1];       // VARCHAR: text
-        auto &start_pos_vec = *struct_children[2];  // BIGINT: start_pos
-        auto &end_pos_vec = *struct_children[3];    // BIGINT: end_pos
-        auto &confidence_vec = *struct_children[4]; // DOUBLE: confidence
-
-        // Reset list size
-        ListVector::SetListSize(result, 0);
-
-        for (idx_t row = 0; row < args.size(); row++) {
-            auto input_value = args.GetValue(0, row);
-            if (input_value.IsNull()) {
-                FlatVector::SetNull(result, row, true);
-                continue;
-            }
-            FlatVector::SetNull(result, row, false);
-
-            std::string text = input_value.ToString();
-            auto matches = engine.Detect(text, {}, config);
-
-            // Set list entry for this row
-            list_entries[row].offset = ListVector::GetListSize(result);
-            list_entries[row].length = matches.size();
-
-            // Reserve space in child vector
-            ListVector::Reserve(result, ListVector::GetListSize(result) + matches.size());
-
-            // Add each match to the list
-            for (size_t i = 0; i < matches.size(); i++) {
-                auto &match = matches[i];
-                idx_t child_idx = ListVector::GetListSize(result);
-
-                // Set struct field values
-                FlatVector::GetData<string_t>(type_vec)[child_idx] =
-                    StringVector::AddString(type_vec, PIITypeToString(match.type));
-                FlatVector::GetData<string_t>(text_vec)[child_idx] =
-                    StringVector::AddString(text_vec, match.matched_text);
-                FlatVector::GetData<int64_t>(start_pos_vec)[child_idx] =
-                    static_cast<int64_t>(match.start_pos);
-                FlatVector::GetData<int64_t>(end_pos_vec)[child_idx] =
-                    static_cast<int64_t>(match.end_pos);
-                FlatVector::GetData<double>(confidence_vec)[child_idx] = match.confidence;
-
-                ListVector::SetListSize(result, child_idx + 1);
-            }
-        }
-
-        // Fix for constant folding: Convert to CONSTANT_VECTOR when all inputs are constant
-        // This prevents assertion failures in DuckDB's expression evaluator which expects
-        // constant input arguments to produce constant result vectors
-        if (args.AllConstant()) {
-            result.SetVectorType(VectorType::CONSTANT_VECTOR);
-        }
+        ExecutePIIDetectToList(args, result, {});
     }
 
     static ScalarFunction GetFunction() {
@@ -2128,47 +2139,10 @@ Value CreatePIIMatchListValue(const std::vector<PIIMatch> &matches) {
     return Value::LIST(GetPIIMatchStructType(), std::move(match_values));
 }
 
-// Template for type-specific detection
-template<PIIType Type>
-struct PIIDetectTypeFunction {
-    static void Execute(DataChunk &args, ExpressionState &state, Vector &result) {
-        auto &engine = PIIEngine::Instance();
-        const auto config = PIIConfig::Get().Snapshot();
-
-        UnaryExecutor::ExecuteWithNulls<string_t, list_entry_t>(
-            args.data[0], result, args.size(),
-            [&](string_t input, ValidityMask &mask, idx_t idx) {
-                std::string text = input.GetString();
-
-                // Detect with type filter
-                std::vector<PIIType> filter = {Type};
-                auto matches = engine.Detect(text, filter, config);
-
-                auto list_value = CreatePIIMatchListValue(matches);
-                result.SetValue(idx, list_value);
-
-                return list_entry_t{0, 0};  // Return value is not used when SetValue is called
-            }
-        );
-    }
-};
-
 // pii_detect_emails(text) -> LIST(STRUCT(...))
 struct PIIDetectEmailsFunction {
     static void Execute(DataChunk &args, ExpressionState &state, Vector &result) {
-        auto &engine = PIIEngine::Instance();
-        const auto config = PIIConfig::Get().Snapshot();
-        std::vector<PIIType> filter = {PIIType::EMAIL};
-
-        for (idx_t i = 0; i < args.size(); i++) {
-            auto val = args.data[0].GetValue(i);
-            if (val.IsNull()) {
-                result.SetValue(i, Value(LogicalType::SQLNULL));
-            } else {
-                auto matches = engine.Detect(val.GetValue<std::string>(), filter, config);
-                result.SetValue(i, CreatePIIMatchListValue(matches));
-            }
-        }
+        ExecutePIIDetectToList(args, result, {PIIType::EMAIL});
     }
 
     static ScalarFunction GetFunction() {
@@ -2180,19 +2154,7 @@ struct PIIDetectEmailsFunction {
 // pii_detect_phones(text) -> LIST(STRUCT(...))
 struct PIIDetectPhonesFunction {
     static void Execute(DataChunk &args, ExpressionState &state, Vector &result) {
-        auto &engine = PIIEngine::Instance();
-        const auto config = PIIConfig::Get().Snapshot();
-        std::vector<PIIType> filter = {PIIType::PHONE};
-
-        for (idx_t i = 0; i < args.size(); i++) {
-            auto val = args.data[0].GetValue(i);
-            if (val.IsNull()) {
-                result.SetValue(i, Value(LogicalType::SQLNULL));
-            } else {
-                auto matches = engine.Detect(val.GetValue<std::string>(), filter, config);
-                result.SetValue(i, CreatePIIMatchListValue(matches));
-            }
-        }
+        ExecutePIIDetectToList(args, result, {PIIType::PHONE});
     }
 
     static ScalarFunction GetFunction() {
@@ -2204,19 +2166,7 @@ struct PIIDetectPhonesFunction {
 // pii_detect_credit_cards(text) -> LIST(STRUCT(...))
 struct PIIDetectCreditCardsFunction {
     static void Execute(DataChunk &args, ExpressionState &state, Vector &result) {
-        auto &engine = PIIEngine::Instance();
-        const auto config = PIIConfig::Get().Snapshot();
-        std::vector<PIIType> filter = {PIIType::CREDIT_CARD};
-
-        for (idx_t i = 0; i < args.size(); i++) {
-            auto val = args.data[0].GetValue(i);
-            if (val.IsNull()) {
-                result.SetValue(i, Value(LogicalType::SQLNULL));
-            } else {
-                auto matches = engine.Detect(val.GetValue<std::string>(), filter, config);
-                result.SetValue(i, CreatePIIMatchListValue(matches));
-            }
-        }
+        ExecutePIIDetectToList(args, result, {PIIType::CREDIT_CARD});
     }
 
     static ScalarFunction GetFunction() {
@@ -2228,19 +2178,7 @@ struct PIIDetectCreditCardsFunction {
 // pii_detect_ssns(text) -> LIST(STRUCT(...))
 struct PIIDetectSSNsFunction {
     static void Execute(DataChunk &args, ExpressionState &state, Vector &result) {
-        auto &engine = PIIEngine::Instance();
-        const auto config = PIIConfig::Get().Snapshot();
-        std::vector<PIIType> filter = {PIIType::US_SSN};
-
-        for (idx_t i = 0; i < args.size(); i++) {
-            auto val = args.data[0].GetValue(i);
-            if (val.IsNull()) {
-                result.SetValue(i, Value(LogicalType::SQLNULL));
-            } else {
-                auto matches = engine.Detect(val.GetValue<std::string>(), filter, config);
-                result.SetValue(i, CreatePIIMatchListValue(matches));
-            }
-        }
+        ExecutePIIDetectToList(args, result, {PIIType::US_SSN});
     }
 
     static ScalarFunction GetFunction() {
@@ -2252,19 +2190,7 @@ struct PIIDetectSSNsFunction {
 // pii_detect_names(text) -> LIST(STRUCT(...))
 struct PIIDetectNamesFunction {
     static void Execute(DataChunk &args, ExpressionState &state, Vector &result) {
-        auto &engine = PIIEngine::Instance();
-        const auto config = PIIConfig::Get().Snapshot();
-        std::vector<PIIType> filter = {PIIType::NAME};
-
-        for (idx_t i = 0; i < args.size(); i++) {
-            auto val = args.data[0].GetValue(i);
-            if (val.IsNull()) {
-                result.SetValue(i, Value(LogicalType::SQLNULL));
-            } else {
-                auto matches = engine.Detect(val.GetValue<std::string>(), filter, config);
-                result.SetValue(i, CreatePIIMatchListValue(matches));
-            }
-        }
+        ExecutePIIDetectToList(args, result, {PIIType::NAME});
     }
 
     static ScalarFunction GetFunction() {
@@ -2276,19 +2202,7 @@ struct PIIDetectNamesFunction {
 // pii_detect_ibans(text) -> LIST(STRUCT(...))
 struct PIIDetectIBANsFunction {
     static void Execute(DataChunk &args, ExpressionState &state, Vector &result) {
-        auto &engine = PIIEngine::Instance();
-        const auto config = PIIConfig::Get().Snapshot();
-        std::vector<PIIType> filter = {PIIType::IBAN};
-
-        for (idx_t i = 0; i < args.size(); i++) {
-            auto val = args.data[0].GetValue(i);
-            if (val.IsNull()) {
-                result.SetValue(i, Value(LogicalType::SQLNULL));
-            } else {
-                auto matches = engine.Detect(val.GetValue<std::string>(), filter, config);
-                result.SetValue(i, CreatePIIMatchListValue(matches));
-            }
-        }
+        ExecutePIIDetectToList(args, result, {PIIType::IBAN});
     }
 
     static ScalarFunction GetFunction() {
@@ -2394,22 +2308,14 @@ struct PIIMaskColumnFunction {
         // Use type filter for detection
         std::vector<PIIType> filter = {pii_type};
 
-        for (idx_t i = 0; i < args.size(); i++) {
-            auto val = args.data[0].GetValue(i);
-            if (val.IsNull()) {
-                result.SetValue(i, Value(LogicalType::SQLNULL));
-            } else {
-                auto text = val.GetValue<std::string>();
-                // Detect only the specified type, then mask
-                auto matches = engine.Detect(text, filter, config);
-                if (matches.empty()) {
-                    // No PII of that type found - return original
-                    result.SetValue(i, Value(text));
-                } else {
-                    result.SetValue(i, Value(engine.Mask(text, strategy, filter, config)));
-                }
+        // Mask() returns the original text when nothing of the requested type is
+        // found, so a single call per row suffices (no separate Detect pass).
+        UnaryExecutor::Execute<string_t, string_t>(
+            args.data[0], result, args.size(),
+            [&](string_t input) {
+                return StringVector::AddString(result, engine.Mask(input.GetString(), strategy, filter, config));
             }
-        }
+        );
     }
 
     static ScalarFunction GetFunction() {
@@ -2434,15 +2340,12 @@ struct PIIRedactColumnFunction {
             strategy = StringToMaskStrategy(strategy_arg.GetValue<std::string>());
         }
 
-        for (idx_t i = 0; i < args.size(); i++) {
-            auto val = args.data[0].GetValue(i);
-            if (val.IsNull()) {
-                result.SetValue(i, Value(LogicalType::SQLNULL));
-            } else {
-                auto text = val.GetValue<std::string>();
-                result.SetValue(i, Value(engine.Mask(text, strategy, {}, config)));
+        UnaryExecutor::Execute<string_t, string_t>(
+            args.data[0], result, args.size(),
+            [&](string_t input) {
+                return StringVector::AddString(result, engine.Mask(input.GetString(), strategy, {}, config));
             }
-        }
+        );
     }
 
     static ScalarFunction GetFunction() {
@@ -2459,15 +2362,12 @@ struct PIIRedactColumnDefaultFunction {
         const auto config = PIIConfig::Get().Snapshot();
         auto strategy = config.default_mask_strategy;
 
-        for (idx_t i = 0; i < args.size(); i++) {
-            auto val = args.data[0].GetValue(i);
-            if (val.IsNull()) {
-                result.SetValue(i, Value(LogicalType::SQLNULL));
-            } else {
-                auto text = val.GetValue<std::string>();
-                result.SetValue(i, Value(engine.Mask(text, strategy, {}, config)));
+        UnaryExecutor::Execute<string_t, string_t>(
+            args.data[0], result, args.size(),
+            [&](string_t input) {
+                return StringVector::AddString(result, engine.Mask(input.GetString(), strategy, {}, config));
             }
-        }
+        );
     }
 
     static ScalarFunction GetFunction() {

--- a/src/anofox_postal.cpp
+++ b/src/anofox_postal.cpp
@@ -185,26 +185,29 @@ std::string PostalManager::GetDataDirectory() const {
 	return data_directory;
 }
 
-std::vector<PostalComponent> PostalManager::ParseAddress(const std::string &input) {
+void PostalManager::ParseAddress(const std::string &input,
+                                 const std::function<void(char **labels, char **values, size_t count)> &visit) {
 	libpostal_address_parser_options_t options = libpostal_get_address_parser_default_options();
 	libpostal_address_parser_response_t *parsed = libpostal_parse_address(const_cast<char *>(input.c_str()), options);
 	if (!parsed) {
 		AnofoxTrace(AnofoxLogLevel::Warn, "Postal parse failed");
 		throw IOException("libpostal_parse_address failed");
 	}
-	AnofoxTrace(AnofoxLogLevel::Debug,
-	           "Postal parsed address components=" + std::to_string(parsed->num_components) + " ");
+	// RAII so the response is destroyed even if the visitor throws.
+	auto response_deleter = [](libpostal_address_parser_response_t *response) {
+		libpostal_address_parser_response_destroy(response);
+	};
+	std::unique_ptr<libpostal_address_parser_response_t, decltype(response_deleter)> guard(parsed, response_deleter);
 
-	std::vector<PostalComponent> components;
-	components.reserve(parsed->num_components);
-	for (size_t i = 0; i < parsed->num_components; i++) {
-		components.push_back({parsed->labels[i], parsed->components[i]});
+	if (AnofoxTraceConfig::Get().ShouldLog(AnofoxLogLevel::Debug)) {
+		AnofoxTrace(AnofoxLogLevel::Debug,
+		            "Postal parsed address components=" + std::to_string(parsed->num_components) + " ");
 	}
-	libpostal_address_parser_response_destroy(parsed);
-	return components;
+	visit(parsed->labels, parsed->components, parsed->num_components);
 }
 
-std::vector<std::string> PostalManager::ExpandAddress(const std::string &input) {
+void PostalManager::ExpandAddress(const std::string &input,
+                                  const std::function<void(char **expansions, size_t count)> &visit) {
 	libpostal_normalize_options_t options = libpostal_get_default_options();
 	size_t num_expansions = 0;
 	char **expansions = libpostal_expand_address(const_cast<char *>(input.c_str()), options, &num_expansions);
@@ -212,16 +215,18 @@ std::vector<std::string> PostalManager::ExpandAddress(const std::string &input) 
 		AnofoxTrace(AnofoxLogLevel::Warn, "Postal expand failed");
 		throw IOException("libpostal_expand_address failed");
 	}
-	AnofoxTrace(AnofoxLogLevel::Debug,
-	           "Postal expand generated " + std::to_string(num_expansions) + " variants");
-
-	std::vector<std::string> result;
-	result.reserve(num_expansions);
-	for (size_t i = 0; i < num_expansions; i++) {
-		result.emplace_back(expansions[i]);
+	if (AnofoxTraceConfig::Get().ShouldLog(AnofoxLogLevel::Debug)) {
+		AnofoxTrace(AnofoxLogLevel::Debug,
+		            "Postal expand generated " + std::to_string(num_expansions) + " variants");
+	}
+	// The expansion array needs a paired destroy call; release it on every exit path.
+	try {
+		visit(expansions, num_expansions);
+	} catch (...) {
+		libpostal_expansion_array_destroy(expansions, num_expansions);
+		throw;
 	}
 	libpostal_expansion_array_destroy(expansions, num_expansions);
-	return result;
 }
 
 void PostalManager::LoadData(ClientContext &context) {
@@ -418,7 +423,6 @@ void PostalManager::Initialize(ClientContext &context) {
 namespace duckdb {
 namespace anofox {
 
-using postal::PostalComponent;
 using postal::PostalManager;
 using postal::PostalStatus;
 
@@ -443,12 +447,16 @@ void PostalParseAddressFunction(DataChunk &args, ExpressionState &state, Vector 
 	result.SetVectorType(VectorType::FLAT_VECTOR);
 	auto &children = StructVector::GetEntries(result);
 
-	auto &house_number_vec = *children[0];
-	auto &road_vec = *children[1];
-	auto &city_vec = *children[2];
-	auto &state_vec = *children[3];
-	auto &postcode_vec = *children[4];
-	auto &country_vec = *children[5];
+	// The recognized component labels in struct-child order. Child data
+	// pointers are hoisted out of the row loop (struct children are pre-sized,
+	// so the pointers stay valid for the whole chunk).
+	static constexpr const char *COMPONENT_LABELS[] = {"house_number", "road",     "city",
+	                                                   "state",        "postcode", "country"};
+	constexpr idx_t COMPONENT_COUNT = 6;
+	string_t *child_data[COMPONENT_COUNT];
+	for (idx_t c = 0; c < COMPONENT_COUNT; c++) {
+		child_data[c] = FlatVector::GetData<string_t>(*children[c]);
+	}
 
 	// Initialize libpostal lazily on the first non-NULL row so NULL-only
 	// queries never require the data bundle.
@@ -468,28 +476,24 @@ void PostalParseAddressFunction(DataChunk &args, ExpressionState &state, Vector 
 			initialization_checked = true;
 		}
 
-		auto input_str = inputs[idx].GetString();
-		auto components = manager.ParseAddress(input_str);
-
 		for (auto &child : children) {
 			FlatVector::SetNull(*child, i, true);
 		}
 
-		for (const auto &component : components) {
-			if (component.label == "house_number") {
-				house_number_vec.SetValue(i, component.value);
-			} else if (component.label == "road") {
-				road_vec.SetValue(i, component.value);
-			} else if (component.label == "city") {
-				city_vec.SetValue(i, component.value);
-			} else if (component.label == "state") {
-				state_vec.SetValue(i, component.value);
-			} else if (component.label == "postcode") {
-				postcode_vec.SetValue(i, component.value);
-			} else if (component.label == "country") {
-				country_vec.SetValue(i, component.value);
+		// Write the libpostal component values straight into the child vectors
+		// (no intermediate std::string or Value copies).
+		auto input_str = inputs[idx].GetString();
+		manager.ParseAddress(input_str, [&](char **labels, char **values, size_t count) {
+			for (size_t component = 0; component < count; component++) {
+				for (idx_t c = 0; c < COMPONENT_COUNT; c++) {
+					if (std::strcmp(labels[component], COMPONENT_LABELS[c]) == 0) {
+						child_data[c][i] = StringVector::AddString(*children[c], values[component]);
+						FlatVector::SetNull(*children[c], i, false);
+						break;
+					}
+				}
 			}
-		}
+		});
 	}
 
 	if (args.AllConstant()) {
@@ -508,6 +512,7 @@ void PostalExpandAddressFunction(DataChunk &args, ExpressionState &state, Vector
 
 	result.SetVectorType(VectorType::FLAT_VECTOR);
 	auto list_entries = FlatVector::GetData<list_entry_t>(result);
+	auto &expansion_child = ListVector::GetEntry(result);
 
 	// Initialize libpostal lazily on the first non-NULL row so NULL-only
 	// queries never require the data bundle.
@@ -526,15 +531,21 @@ void PostalExpandAddressFunction(DataChunk &args, ExpressionState &state, Vector
 			initialization_checked = true;
 		}
 
+		// Write the libpostal expansions straight into the list child vector
+		// (reserve once per row, no per-element Value construction).
 		auto input_str = inputs[idx].GetString();
-		auto expansions = manager.ExpandAddress(input_str);
-
-		list_entries[i].offset = ListVector::GetListSize(result);
-		list_entries[i].length = expansions.size();
-
-		for (auto &expansion : expansions) {
-			ListVector::PushBack(result, Value(expansion));
-		}
+		manager.ExpandAddress(input_str, [&](char **expansions, size_t count) {
+			auto offset = ListVector::GetListSize(result);
+			ListVector::Reserve(result, offset + count);
+			// Re-fetch after Reserve: growing the child may reallocate its data.
+			auto child_data = FlatVector::GetData<string_t>(expansion_child);
+			for (size_t k = 0; k < count; k++) {
+				child_data[offset + k] = StringVector::AddString(expansion_child, expansions[k]);
+			}
+			ListVector::SetListSize(result, offset + count);
+			list_entries[i].offset = offset;
+			list_entries[i].length = count;
+		});
 	}
 
 	if (args.AllConstant()) {

--- a/src/anofox_vat.cpp
+++ b/src/anofox_vat.cpp
@@ -26,7 +26,7 @@ static LogicalType GetVATType() {
 static void VATParseFunc(DataChunk& args, ExpressionState& state,
                         Vector& result) {
   auto& registry = VATRegistry::Instance();
-  IterateSingleStringInput(args, result, [&](const std::string& input, size_t idx) {
+  IterateSingleStringInput(args, result, [&](std::string_view input, size_t idx) {
     auto split_result = registry.SplitVAT(input);
     if (!split_result.has_value()) {
       FlatVector::SetNull(result, idx, true);
@@ -41,7 +41,7 @@ static void VATParseFunc(DataChunk& args, ExpressionState& state,
 static void IsValidVATCountryFunc(DataChunk& args, ExpressionState& state,
                                  Vector& result) {
   auto& registry = VATRegistry::Instance();
-  IterateSingleStringInput(args, result, [&](const std::string& country, size_t idx) {
+  IterateSingleStringInput(args, result, [&](std::string_view country, size_t idx) {
     SetBoolResult(result, idx, registry.IsValidCountry(country));
   });
 }
@@ -50,7 +50,7 @@ static void IsValidVATCountryFunc(DataChunk& args, ExpressionState& state,
 static void VATNormalizeFunc(DataChunk& args, ExpressionState& state,
                             Vector& result) {
   auto& registry = VATRegistry::Instance();
-  IterateSingleStringInput(args, result, [&](const std::string& input, size_t idx) {
+  IterateSingleStringInput(args, result, [&](std::string_view input, size_t idx) {
     SetStringResult(result, idx, registry.NormalizeVAT(input));
   });
 }
@@ -63,7 +63,7 @@ static void VATNormalizeFunc(DataChunk& args, ExpressionState& state,
 static void VATIsValidSyntaxFunc(DataChunk& args, ExpressionState& state,
                                 Vector& result) {
   auto& registry = VATRegistry::Instance();
-  IterateSingleStringInput(args, result, [&](const std::string& input, size_t idx) {
+  IterateSingleStringInput(args, result, [&](std::string_view input, size_t idx) {
     auto split_result = registry.SplitVAT(input);
     if (!split_result.has_value()) {
       SetBoolResult(result, idx, false);
@@ -78,7 +78,7 @@ static void VATIsValidSyntaxFunc(DataChunk& args, ExpressionState& state,
 static void VATSplitFunc(DataChunk& args, ExpressionState& state,
                         Vector& result) {
   auto& registry = VATRegistry::Instance();
-  IterateSingleStringInput(args, result, [&](const std::string& input, size_t idx) {
+  IterateSingleStringInput(args, result, [&](std::string_view input, size_t idx) {
     auto split_result = registry.SplitVAT(input);
     if (!split_result.has_value()) {
       FlatVector::SetNull(result, idx, true);
@@ -93,7 +93,7 @@ static void VATSplitFunc(DataChunk& args, ExpressionState& state,
 static void VATExistsFunc(DataChunk& args, ExpressionState& state,
                          Vector& result) {
   auto& registry = VATRegistry::Instance();
-  IterateSingleStringInput(args, result, [&](const std::string& input, size_t idx) {
+  IterateSingleStringInput(args, result, [&](std::string_view input, size_t idx) {
     SetBoolResult(result, idx, registry.SplitVAT(input).has_value());
   });
 }
@@ -106,7 +106,7 @@ static void VATExistsFunc(DataChunk& args, ExpressionState& state,
 static void VATIsEUMemberFunc(DataChunk& args, ExpressionState& state,
                              Vector& result) {
   auto& registry = VATRegistry::Instance();
-  IterateSingleStringInput(args, result, [&](const std::string& country, size_t idx) {
+  IterateSingleStringInput(args, result, [&](std::string_view country, size_t idx) {
     SetBoolResult(result, idx, registry.IsEUMember(country));
   });
 }
@@ -115,7 +115,7 @@ static void VATIsEUMemberFunc(DataChunk& args, ExpressionState& state,
 static void VATCountryNameFunc(DataChunk& args, ExpressionState& state,
                               Vector& result) {
   auto& registry = VATRegistry::Instance();
-  IterateSingleStringInput(args, result, [&](const std::string& country, size_t idx) {
+  IterateSingleStringInput(args, result, [&](std::string_view country, size_t idx) {
     std::string name = registry.GetCountryName(country);
     if (name.empty()) {
       FlatVector::SetNull(result, idx, true);
@@ -130,8 +130,8 @@ static void VATCountryNameFunc(DataChunk& args, ExpressionState& state,
 static void VATFormatFunc(DataChunk& args, ExpressionState& state,
                          Vector& result) {
   auto& registry = VATRegistry::Instance();
-  IterateTwoStringInputs(args, result, [&](const std::string& vat,
-                                           const std::string& style,
+  IterateTwoStringInputs(args, result, [&](std::string_view vat,
+                                           std::string_view style,
                                            size_t idx) {
     auto split_result = registry.SplitVAT(vat);
     if (!split_result.has_value()) {
@@ -139,15 +139,14 @@ static void VATFormatFunc(DataChunk& args, ExpressionState& state,
       return;
     }
     auto [country, digits] = split_result.value();
-    auto normalized_style = StringUtil::Lower(style);
-    if (normalized_style == "plain") {
+    if (StringUtil::CIEquals(style.data(), style.size(), "plain", 5)) {
       SetStringResult(result, idx, digits);
-    } else if (normalized_style == "iso") {
+    } else if (StringUtil::CIEquals(style.data(), style.size(), "iso", 3)) {
       SetStringResult(result, idx, registry.ConvertISOToVAT(country) + digits);
     } else {
       throw InvalidInputException(
           "Unsupported VAT format style: %s (expected 'plain' or 'iso')",
-          style);
+          std::string(style));
     }
   });
 }
@@ -161,7 +160,7 @@ static void VATFormatFunc(DataChunk& args, ExpressionState& state,
 static void VATIsValidFunc(DataChunk& args, ExpressionState& state,
                           Vector& result) {
   auto& registry = VATRegistry::Instance();
-  IterateSingleStringInput(args, result, [&](const std::string& input, size_t idx) {
+  IterateSingleStringInput(args, result, [&](std::string_view input, size_t idx) {
     auto split_result = registry.SplitVAT(input);
     if (!split_result.has_value()) {
       SetBoolResult(result, idx, false);

--- a/src/anofox_vat_country.cpp
+++ b/src/anofox_vat_country.cpp
@@ -67,11 +67,11 @@ void VATRegistry::InitializeCountries() {
   countries_["SK"] = {"SK", "Slovakia", "[0-9]{10}", true, false};
 }
 
-bool VATRegistry::IsValidCountry(const std::string& code) const {
+bool VATRegistry::IsValidCountry(std::string_view code) const {
   return countries_.find(NormalizeCountryCode(code)) != countries_.end();
 }
 
-bool VATRegistry::IsEUMember(const std::string& code) const {
+bool VATRegistry::IsEUMember(std::string_view code) const {
   auto it = countries_.find(NormalizeCountryCode(code));
   if (it == countries_.end()) {
     return false;
@@ -79,7 +79,7 @@ bool VATRegistry::IsEUMember(const std::string& code) const {
   return it->second.is_eu_member;
 }
 
-std::string VATRegistry::GetCountryName(const std::string& code) const {
+std::string VATRegistry::GetCountryName(std::string_view code) const {
   auto it = countries_.find(NormalizeCountryCode(code));
   if (it == countries_.end()) {
     return "";
@@ -96,7 +96,7 @@ bool VATRegistry::IsValidSyntax(const std::string& country,
   return std::regex_match(digits, it->second.compiled_pattern);
 }
 
-std::string VATRegistry::NormalizeVAT(const std::string& input) const {
+std::string VATRegistry::NormalizeVAT(std::string_view input) const {
   std::string result;
   result.reserve(input.size());
   // Convert to uppercase and remove spaces, punctuation
@@ -108,12 +108,12 @@ std::string VATRegistry::NormalizeVAT(const std::string& input) const {
   return result;
 }
 
-std::string VATRegistry::NormalizeCountryCode(const std::string& code) const {
+std::string VATRegistry::NormalizeCountryCode(std::string_view code) const {
   return ConvertVATToISO(NormalizeVAT(code));
 }
 
 std::optional<std::pair<std::string, std::string>> VATRegistry::SplitVAT(
-    const std::string& input) const {
+    std::string_view input) const {
   if (input.length() < 2) {
     return std::nullopt;
   }

--- a/src/include/anofox_money.hpp
+++ b/src/include/anofox_money.hpp
@@ -57,11 +57,17 @@ struct MoneyStructData {
     return amount_values[amount_data.sel->get_index(row)];
   }
 
-  std::string Currency(idx_t i) const {
+  //! Returns the currency code as a view into the input vector (no copy).
+  string_t Currency(idx_t i) const {
     auto row = struct_data.sel->get_index(i);
-    return currency_values[currency_data.sel->get_index(row)].GetString();
+    return currency_values[currency_data.sel->get_index(row)];
   }
 };
+
+//! Case-insensitive comparison of two currency codes without allocating.
+inline bool CurrencyCIEquals(string_t left, string_t right) {
+  return StringUtil::CIEquals(left.GetData(), left.GetSize(), right.GetData(), right.GetSize());
+}
 
 inline MoneyStructData ExtractMoneyStruct(Vector& money_vec, idx_t count) {
   auto& children = StructVector::GetEntries(money_vec);
@@ -86,11 +92,12 @@ inline MoneyStructData ExtractMoneyStruct(Vector& money_vec, idx_t count) {
 // ============================================================================
 // Helper: Money Result Builder
 // ============================================================================
+//! Holds the child-data pointers and the currency child vector of a money
+//! result struct, hoisted out of the row loops (no per-row GetEntries).
 struct MoneyResultBuilder {
   int64_t* amount_ptr;
   string_t* currency_ptr;
-  ValidityMask& amount_validity;
-  ValidityMask& currency_validity;
+  Vector& currency_vec;
 };
 
 inline MoneyResultBuilder PrepareMoneyResult(Vector& result) {
@@ -108,17 +115,20 @@ inline MoneyResultBuilder PrepareMoneyResult(Vector& result) {
   return MoneyResultBuilder{
     FlatVector::GetData<int64_t>(amount_vec),
     FlatVector::GetData<string_t>(currency_vec),
-    FlatVector::Validity(amount_vec),
-    FlatVector::Validity(currency_vec),
+    currency_vec,
   };
 }
 
 inline void SetMoneyResult(MoneyResultBuilder& builder, idx_t i,
-                          int64_t scaled_amount, const std::string& currency,
-                          Vector& result) {
+                          int64_t scaled_amount, const std::string& currency) {
   builder.amount_ptr[i] = scaled_amount;
-  auto& children = StructVector::GetEntries(result);
-  builder.currency_ptr[i] = StringVector::AddString(*children[1], currency);
+  builder.currency_ptr[i] = StringVector::AddString(builder.currency_vec, currency);
+}
+
+inline void SetMoneyResult(MoneyResultBuilder& builder, idx_t i,
+                          int64_t scaled_amount, string_t currency) {
+  builder.amount_ptr[i] = scaled_amount;
+  builder.currency_ptr[i] = StringVector::AddString(builder.currency_vec, currency);
 }
 
 //! Marks a money result row as SQL NULL. FlatVector::SetNull on a STRUCT vector
@@ -195,13 +205,13 @@ inline void IterateBinaryMoneyOp(DataChunk& args, Vector& result,
 
       // Codes are canonicalized at construction; compare case-insensitively so
       // manually constructed structs with mixed-case codes still work.
-      if (check_same_currency && !StringUtil::CIEquals(currency1, currency2)) {
+      if (check_same_currency && !CurrencyCIEquals(currency1, currency2)) {
         throw InvalidInputException(
             "Cannot operate on money with different currencies: %s and %s",
-            currency1.c_str(), currency2.c_str());
+            currency1.GetString(), currency2.GetString());
       }
 
-      op(builder, i, data1.Amount(i), data2.Amount(i), currency1, result);
+      op(builder, i, data1.Amount(i), data2.Amount(i), currency1);
     }
   }
 }

--- a/src/include/anofox_postal.hpp
+++ b/src/include/anofox_postal.hpp
@@ -6,6 +6,7 @@
 #include "duckdb/main/client_context.hpp"
 
 #include <atomic>
+#include <functional>
 #include <mutex>
 #include <string>
 #include <vector>
@@ -17,11 +18,6 @@ void RegisterPostalOptions(ExtensionLoader &loader);
 void RegisterPostalFunctions(ExtensionLoader &loader);
 
 namespace postal {
-
-struct PostalComponent {
-	std::string label;
-	std::string value;
-};
 
 struct PostalStatus {
 	bool initialized = false;
@@ -35,8 +31,16 @@ public:
 
 	void EnsureInitialized(ClientContext &context);
 	void LoadData(ClientContext &context);
-	std::vector<PostalComponent> ParseAddress(const std::string &input);
-	std::vector<std::string> ExpandAddress(const std::string &input);
+	//! Parses `input` and invokes `visit(labels, values, count)` on the raw
+	//! libpostal component arrays. The callback writes the values straight into
+	//! DuckDB vectors, so no intermediate std::string copies are made; the
+	//! libpostal response is released on every exit path.
+	void ParseAddress(const std::string &input,
+	                  const std::function<void(char **labels, char **values, size_t count)> &visit);
+	//! Expands `input` and invokes `visit(expansions, count)` on the raw
+	//! libpostal expansion array (same direct-write contract as ParseAddress).
+	void ExpandAddress(const std::string &input,
+	                   const std::function<void(char **expansions, size_t count)> &visit);
 	PostalStatus GetStatus(ClientContext &context);
 
 	void SetDataDirectory(const std::string &path);

--- a/src/include/anofox_vat.hpp
+++ b/src/include/anofox_vat.hpp
@@ -8,6 +8,7 @@
 #include <optional>
 #include <regex>
 #include <string>
+#include <string_view>
 #include <unordered_map>
 
 namespace duckdb {
@@ -22,10 +23,11 @@ struct VAT {
 // ============================================================================
 // Handles all boilerplate: vector format conversion, validity checking, loop,
 // and result verification. The operation lambda/function receives each valid
-// input string and the output index.
+// input as a std::string_view into the input vector (no per-row std::string
+// copy) and the output index.
 //
 // Usage:
-//   IterateSingleStringInput(args, result, [&](const std::string& input, size_t idx) {
+//   IterateSingleStringInput(args, result, [&](std::string_view input, size_t idx) {
 //       auto value = registry.DoSomething(input);
 //       SetBoolResult(result, idx, value);
 //   });
@@ -37,7 +39,7 @@ inline void IterateSingleStringInput(DataChunk& args, Vector& result,
 
   UnifiedVectorFormat idata;
   input_vec.ToUnifiedFormat(count, idata);
-  auto input_strings = (string_t*)idata.data;
+  auto input_strings = UnifiedVectorFormat::GetData<string_t>(idata);
 
   for (size_t i = 0; i < count; i++) {
     size_t idx = idata.sel->get_index(i);
@@ -46,8 +48,8 @@ inline void IterateSingleStringInput(DataChunk& args, Vector& result,
       continue;
     }
 
-    std::string input = input_strings[idx].GetString();
-    op(input, i);
+    auto& input = input_strings[idx];
+    op(std::string_view(input.GetData(), input.GetSize()), i);
   }
 
   result.Verify(count);
@@ -66,8 +68,8 @@ inline void IterateTwoStringInputs(DataChunk& args, Vector& result,
   UnifiedVectorFormat idata1, idata2;
   input1_vec.ToUnifiedFormat(count, idata1);
   input2_vec.ToUnifiedFormat(count, idata2);
-  auto input1_strings = (string_t*)idata1.data;
-  auto input2_strings = (string_t*)idata2.data;
+  auto input1_strings = UnifiedVectorFormat::GetData<string_t>(idata1);
+  auto input2_strings = UnifiedVectorFormat::GetData<string_t>(idata2);
 
   for (size_t i = 0; i < count; i++) {
     size_t idx1 = idata1.sel->get_index(i);
@@ -79,9 +81,10 @@ inline void IterateTwoStringInputs(DataChunk& args, Vector& result,
       continue;
     }
 
-    std::string input1 = input1_strings[idx1].GetString();
-    std::string input2 = input2_strings[idx2].GetString();
-    op(input1, input2, i);
+    auto& input1 = input1_strings[idx1];
+    auto& input2 = input2_strings[idx2];
+    op(std::string_view(input1.GetData(), input1.GetSize()),
+       std::string_view(input2.GetData(), input2.GetSize()), i);
   }
 
   result.Verify(count);
@@ -122,18 +125,18 @@ class VATRegistry {
  public:
   static VATRegistry& Instance();
 
-  bool IsValidCountry(const std::string& code) const;
-  bool IsEUMember(const std::string& code) const;
-  std::string GetCountryName(const std::string& code) const;
+  bool IsValidCountry(std::string_view code) const;
+  bool IsEUMember(std::string_view code) const;
+  std::string GetCountryName(std::string_view code) const;
   bool IsValidSyntax(const std::string& country, const std::string& digits) const;
   // Validates the country-specific check digits. Returns true for countries
   // without an implemented checksum (syntax-only validation).
   bool IsValidChecksum(const std::string& country, const std::string& digits) const;
-  std::string NormalizeVAT(const std::string& input) const;
+  std::string NormalizeVAT(std::string_view input) const;
   // Uppercases the code and resolves VAT prefixes (EL -> GR, XI -> GB) to ISO.
-  std::string NormalizeCountryCode(const std::string& code) const;
+  std::string NormalizeCountryCode(std::string_view code) const;
   std::optional<std::pair<std::string, std::string>> SplitVAT(
-      const std::string& input) const;
+      std::string_view input) const;
   std::string ConvertVATToISO(const std::string& vat_country) const;
   std::string ConvertISOToVAT(const std::string& iso_country) const;
 

--- a/test/sql/anofox_vectorization_pins.test
+++ b/test/sql/anofox_vectorization_pins.test
@@ -1,0 +1,730 @@
+# name: test/sql/anofox_vectorization_pins.test
+# description: Behavior pins for the scalar vectorization sweep (issue #58).
+#   Every scalar function refactored in #58 is exercised here with:
+#   - constant-vector inputs (literal arguments)
+#   - dictionary-style inputs (repeated values selected from a table)
+#   - NULL patterns (leading / trailing / all-NULL / mixed)
+#   - empty strings
+#   - large batches (range(5000)) checked via aggregate counts
+#   These tests were green BEFORE the refactor and must stay green after it.
+# group: [anofox_tabular]
+
+require anofox_tabular
+
+statement ok
+LOAD anofox_tabular;
+
+# ============================================================================
+# EMAIL: anofox_tab_email_is_valid / anofox_tab_email_validate (regex mode only,
+# so no network access is required)
+# ============================================================================
+
+# The email configuration is a process-global singleton shared across test
+# files; restore the defaults so earlier tests (e.g. anofox_email_basic.test
+# overriding the regex pattern) cannot leak into these pins.
+statement ok
+SET anofox_tab_email_default_validation = 'regex';
+
+statement ok
+SET anofox_tab_email_regex_pattern = '^[A-Za-z0-9.!#$%&''*+/=?^_`{|}~-]+@[A-Za-z0-9-]+(?:\.[A-Za-z0-9-]+)*$';
+
+# Constant input, implicit default mode (regex)
+query T
+SELECT anofox_tab_email_is_valid('user@example.com');
+----
+true
+
+# Constant input, explicit constant mode
+query T
+SELECT anofox_tab_email_is_valid('user@example.com', 'regex');
+----
+true
+
+# Mode normalization: case and surrounding whitespace must not matter
+query T
+SELECT anofox_tab_email_is_valid('user@example.com', '  REGEX  ');
+----
+true
+
+# Invalid constant input
+query T
+SELECT anofox_tab_email_is_valid('not-an-email');
+----
+false
+
+# Empty string input
+query T
+SELECT anofox_tab_email_is_valid('');
+----
+false
+
+# NULL email yields NULL
+query T
+SELECT anofox_tab_email_is_valid(NULL);
+----
+NULL
+
+# NULL mode falls back to the configured default (regex)
+query T
+SELECT anofox_tab_email_is_valid('user@example.com', NULL);
+----
+true
+
+# Unsupported mode: regex passes first, then stage becomes 'unsupported'
+query TTT
+SELECT (r).valid, (r).stage, (r).reason
+FROM (SELECT anofox_tab_email_validate('user@example.com', 'bogus-mode') AS r);
+----
+false	unsupported	validation_not_implemented
+
+# Unsupported mode with a regex failure reports the regex stage
+query TTT
+SELECT (r).valid, (r).stage, (r).reason
+FROM (SELECT anofox_tab_email_validate('not-an-email', 'bogus-mode') AS r);
+----
+false	regex	invalid_format
+
+# Struct shape pins for regex mode: empty mx_hosts and transcript lists
+query TTII
+SELECT (r).valid, (r).stage, len((r).mx_hosts), len((r).smtp_debug.transcript)
+FROM (SELECT anofox_tab_email_validate('user@example.com', 'regex') AS r);
+----
+true	regex	0	0
+
+# NULL email yields a NULL struct
+query T
+SELECT anofox_tab_email_validate(NULL) IS NULL;
+----
+true
+
+# Table-driven inputs with repeated values and mixed NULL pattern
+statement ok
+CREATE TABLE email_pin_inputs(email VARCHAR, mode VARCHAR);
+
+statement ok
+INSERT INTO email_pin_inputs VALUES
+    (NULL, 'regex'),
+    ('user@example.com', 'regex'),
+    ('user@example.com', 'regex'),
+    ('not-an-email', 'regex'),
+    ('', 'regex'),
+    ('other@example.com', NULL),
+    (NULL, NULL),
+    ('user@example.com', '  Regex ');
+
+query T
+SELECT anofox_tab_email_is_valid(email, mode) FROM email_pin_inputs;
+----
+NULL
+true
+true
+false
+false
+true
+NULL
+true
+
+# Mode passed as a column reference together with a constant email
+query T
+SELECT anofox_tab_email_is_valid('user@example.com', mode) FROM email_pin_inputs WHERE mode IS NOT NULL ORDER BY ALL;
+----
+true
+true
+true
+true
+true
+true
+
+statement ok
+DROP TABLE email_pin_inputs;
+
+# Large batch: 5000 generated addresses, alternating valid/invalid
+query II
+SELECT count(*) FILTER (WHERE ok), count(*) FILTER (WHERE NOT ok)
+FROM (
+    SELECT anofox_tab_email_is_valid(CASE WHEN i % 2 = 0 THEN 'user' || i || '@example.com' ELSE 'invalid-' || i END) AS ok
+    FROM range(5000) t(i)
+);
+----
+2500	2500
+
+# Large batch through email_validate (struct path)
+query I
+SELECT count(*) FILTER (WHERE (r).valid AND (r).stage = 'regex')
+FROM (SELECT anofox_tab_email_validate('user' || i || '@example.com', 'regex') AS r FROM range(5000) t(i));
+----
+5000
+
+# ============================================================================
+# VAT scalar functions
+# ============================================================================
+
+# Constant inputs across all VAT functions
+query T
+SELECT anofox_tab_vat('DE123456789');
+----
+{'country': DE, 'digits': 123456789}
+
+query T
+SELECT anofox_tab_vat_split('de 123-456-789');
+----
+{'country': DE, 'digits': 123456789}
+
+query T
+SELECT anofox_tab_vat_exists('DE123456789');
+----
+true
+
+query T
+SELECT anofox_tab_vat_exists('XX123456789');
+----
+false
+
+query T
+SELECT anofox_tab_vat_normalize('de 123.456-789');
+----
+DE123456789
+
+query T
+SELECT anofox_tab_is_valid_vat_country('DE');
+----
+true
+
+query T
+SELECT anofox_tab_is_valid_vat_country('XX');
+----
+false
+
+query T
+SELECT anofox_tab_vat_is_valid_syntax('DE123456789');
+----
+true
+
+query T
+SELECT anofox_tab_vat_is_valid_syntax('DE12345');
+----
+false
+
+query T
+SELECT anofox_tab_vat_is_valid('DE111111125');
+----
+true
+
+query T
+SELECT anofox_tab_vat_is_valid('DE111111124');
+----
+false
+
+# is_eu_member / country_name take 2-letter country codes; full VAT strings miss
+query TT
+SELECT anofox_tab_vat_is_eu_member('DE'), anofox_tab_vat_is_eu_member('DE123456789');
+----
+true	false
+
+query TT
+SELECT anofox_tab_vat_country_name('DE'), anofox_tab_vat_country_name('DE123456789') IS NULL;
+----
+Germany	true
+
+query T
+SELECT anofox_tab_vat_format('DE123456789', 'plain');
+----
+123456789
+
+query T
+SELECT anofox_tab_vat_format('GR123456789', 'iso');
+----
+EL123456789
+
+# Empty string handling
+query TTTT
+SELECT anofox_tab_vat(''), anofox_tab_vat_exists(''), anofox_tab_vat_normalize(''), anofox_tab_vat_is_valid('');
+----
+NULL	false	(empty)	false
+
+# NULL handling
+query TTTTT
+SELECT anofox_tab_vat(NULL), anofox_tab_vat_exists(NULL), anofox_tab_vat_normalize(NULL),
+       anofox_tab_vat_is_valid(NULL), anofox_tab_vat_country_name(NULL);
+----
+NULL	NULL	NULL	NULL	NULL
+
+query T
+SELECT anofox_tab_vat_format(NULL, 'plain');
+----
+NULL
+
+query T
+SELECT anofox_tab_vat_format('DE123456789', NULL);
+----
+NULL
+
+# Table-driven repeated values with leading/trailing NULLs
+statement ok
+CREATE TABLE vat_pin_inputs(v VARCHAR);
+
+statement ok
+INSERT INTO vat_pin_inputs VALUES
+    (NULL),
+    ('DE111111125'),
+    ('DE111111125'),
+    ('ATU13585627'),
+    (''),
+    ('XX123'),
+    ('DE111111124'),
+    (NULL);
+
+query T
+SELECT anofox_tab_vat_is_valid(v) FROM vat_pin_inputs;
+----
+NULL
+true
+true
+true
+false
+false
+false
+NULL
+
+statement ok
+DROP TABLE vat_pin_inputs;
+
+# Table-driven country codes with leading/trailing NULLs (country_name path)
+statement ok
+CREATE TABLE vat_country_inputs(c VARCHAR);
+
+statement ok
+INSERT INTO vat_country_inputs VALUES (NULL), ('DE'), ('DE'), ('at'), (''), ('XX'), (NULL);
+
+query T
+SELECT anofox_tab_vat_country_name(c) FROM vat_country_inputs;
+----
+NULL
+Germany
+Germany
+Austria
+NULL
+NULL
+NULL
+
+query T
+SELECT anofox_tab_vat_is_eu_member(c) FROM vat_country_inputs;
+----
+NULL
+true
+true
+true
+false
+false
+NULL
+
+statement ok
+DROP TABLE vat_country_inputs;
+
+# All-NULL column
+query I
+SELECT count(anofox_tab_vat_is_valid(v)) FROM (SELECT NULL::VARCHAR AS v FROM range(100)) t;
+----
+0
+
+# Large batch: syntax validation over generated VATs (9-digit numbers are valid DE syntax)
+query II
+SELECT count(*) FILTER (WHERE ok), count(*) FILTER (WHERE NOT ok)
+FROM (
+    SELECT anofox_tab_vat_is_valid_syntax(CASE WHEN i % 2 = 0 THEN 'DE' || (100000000 + i) ELSE 'DE12' END) AS ok
+    FROM range(5000) t(i)
+);
+----
+2500	2500
+
+# Large batch through the struct-returning path
+query I
+SELECT count(*) FROM (
+    SELECT anofox_tab_vat('DE' || (100000000 + i)) AS s FROM range(5000) t(i)
+) WHERE (s).country = 'DE';
+----
+5000
+
+# ============================================================================
+# MONEY scalar functions
+# ============================================================================
+
+# Constructors with constant inputs
+query T
+SELECT anofox_tab_money(19.99, 'USD');
+----
+{'amount': 19.990, 'currency': USD}
+
+# Lowercase currency codes are canonicalized
+query T
+SELECT anofox_tab_money(1.5, 'usd');
+----
+{'amount': 1.500, 'currency': USD}
+
+query T
+SELECT anofox_tab_money_from_cents(10050, 'USD');
+----
+{'amount': 100.500, 'currency': USD}
+
+query T
+SELECT anofox_tab_money_from_cents(1999, 'JPY');
+----
+{'amount': 1999.000, 'currency': JPY}
+
+# Accessors
+query II
+SELECT anofox_tab_money_amount(anofox_tab_money(19.99, 'USD')) = 19.99,
+       anofox_tab_money_currency(anofox_tab_money(19.99, 'USD')) = 'USD';
+----
+true	true
+
+# Arithmetic and comparisons
+query T
+SELECT anofox_tab_money_add(anofox_tab_money(10.00, 'USD'), anofox_tab_money(5.25, 'USD'));
+----
+{'amount': 15.250, 'currency': USD}
+
+query T
+SELECT anofox_tab_money_subtract(anofox_tab_money(10.00, 'USD'), anofox_tab_money(3.75, 'USD'));
+----
+{'amount': 6.250, 'currency': USD}
+
+query T
+SELECT anofox_tab_money_multiply(anofox_tab_money(10.00, 'USD'), 1.5);
+----
+{'amount': 15.000, 'currency': USD}
+
+query T
+SELECT anofox_tab_money_abs(anofox_tab_money(-19.99, 'USD'));
+----
+{'amount': 19.990, 'currency': USD}
+
+query TTT
+SELECT anofox_tab_money_is_positive(anofox_tab_money(1.0, 'USD')),
+       anofox_tab_money_is_negative(anofox_tab_money(-1.0, 'USD')),
+       anofox_tab_money_is_zero(anofox_tab_money(0.0, 'USD'));
+----
+true	true	true
+
+query TT
+SELECT anofox_tab_money_in_range(anofox_tab_money(15.00, 'USD'), 10.0, 20.0),
+       anofox_tab_money_in_range(anofox_tab_money(25.00, 'USD'), 10.0, 20.0);
+----
+true	false
+
+query TT
+SELECT anofox_tab_money_same_currency(anofox_tab_money(1.0, 'USD'), anofox_tab_money(2.0, 'USD')),
+       anofox_tab_money_same_currency(anofox_tab_money(1.0, 'USD'), anofox_tab_money(2.0, 'EUR'));
+----
+true	false
+
+# Mismatched currency arithmetic must raise
+statement error
+SELECT anofox_tab_money_add(anofox_tab_money(1.0, 'USD'), anofox_tab_money(1.0, 'EUR'));
+----
+different currencies
+
+# Currency utilities
+query TT
+SELECT anofox_tab_is_valid_currency('USD'), anofox_tab_is_valid_currency('XXX-NOT');
+----
+true	false
+
+query TT
+SELECT anofox_tab_currency_symbol('USD'), anofox_tab_currency_name('EUR');
+----
+$	Euro
+
+# Formatting styles
+query T
+SELECT anofox_tab_money_format(anofox_tab_money(1234.56, 'USD'), 'code');
+----
+1234.56 USD
+
+query T
+SELECT anofox_tab_money_format(anofox_tab_money(1234.56, 'USD'), 'symbol');
+----
+$1,234.56
+
+# NULL propagation
+query TTTT
+SELECT anofox_tab_money(NULL, 'USD') IS NULL,
+       anofox_tab_money(1.0, NULL) IS NULL,
+       anofox_tab_money_amount(NULL) IS NULL,
+       anofox_tab_money_currency(NULL) IS NULL;
+----
+true	true	true	true
+
+query TT
+SELECT anofox_tab_money_add(NULL, anofox_tab_money(1.0, 'USD')) IS NULL,
+       anofox_tab_money_format(anofox_tab_money(1.0, 'USD'), NULL) IS NULL;
+----
+true	true
+
+query TT
+SELECT anofox_tab_is_valid_currency(NULL), anofox_tab_currency_symbol(NULL);
+----
+NULL	NULL
+
+# Empty-string currency is rejected (not a silent fallback)
+statement error
+SELECT anofox_tab_money(1.0, '');
+----
+Invalid currency code
+
+# Table-driven repeated values with NULL pattern (dictionary-style inputs)
+statement ok
+CREATE TABLE money_pin_inputs(amount DOUBLE, code VARCHAR);
+
+statement ok
+INSERT INTO money_pin_inputs VALUES
+    (NULL, NULL),
+    (1.25, 'USD'),
+    (1.25, 'USD'),
+    (-3.50, 'EUR'),
+    (0.0, 'JPY'),
+    (NULL, 'USD'),
+    (2.00, NULL);
+
+query T
+SELECT anofox_tab_money(amount, code) FROM money_pin_inputs;
+----
+NULL
+{'amount': 1.250, 'currency': USD}
+{'amount': 1.250, 'currency': USD}
+{'amount': -3.500, 'currency': EUR}
+{'amount': 0.000, 'currency': JPY}
+NULL
+NULL
+
+query T
+SELECT anofox_tab_money_currency(anofox_tab_money(amount, code)) FROM money_pin_inputs;
+----
+NULL
+USD
+USD
+EUR
+JPY
+NULL
+NULL
+
+statement ok
+DROP TABLE money_pin_inputs;
+
+# Large batch: exact aggregate over 5000 constructed money values
+query I
+SELECT SUM(anofox_tab_money_amount(anofox_tab_money(0.10, 'USD'))) = 500.00 FROM range(5000);
+----
+true
+
+query I
+SELECT count(*) FROM (
+    SELECT anofox_tab_money_add(anofox_tab_money(i * 0.01, 'USD'), anofox_tab_money(1.0, 'USD')) AS m
+    FROM range(5000) t(i)
+) WHERE anofox_tab_money_currency(m) = 'USD';
+----
+5000
+
+query I
+SELECT count(*) FILTER (WHERE f LIKE '%USD')
+FROM (SELECT anofox_tab_money_format(anofox_tab_money(i * 1.0, 'USD'), 'code') AS f FROM range(5000) t(i));
+----
+5000
+
+# ============================================================================
+# PII scalar functions (detect family, mask/redact column)
+# ============================================================================
+
+# Constant input detection: full detect and typed variants
+query I
+SELECT (unnest(pii_detect('Contact: test@example.com'))).type;
+----
+EMAIL
+
+query II
+SELECT len(anofox_tab_pii_detect_emails('Contact: a@b.com')), len(anofox_tab_pii_detect_emails('no pii at all'));
+----
+1	0
+
+query I
+SELECT (unnest(anofox_tab_pii_detect_emails('Contact: a@b.com'))).type;
+----
+EMAIL
+
+# Struct field fidelity for the typed detect path
+query IIII
+SELECT m.type, m.text, m.start_pos, m.end_pos
+FROM (SELECT unnest(anofox_tab_pii_detect_emails('Contact: john.doe@example.com')) AS m);
+----
+EMAIL	john.doe@example.com	9	29
+
+query I
+SELECT len(anofox_tab_pii_detect_phones('Call +14155551234 now'));
+----
+1
+
+query I
+SELECT len(anofox_tab_pii_detect_credit_cards('Card: 4111111111111111'));
+----
+1
+
+query I
+SELECT m.type FROM (SELECT unnest(anofox_tab_pii_detect_ssns('SSN: 123-45-6789')) AS m) WHERE m.type = 'US_SSN';
+----
+US_SSN
+
+query I
+SELECT len(anofox_tab_pii_detect_ibans('IBAN: DE89370400440532013000'));
+----
+1
+
+# Empty string inputs return empty lists (not NULL)
+query IIII
+SELECT len(anofox_tab_pii_detect_emails('')), len(anofox_tab_pii_detect_phones('')),
+       len(anofox_tab_pii_detect_ssns('')), len(pii_detect(''));
+----
+0	0	0	0
+
+# NULL inputs return NULL
+query TTT
+SELECT anofox_tab_pii_detect_emails(NULL) IS NULL,
+       anofox_tab_pii_detect_names(NULL) IS NULL,
+       pii_detect(NULL) IS NULL;
+----
+true	true	true
+
+# Table-driven mixed NULL/repeated inputs through the typed detect path
+statement ok
+CREATE TABLE pii_pin_inputs(t VARCHAR);
+
+statement ok
+INSERT INTO pii_pin_inputs VALUES
+    (NULL),
+    ('mail me: x@y.com'),
+    ('mail me: x@y.com'),
+    (''),
+    ('nothing here'),
+    (NULL);
+
+query I
+SELECT len(anofox_tab_pii_detect_emails(t)) FROM pii_pin_inputs;
+----
+NULL
+1
+1
+0
+0
+NULL
+
+query T
+SELECT pii_detect(t) IS NULL FROM pii_pin_inputs;
+----
+true
+false
+false
+false
+false
+true
+
+statement ok
+DROP TABLE pii_pin_inputs;
+
+# Mask column functions: constant type/strategy arguments
+query I
+SELECT anofox_tab_pii_mask_column('SSN: 123-45-6789', 'US_SSN', 'redact') LIKE '%[US_SSN]%';
+----
+true
+
+# No match of the requested type: original text is returned unchanged
+query T
+SELECT anofox_tab_pii_mask_column('Email: test@example.com', 'US_SSN', 'redact');
+----
+Email: test@example.com
+
+query I
+SELECT anofox_tab_pii_redact_column('Email: test@example.com', 'redact') LIKE '%[EMAIL]%';
+----
+true
+
+query I
+SELECT anofox_tab_pii_redact_column('Email: test@example.com') LIKE '%[EMAIL]%';
+----
+true
+
+# NULL text propagates through mask/redact
+query TTT
+SELECT anofox_tab_pii_mask_column(NULL, 'US_SSN', 'redact') IS NULL,
+       anofox_tab_pii_redact_column(NULL, 'redact') IS NULL,
+       anofox_tab_pii_redact_column(NULL) IS NULL;
+----
+true	true	true
+
+# Empty string stays empty
+query TT
+SELECT anofox_tab_pii_mask_column('', 'US_SSN', 'redact') = '',
+       anofox_tab_pii_redact_column('', 'redact') = '';
+----
+true	true
+
+# Unknown PII type raises
+statement error
+SELECT anofox_tab_pii_mask_column('text', 'NOT_A_TYPE', 'redact');
+----
+Unknown PII type
+
+# Table-driven mask inputs with NULL pattern
+statement ok
+CREATE TABLE pii_mask_inputs(t VARCHAR);
+
+statement ok
+INSERT INTO pii_mask_inputs VALUES
+    (NULL),
+    ('SSN: 123-45-6789'),
+    ('no pii'),
+    (''),
+    ('SSN: 123-45-6789'),
+    (NULL);
+
+query T
+SELECT anofox_tab_pii_mask_column(t, 'US_SSN', 'redact') FROM pii_mask_inputs;
+----
+NULL
+SSN: [US_SSN]
+no pii
+(empty)
+SSN: [US_SSN]
+NULL
+
+# redact_column masks all PII types (NER may add more matches than the SSN),
+# so pin the SSN replacement and NULL/empty propagation rather than exact text.
+query TT
+SELECT anofox_tab_pii_redact_column(t, 'redact') IS NULL,
+       coalesce(anofox_tab_pii_redact_column(t, 'redact') LIKE '%[US_SSN]%', false)
+FROM pii_mask_inputs;
+----
+true	false
+false	true
+false	false
+false	false
+false	true
+true	false
+
+statement ok
+DROP TABLE pii_mask_inputs;
+
+# Large batch through the typed detect path: alternating hit/miss over 5000 rows
+query II
+SELECT count(*) FILTER (WHERE n = 1), count(*) FILTER (WHERE n = 0)
+FROM (
+    SELECT len(anofox_tab_pii_detect_emails(CASE WHEN i % 2 = 0 THEN 'user' || i || '@example.com' ELSE 'row ' || i END)) AS n
+    FROM range(5000) t(i)
+);
+----
+2500	2500
+
+# Large batch through mask_column
+query I
+SELECT count(*) FILTER (WHERE m LIKE '%[US_SSN]%')
+FROM (SELECT anofox_tab_pii_mask_column('SSN: 123-45-6789 row ' || i, 'US_SSN', 'redact') AS m FROM range(5000) t(i));
+----
+5000


### PR DESCRIPTION
Closes #58.

> **Note:** this PR builds on `integration/code-quality-2026-06` (the integration of PRs #62–#78). It should be rebased/retargeted onto `main` once those merge.

## Scope

Sweep over the SCALAR function row loops flagged by the 2026-06 review (theme T3), eliminating per-row work that belongs at chunk or registry level. Several findings were already addressed on the integration base (money uses `UnifiedVectorFormat`, phonenumber/vat precompile regexes, `pii_contains`/`pii_count`/`pii_mask` already use executors) — those were left untouched.

### What changed

**Email** (`src/anofox_email.cpp`)
- `email_is_valid`/`email_validate` no longer call `args.GetValue()` per row and no longer re-run `ToUnifiedFormat` on the mode vector for every row; inputs are normalized once per chunk.
- The mode argument is parsed once when it is a constant vector (literal or absent — the common case); the configured default and the compiled regex (both mutex-guarded singleton reads) are hoisted out of the row loops.
- The email is passed down as `string_view`; per-row trace string construction is guarded behind `ShouldLog`.
- `mx_hosts`/`smtp_debug.transcript` are appended via `ListVector::Reserve` + direct child writes instead of `ListVector::PushBack(Value)`.

**VAT** (`src/include/anofox_vat.hpp`, `src/anofox_vat*.cpp`)
- The generic iterators pass `std::string_view` into the row lambdas instead of copying every `string_t` to `std::string`; the registry entry points used per row take `string_view`, so allocations only happen where normalization actually produces a new string.
- `vat_format` compares the style case-insensitively via `StringUtil::CIEquals` instead of allocating a lowercased copy per row.

**Money** (`src/include/anofox_money.hpp`, `src/anofox_money.cpp`)
- `SetMoneyResult` no longer calls `StructVector::GetEntries` per row — the builder carries the currency child vector.
- `MoneyStructData::Currency` returns `string_t` (a view) instead of a `std::string` copy; same-currency checks compare views via `StringUtil::CIEquals`.

**Postal** (`src/anofox_postal.cpp`, `src/include/anofox_postal.hpp`)
- `ParseAddress`/`ExpandAddress` hand the raw libpostal arrays to a visitor; component values and expansions are written straight into DuckDB vectors — the intermediate `std::vector<PostalComponent>`/`std::vector<std::string>` and all per-row `Vector::SetValue(Value)`/`ListVector::PushBack(Value)` calls are gone. libpostal responses are released via RAII on every exit path.
- Verified manually against the local libpostal data bundle: parse/expand output is byte-identical to the pre-refactor build (the data-dependent SQL tests remain disabled as before).

**PII** (`src/anofox_pii.cpp`)
- New shared `ExecutePIIDetectToList` used by `pii_detect` and all six typed detect functions: input normalized once per chunk, matches written directly into the `LIST(STRUCT)` child vectors (`ListVector::Reserve` + `FlatVector` writes) instead of per-row `Value::LIST` construction. The dead, never-registered `PIIDetectTypeFunction` template was removed.
- `pii_mask_column` / `pii_redact_column` (both overloads) use `UnaryExecutor` instead of per-row `GetValue`/`SetValue`; `pii_mask_column` also drops a redundant second detection pass (`Mask` already returns the original text when nothing matches).
- `pii_detect_batch` intentionally stays `Value`-based: its nested `LIST(LIST(STRUCT))` output is inherently row-structured and it exists for NER cache pre-warming, not throughput.

## TDD: behavior pinned first

Commit 1 (`test: pin scalar function behavior…`) adds `test/sql/anofox_vectorization_pins.test` — 220+ assertions covering, for every refactored function: constant-vector inputs, dictionary-style repeated table inputs, NULL patterns (leading/trailing/all-NULL/mixed), empty strings, and `range(5000)` batches checked via aggregate counts. These were green on the unrefactored base before any source change (see commit order) and stay green after each per-module commit. Writing the pins also surfaced that the email config singleton leaks across test files, so the pins restore the email defaults explicitly.

## Micro-benchmarks

Back-to-back on the same machine under identical load, best of 3 (`.timer on`, telemetry disabled); indicative only:

| Query | rows | before | after | Δ real |
|---|---|---|---|---|
| `email_is_valid(…, 'regex')` | 1M | 6.98s | 5.91s | −15% |
| `email_validate(…, 'regex').valid` | 500k | 3.71s | 3.61s | −3% |
| `vat_is_valid(…)` | 1M | 0.78s | 0.72s | −7% |
| `vat_normalize(…)` | 1M | 0.178s | 0.172s | −3% |
| `money(…)` → `money_add` → `money_currency` | 1M | 0.195s | 0.153s | −22% |
| `money_format(money(…), 'code')` | 1M | 0.366s | 0.347s | −5% |
| `pii_detect_emails(…)` | 200k | 0.943s | 0.443s | **−53% (2.1×)** |
| `pii_mask_column(…, 'US_SSN', 'redact')` | 200k | 3.20s | 1.57s | **−51% (2×)** |

## Test status

- SQL: `make test` — 2692 assertions in 37 test cases, all green (3 skips: OpenVINO env + disabled postal data tests, pre-existing)
- C++: `unittest "test/cpp/*"` 243 assertions / 9 cases; standalone `anofox_tabular_cpp_tests` 1085 assertions / 14 cases — all green
- Python: 253 passed