### PR TITLE
perf: stream table function output, vectorized input reads

### DIFF
--- a/src/anofox_metric.cpp
+++ b/src/anofox_metric.cpp
@@ -10,6 +10,7 @@
 #include "duckdb/parser/tableref/subqueryref.hpp"
 #include "duckdb/common/exception.hpp"
 #include "duckdb/common/string_util.hpp"
+#include "duckdb/common/types/vector.hpp"
 #include "duckdb/main/connection.hpp"
 #include "duckdb/main/client_context.hpp"
 #include <algorithm>
@@ -443,14 +444,6 @@ static unique_ptr<TableRef> MetricFreshnessBindReplace(ClientContext &context, T
 // Isolation Forest Table Function - Actual C++ Execution
 //===--------------------------------------------------------------------===//
 
-// Result structure for isolation forest
-struct IsolationForestResult {
-	int64_t row_id;
-	double value;  // For univariate - single value; for multivariate - unused
-	double anomaly_score;
-	bool is_anomaly;
-};
-
 // Bind data for isolation forest table function (immutable after bind)
 struct IsolationForestBindData : public TableFunctionData {
 	string table_name;
@@ -490,8 +483,13 @@ struct IsolationForestGlobalState : public GlobalTableFunctionState {
 	bool executed = false;
 	idx_t current_row = 0;
 
-	// Results computed during execution (stored here because bind_data is const)
-	std::vector<IsolationForestResult> results;
+	// Model outputs computed during execution (stored here because bind_data
+	// is const). The scores from the fitted model are kept once and emitted
+	// incrementally; row ids and anomaly flags are derived during emission
+	// instead of buffering a duplicate per-row result vector.
+	std::vector<double> scores;
+	std::vector<double> first_column_values;  // univariate numeric path only ("value" output column)
+	double threshold = 0.0;
 	int64_t total_count = 0;
 	int64_t outlier_count = 0;
 	double avg_value = 0.0;
@@ -783,7 +781,10 @@ static void IsolationForestExecute(ClientContext &context, TableFunctionInput &d
 
 		string query = "SELECT " + column_list + " FROM " + BuildQueryTableRef(bind_data.table_name) + " WHERE " + null_checks;
 
-		auto result = con.Query(query);
+		// Stream the input instead of materializing the full result; model
+		// fitting requires the complete dataset, so the feature columns built
+		// below are the only full copy that is kept.
+		auto result = con.SendQuery(query);
 		if (result->HasError()) {
 			throw InvalidInputException("Failed to query source table: %s", result->GetError());
 		}
@@ -825,17 +826,24 @@ static void IsolationForestExecute(ClientContext &context, TableFunctionInput &d
 			double sum_first_col = 0.0;
 			std::vector<double> sample_weights;  // Collected during data fetch if weight column provided
 
-			// Read data and build category mappings
-			// Weight column (if present) is the last column in the result
+			// Read data and build category mappings, reading chunks through
+			// UnifiedVectorFormat typed accessors. The weight column (if
+			// present) is the last column in the result.
+			std::vector<UnifiedVectorFormat> formats;
 			while (true) {
 				auto chunk = result->Fetch();
 				if (!chunk || chunk->size() == 0) break;
 
+				const idx_t chunk_cols = chunk->ColumnCount();
+				formats.resize(chunk_cols);
+				for (idx_t col = 0; col < chunk_cols; ++col) {
+					chunk->data[col].ToUnifiedFormat(chunk->size(), formats[col]);
+				}
+
 				for (idx_t row = 0; row < chunk->size(); ++row) {
 					bool valid_row = true;
-					for (idx_t col = 0; col < chunk->ColumnCount(); ++col) {
-						auto val = chunk->GetValue(col, row);
-						if (val.IsNull()) {
+					for (idx_t col = 0; col < chunk_cols; ++col) {
+						if (!formats[col].validity.RowIsValid(formats[col].sel->get_index(row))) {
 							valid_row = false;
 							break;
 						}
@@ -844,13 +852,13 @@ static void IsolationForestExecute(ClientContext &context, TableFunctionInput &d
 
 					// Process feature columns (not including weight column)
 					for (idx_t col = 0; col < bind_data.column_names.size(); ++col) {
-						auto val = chunk->GetValue(col, row);
+						auto idx = formats[col].sel->get_index(row);
 						if (is_categorical[col]) {
-							string cat_val = val.ToString();
+							string cat_val = UnifiedVectorFormat::GetData<string_t>(formats[col])[idx].GetString();
 							int cat_idx = column_info[col].AddCategory(cat_val);
 							data[col].category_indices.push_back(cat_idx);
 						} else {
-							double num_val = val.GetValue<double>();
+							double num_val = UnifiedVectorFormat::GetData<double>(formats[col])[idx];
 							data[col].numeric_values.push_back(num_val);
 							if (col == 0 && !bind_data.is_multivariate) {
 								sum_first_col += num_val;
@@ -860,10 +868,13 @@ static void IsolationForestExecute(ClientContext &context, TableFunctionInput &d
 
 					// Extract weight value if weight column is present (last column in result)
 					if (bind_data.has_weight_column) {
-						auto weight_val = chunk->GetValue(weight_col_idx, row);
-						sample_weights.push_back(weight_val.GetValue<double>());
+						auto idx = formats[weight_col_idx].sel->get_index(row);
+						sample_weights.push_back(UnifiedVectorFormat::GetData<double>(formats[weight_col_idx])[idx]);
 					}
 				}
+			}
+			if (result->HasError()) {
+				throw InvalidInputException("Failed to query source table: %s", result->GetError());
 			}
 
 			size_t n_rows = data.empty() ? 0 : data[0].size();
@@ -883,54 +894,53 @@ static void IsolationForestExecute(ClientContext &context, TableFunctionInput &d
 				// sample_weights was already collected during data fetch (guarantees correct row alignment)
 				forest.FitMixed(data, column_info, sample_weights);
 
-				// Score all points
-				std::vector<double> scores = forest.ScoreBatchMixed(data);
-
-				// Compute threshold based on contamination
-				double threshold = forest.ComputeThreshold(scores);
-
-				// Build results
-				state.results.reserve(n_rows);
-				state.outlier_count = 0;
-
-				for (size_t i = 0; i < n_rows; ++i) {
-					IsolationForestResult res;
-					res.row_id = static_cast<int64_t>(i + 1);  // 1-indexed
-					res.value = 0.0;  // Not applicable for mixed-type
-					res.anomaly_score = scores[i];
-					res.is_anomaly = scores[i] > threshold;
-					if (res.is_anomaly) {
-						state.outlier_count++;
-					}
-					state.results.push_back(res);
-				}
+				// Score all points directly into the state; row ids and
+				// anomaly flags are derived during emission
+				state.scores = forest.ScoreBatchMixed(data);
+				state.threshold = forest.ComputeThreshold(state.scores);
+				state.outlier_count = static_cast<int64_t>(std::count_if(
+				    state.scores.begin(), state.scores.end(), [&](double s) { return s > state.threshold; }));
 			}
 		} else {
 			// Numeric-only path: use original vector<vector<double>> format
 			std::vector<std::vector<double>> data;
 			double sum_first_col = 0.0;
 
+			std::vector<UnifiedVectorFormat> formats;
 			while (true) {
 				auto chunk = result->Fetch();
 				if (!chunk || chunk->size() == 0) break;
 
+				const idx_t chunk_cols = chunk->ColumnCount();
+				formats.resize(chunk_cols);
+				for (idx_t col = 0; col < chunk_cols; ++col) {
+					chunk->data[col].ToUnifiedFormat(chunk->size(), formats[col]);
+				}
+
 				for (idx_t row = 0; row < chunk->size(); ++row) {
-					std::vector<double> point;
-					for (idx_t col = 0; col < chunk->ColumnCount(); ++col) {
-						auto val = chunk->GetValue(col, row);
-						if (val.IsNull()) {
-							point.clear();
+					bool valid_row = true;
+					for (idx_t col = 0; col < chunk_cols; ++col) {
+						if (!formats[col].validity.RowIsValid(formats[col].sel->get_index(row))) {
+							valid_row = false;
 							break;
 						}
-						point.push_back(val.GetValue<double>());
 					}
-					if (!point.empty()) {
-						if (!bind_data.is_multivariate) {
-							sum_first_col += point[0];
-						}
-						data.push_back(std::move(point));
+					if (!valid_row) continue;
+
+					std::vector<double> point(chunk_cols);
+					for (idx_t col = 0; col < chunk_cols; ++col) {
+						point[col] = UnifiedVectorFormat::GetData<double>(formats[col])[formats[col].sel->get_index(row)];
 					}
+					if (!bind_data.is_multivariate) {
+						sum_first_col += point[0];
+						// Retain the raw input values for the "value" output column
+						state.first_column_values.push_back(point[0]);
+					}
+					data.push_back(std::move(point));
 				}
+			}
+			if (result->HasError()) {
+				throw InvalidInputException("Failed to query source table: %s", result->GetError());
 			}
 
 			state.total_count = static_cast<int64_t>(data.size());
@@ -947,52 +957,42 @@ static void IsolationForestExecute(ClientContext &context, TableFunctionInput &d
 				                       bind_data.ntry, bind_data.prob_pick_avg_gain);
 				forest.Fit(data);
 
-				// Score all points
-				std::vector<double> scores = forest.ScoreBatch(data);
-
-				// Compute threshold based on contamination
-				double threshold = forest.ComputeThreshold(scores);
-
-				// Build results
-				state.results.reserve(data.size());
-				state.outlier_count = 0;
-
-				for (size_t i = 0; i < data.size(); ++i) {
-					IsolationForestResult res;
-					res.row_id = static_cast<int64_t>(i + 1);  // 1-indexed
-					res.value = bind_data.is_multivariate ? 0.0 : data[i][0];
-					res.anomaly_score = scores[i];
-					res.is_anomaly = scores[i] > threshold;
-					if (res.is_anomaly) {
-						state.outlier_count++;
-					}
-					state.results.push_back(res);
-				}
+				// Score all points directly into the state; row ids and
+				// anomaly flags are derived during emission
+				state.scores = forest.ScoreBatch(data);
+				state.threshold = forest.ComputeThreshold(state.scores);
+				state.outlier_count = static_cast<int64_t>(std::count_if(
+				    state.scores.begin(), state.scores.end(), [&](double s) { return s > state.threshold; }));
 			}
 		}
 	}
 
-	// Output results
+	// Output results, streamed chunk-wise from the scores held in the state
 	if (bind_data.output_mode == "scores") {
 		// Scores mode - return individual rows
-		idx_t count = 0;
-		idx_t max_count = STANDARD_VECTOR_SIZE;
-
-		while (state.current_row < state.results.size() && count < max_count) {
-			auto &res = state.results[state.current_row];
-			output.SetValue(0, count, Value::BIGINT(res.row_id));
-			if (!bind_data.is_multivariate) {
-				output.SetValue(1, count, Value::DOUBLE(res.value));
-				output.SetValue(2, count, Value::DOUBLE(res.anomaly_score));
-				output.SetValue(3, count, Value::BOOLEAN(res.is_anomaly));
-			} else {
-				output.SetValue(1, count, Value::DOUBLE(res.anomaly_score));
-				output.SetValue(2, count, Value::BOOLEAN(res.is_anomaly));
-			}
-			state.current_row++;
-			count++;
-		}
+		idx_t count = MinValue<idx_t>(state.scores.size() - state.current_row, STANDARD_VECTOR_SIZE);
 		output.SetCardinality(count);
+
+		auto row_ids = FlatVector::GetData<int64_t>(output.data[0]);
+		idx_t col = 1;
+		double *values = nullptr;
+		if (!bind_data.is_multivariate) {
+			values = FlatVector::GetData<double>(output.data[col++]);
+		}
+		auto anomaly_scores = FlatVector::GetData<double>(output.data[col++]);
+		auto is_anomaly = FlatVector::GetData<bool>(output.data[col]);
+
+		for (idx_t i = 0; i < count; ++i) {
+			idx_t r = state.current_row + i;
+			row_ids[i] = static_cast<int64_t>(r + 1);  // 1-indexed
+			if (values) {
+				// Mixed-type univariate input has no numeric first column; it reports 0.0
+				values[i] = r < state.first_column_values.size() ? state.first_column_values[r] : 0.0;
+			}
+			anomaly_scores[i] = state.scores[r];
+			is_anomaly[i] = state.scores[r] > state.threshold;
+		}
+		state.current_row += count;
 	} else {
 		// Summary mode - return single row
 		if (state.current_row == 0) {
@@ -1214,36 +1214,52 @@ static void DBSCANExecute(ClientContext &context, TableFunctionInput &data_p, Da
 		string query = "SELECT " + column_list + " FROM " + BuildQueryTableRef(bind_data.table_name) + " WHERE " +
 		               null_checks;
 
-		auto result = con.Query(query);
+		// Stream the input instead of materializing the full result; the
+		// clustering algorithm requires the complete dataset, so the feature
+		// matrix built below is the only full copy that is kept.
+		auto result = con.SendQuery(query);
 		if (result->HasError()) {
 			throw InvalidInputException("Failed to query source table: %s", result->GetError());
 		}
 
 		std::vector<std::vector<double>> data;
+		std::vector<UnifiedVectorFormat> formats;
 		while (true) {
 			auto chunk = result->Fetch();
 			if (!chunk || chunk->size() == 0) {
 				break;
 			}
+
+			const idx_t chunk_cols = chunk->ColumnCount();
+			formats.resize(chunk_cols);
+			for (idx_t col = 0; col < chunk_cols; ++col) {
+				chunk->data[col].ToUnifiedFormat(chunk->size(), formats[col]);
+			}
+
 			for (idx_t row = 0; row < chunk->size(); ++row) {
-				std::vector<double> point;
-				point.reserve(chunk->ColumnCount());
 				bool valid_row = true;
-				for (idx_t col = 0; col < chunk->ColumnCount(); ++col) {
-					auto val = chunk->GetValue(col, row);
-					if (val.IsNull()) {
+				for (idx_t col = 0; col < chunk_cols; ++col) {
+					if (!formats[col].validity.RowIsValid(formats[col].sel->get_index(row))) {
 						valid_row = false;
 						break;
 					}
-					point.push_back(val.GetValue<double>());
 				}
-				if (valid_row) {
-					if (!bind_data.is_multivariate) {
-						state.first_column_values.push_back(point[0]);
-					}
-					data.push_back(std::move(point));
+				if (!valid_row) {
+					continue;
 				}
+
+				std::vector<double> point(chunk_cols);
+				for (idx_t col = 0; col < chunk_cols; ++col) {
+					point[col] = UnifiedVectorFormat::GetData<double>(formats[col])[formats[col].sel->get_index(row)];
+				}
+				if (!bind_data.is_multivariate) {
+					state.first_column_values.push_back(point[0]);
+				}
+				data.push_back(std::move(point));
 			}
+		}
+		if (result->HasError()) {
+			throw InvalidInputException("Failed to query source table: %s", result->GetError());
 		}
 
 		state.total_count = static_cast<int64_t>(data.size());
@@ -1265,26 +1281,39 @@ static void DBSCANExecute(ClientContext &context, TableFunctionInput &data_p, Da
 		                                       " noise=" + std::to_string(state.noise_count));
 	}
 
-	// Output results
+	// Output results, streamed chunk-wise from the clustering results
 	if (bind_data.output_mode == "clusters") {
 		// Clusters mode - return one row per input point
-		idx_t count = 0;
-		while (state.current_row < state.points.size() && count < STANDARD_VECTOR_SIZE) {
-			auto &pt = state.points[state.current_row];
-			idx_t col = 0;
-			output.SetValue(col++, count, Value::BIGINT(static_cast<int64_t>(state.current_row + 1))); // 1-indexed
-			if (!bind_data.is_multivariate) {
-				output.SetValue(col++, count, Value::DOUBLE(state.first_column_values[state.current_row]));
-			}
-			output.SetValue(col++, count, Value::INTEGER(pt.cluster_id));
-			output.SetValue(col++, count, Value(DBSCANPointTypeToString(pt.point_type)));
-			output.SetValue(col++, count, Value::BIGINT(static_cast<int64_t>(pt.neighbor_count)));
-			output.SetValue(col++, count, Value::DOUBLE(state.anomaly_scores[state.current_row]));
-			output.SetValue(col++, count, Value::BOOLEAN(pt.cluster_id == -1));
-			state.current_row++;
-			count++;
-		}
+		idx_t count = MinValue<idx_t>(state.points.size() - state.current_row, STANDARD_VECTOR_SIZE);
 		output.SetCardinality(count);
+
+		idx_t col = 0;
+		auto row_ids = FlatVector::GetData<int64_t>(output.data[col++]);
+		double *values = nullptr;
+		if (!bind_data.is_multivariate) {
+			values = FlatVector::GetData<double>(output.data[col++]);
+		}
+		auto cluster_ids = FlatVector::GetData<int32_t>(output.data[col++]);
+		auto &point_type_vec = output.data[col];
+		auto point_types = FlatVector::GetData<string_t>(output.data[col++]);
+		auto neighbor_counts = FlatVector::GetData<int64_t>(output.data[col++]);
+		auto anomaly_scores = FlatVector::GetData<double>(output.data[col++]);
+		auto is_anomaly = FlatVector::GetData<bool>(output.data[col]);
+
+		for (idx_t i = 0; i < count; ++i) {
+			idx_t r = state.current_row + i;
+			auto &pt = state.points[r];
+			row_ids[i] = static_cast<int64_t>(r + 1);  // 1-indexed
+			if (values) {
+				values[i] = state.first_column_values[r];
+			}
+			cluster_ids[i] = pt.cluster_id;
+			point_types[i] = StringVector::AddString(point_type_vec, DBSCANPointTypeToString(pt.point_type));
+			neighbor_counts[i] = static_cast<int64_t>(pt.neighbor_count);
+			anomaly_scores[i] = state.anomaly_scores[r];
+			is_anomaly[i] = pt.cluster_id == -1;
+		}
+		state.current_row += count;
 	} else {
 		// Summary mode - return single row
 		if (state.current_row == 0) {

--- a/src/anofox_outlier_tree.cpp
+++ b/src/anofox_outlier_tree.cpp
@@ -3,6 +3,7 @@
 #include "anofox_sql_utils.hpp"
 #include "telemetry.hpp"
 #include "anofox_trace.hpp"
+#include "duckdb/common/types/vector.hpp"
 #include "duckdb/function/table_function.hpp"
 #include "duckdb/main/connection.hpp"
 #include "duckdb/main/client_context.hpp"
@@ -917,73 +918,97 @@ static void OutlierTreeExecute(ClientContext &context, TableFunctionInput &data_
 
         Connection con(*context.db);
 
-        // Build query to fetch data
-        std::string column_list;
-        for (size_t i = 0; i < bind_data.column_names.size(); ++i) {
-            if (i > 0) column_list += ", ";
-            column_list += QuoteSqlIdentifier(bind_data.column_names[i]);
+        // Detect column types first (LIMIT 0 only binds the query), so the
+        // data query below can cast every column to a known type
+        const idx_t n_cols = bind_data.column_names.size();
+        std::vector<ColumnInfo> column_info(n_cols);
+        std::vector<ColumnData> data(n_cols);
+
+        {
+            std::string raw_column_list;
+            for (size_t i = 0; i < n_cols; ++i) {
+                if (i > 0) raw_column_list += ", ";
+                raw_column_list += QuoteSqlIdentifier(bind_data.column_names[i]);
+            }
+            std::string type_query = "SELECT " + raw_column_list + " FROM " +
+                                     BuildQueryTableRef(bind_data.table_name) + " LIMIT 0";
+            auto type_result = con.Query(type_query);
+            if (type_result->HasError()) {
+                throw InvalidInputException("Failed to query source table: %s", type_result->GetError());
+            }
+            for (size_t i = 0; i < n_cols; ++i) {
+                auto col_type = type_result->types[i].id();
+                if (col_type == LogicalTypeId::VARCHAR || col_type == LogicalTypeId::ENUM) {
+                    column_info[i].type = FeatureType::CATEGORICAL;
+                    data[i].type = FeatureType::CATEGORICAL;
+                } else {
+                    column_info[i].type = FeatureType::NUMERIC;
+                    data[i].type = FeatureType::NUMERIC;
+                }
+                column_info[i].name = bind_data.column_names[i];
+            }
         }
 
+        // Build the data query: categorical columns as VARCHAR, numeric
+        // columns as DOUBLE, so chunks can be read through typed accessors
+        std::string column_list;
+        for (size_t i = 0; i < n_cols; ++i) {
+            if (i > 0) column_list += ", ";
+            column_list += "CAST(" + QuoteSqlIdentifier(bind_data.column_names[i]) +
+                           (column_info[i].type == FeatureType::CATEGORICAL ? " AS VARCHAR)" : " AS DOUBLE)");
+        }
         std::string query = "SELECT " + column_list + " FROM " + BuildQueryTableRef(bind_data.table_name);
 
-        auto result = con.Query(query);
+        // Stream the input instead of materializing the full result; the
+        // algorithm itself requires the complete dataset for tree fitting,
+        // so this is the only full copy that is kept.
+        auto result = con.SendQuery(query);
         if (result->HasError()) {
             throw InvalidInputException("Failed to query source table: %s", result->GetError());
-        }
-
-        // Detect column types and build column info
-        std::vector<ColumnInfo> column_info(bind_data.column_names.size());
-        std::vector<ColumnData> data(bind_data.column_names.size());
-
-        for (size_t i = 0; i < bind_data.column_names.size(); ++i) {
-            auto col_type = result->types[i].id();
-            if (col_type == LogicalTypeId::VARCHAR || col_type == LogicalTypeId::ENUM) {
-                column_info[i].type = FeatureType::CATEGORICAL;
-                data[i].type = FeatureType::CATEGORICAL;
-            } else {
-                column_info[i].type = FeatureType::NUMERIC;
-                data[i].type = FeatureType::NUMERIC;
-            }
-            column_info[i].name = bind_data.column_names[i];
         }
 
         // Read data; rows containing NULL in any selected column are skipped,
         // but their source positions are preserved for row id reporting.
         int64_t source_row = 0;
+        std::vector<UnifiedVectorFormat> formats(n_cols);
         while (true) {
             auto chunk = result->Fetch();
             if (!chunk || chunk->size() == 0) break;
 
+            for (idx_t col = 0; col < n_cols; ++col) {
+                chunk->data[col].ToUnifiedFormat(chunk->size(), formats[col]);
+            }
+
             for (idx_t row = 0; row < chunk->size(); ++row) {
                 source_row++;
-                bool valid_row = true;
 
                 // Check for NULLs
-                for (idx_t col = 0; col < chunk->ColumnCount(); ++col) {
-                    auto val = chunk->GetValue(col, row);
-                    if (val.IsNull()) {
+                bool valid_row = true;
+                for (idx_t col = 0; col < n_cols; ++col) {
+                    if (!formats[col].validity.RowIsValid(formats[col].sel->get_index(row))) {
                         valid_row = false;
                         break;
                     }
                 }
-
                 if (!valid_row) continue;
 
                 state.source_row_ids.push_back(source_row);
 
                 // Add values to data structures
-                for (idx_t col = 0; col < chunk->ColumnCount(); ++col) {
-                    auto val = chunk->GetValue(col, row);
+                for (idx_t col = 0; col < n_cols; ++col) {
+                    auto idx = formats[col].sel->get_index(row);
                     if (column_info[col].type == FeatureType::CATEGORICAL) {
-                        std::string cat_val = val.ToString();
+                        std::string cat_val = UnifiedVectorFormat::GetData<string_t>(formats[col])[idx].GetString();
                         int cat_idx = column_info[col].AddCategory(cat_val);
                         data[col].category_indices.push_back(cat_idx);
                     } else {
-                        double num_val = val.GetValue<double>();
-                        data[col].numeric_values.push_back(num_val);
+                        data[col].numeric_values.push_back(UnifiedVectorFormat::GetData<double>(formats[col])[idx]);
                     }
                 }
             }
+        }
+        if (result->HasError()) {
+            throw InvalidInputException("Failed to query source table: %s", result->GetError());
         }
 
         // total_rows counts the analyzed rows, i.e. rows that are non-NULL in
@@ -1000,33 +1025,43 @@ static void OutlierTreeExecute(ClientContext &context, TableFunctionInput &data_
         }
     }
 
-    // Output results
+    // Output results, streamed chunk-wise from the computed explanations
     if (bind_data.output_mode == "outliers") {
-        idx_t count = 0;
-        idx_t max_count = STANDARD_VECTOR_SIZE;
+        idx_t count = MinValue<idx_t>(state.outliers.size() - state.current_row, STANDARD_VECTOR_SIZE);
+        output.SetCardinality(count);
 
-        while (state.current_row < state.outliers.size() && count < max_count) {
-            auto &outlier = state.outliers[state.current_row];
+        auto row_ids = FlatVector::GetData<int64_t>(output.data[0]);
+        auto column_names = FlatVector::GetData<string_t>(output.data[1]);
+        auto outlier_values = FlatVector::GetData<string_t>(output.data[2]);
+        auto cluster_means = FlatVector::GetData<double>(output.data[3]);
+        auto cluster_sds = FlatVector::GetData<double>(output.data[4]);
+        auto cluster_sizes = FlatVector::GetData<int64_t>(output.data[5]);
+        auto z_scores = FlatVector::GetData<double>(output.data[6]);
+        auto lower_bounds = FlatVector::GetData<double>(output.data[7]);
+        auto upper_bounds = FlatVector::GetData<double>(output.data[8]);
+        auto conditions = FlatVector::GetData<string_t>(output.data[9]);
+        auto explanations = FlatVector::GetData<string_t>(output.data[10]);
+        auto outlier_scores = FlatVector::GetData<double>(output.data[11]);
+
+        for (idx_t i = 0; i < count; ++i) {
+            auto &outlier = state.outliers[state.current_row + i];
 
             // Report the 1-based source table position, not the index in the
             // NULL-compacted working dataset
-            output.SetValue(0, count, Value::BIGINT(state.source_row_ids[outlier.row_idx]));
-            output.SetValue(1, count, Value(outlier.target_column_name));
-            output.SetValue(2, count, Value(outlier.GetOutlierValueString()));
-            output.SetValue(3, count, Value::DOUBLE(outlier.cluster_mean));
-            output.SetValue(4, count, Value::DOUBLE(outlier.cluster_sd));
-            output.SetValue(5, count, Value::BIGINT(static_cast<int64_t>(outlier.cluster_size)));
-            output.SetValue(6, count, Value::DOUBLE(outlier.z_score));
-            output.SetValue(7, count, Value::DOUBLE(outlier.lower_bound));
-            output.SetValue(8, count, Value::DOUBLE(outlier.upper_bound));
-            output.SetValue(9, count, Value(outlier.GetConditionsJSON()));
-            output.SetValue(10, count, Value(outlier.explanation));
-            output.SetValue(11, count, Value::DOUBLE(outlier.outlier_score));
-
-            state.current_row++;
-            count++;
+            row_ids[i] = state.source_row_ids[outlier.row_idx];
+            column_names[i] = StringVector::AddString(output.data[1], outlier.target_column_name);
+            outlier_values[i] = StringVector::AddString(output.data[2], outlier.GetOutlierValueString());
+            cluster_means[i] = outlier.cluster_mean;
+            cluster_sds[i] = outlier.cluster_sd;
+            cluster_sizes[i] = static_cast<int64_t>(outlier.cluster_size);
+            z_scores[i] = outlier.z_score;
+            lower_bounds[i] = outlier.lower_bound;
+            upper_bounds[i] = outlier.upper_bound;
+            conditions[i] = StringVector::AddString(output.data[9], outlier.GetConditionsJSON());
+            explanations[i] = StringVector::AddString(output.data[10], outlier.explanation);
+            outlier_scores[i] = outlier.outlier_score;
         }
-        output.SetCardinality(count);
+        state.current_row += count;
     } else {
         // Summary mode - single row
         if (state.current_row == 0) {

--- a/src/anofox_pii.cpp
+++ b/src/anofox_pii.cpp
@@ -2696,6 +2696,29 @@ struct PIIAuditTableBindData : public TableFunctionData {
         : table_name(table), column_filter(cols) {}
 };
 
+// Resolve the VARCHAR columns of a table, optionally restricted to a filter list.
+// Shared by pii_audit_table and pii_scan_table.
+static std::vector<std::string> ResolvePIIScanColumns(ClientContext &context, const std::string &table_name,
+                                                      const std::vector<std::string> &column_filter) {
+    auto qname = QualifiedName::Parse(table_name);
+    auto &catalog = Catalog::GetCatalog(context, qname.catalog);
+    auto &entry =
+        catalog.GetEntry(context, CatalogType::TABLE_ENTRY, qname.schema, qname.name).Cast<TableCatalogEntry>();
+
+    std::vector<std::string> columns;
+    for (auto &col : entry.GetColumns().Logical()) {
+        if (col.Type().id() != LogicalTypeId::VARCHAR) {
+            continue;
+        }
+        if (!column_filter.empty() &&
+            std::find(column_filter.begin(), column_filter.end(), col.Name()) == column_filter.end()) {
+            continue;
+        }
+        columns.push_back(col.Name());
+    }
+    return columns;
+}
+
 struct PIIAuditTableResult {
     int64_t row_id;
     std::string column_name;
@@ -2710,10 +2733,25 @@ struct PIIAuditTableResult {
                             start_pos(0), end_pos(0), confidence(0.0) {}
 };
 
+// Streaming audit state: the source table is scanned column by column and
+// chunk by chunk; only the matches of the most recent input chunk are
+// buffered, so neither the input nor the full match set is materialized.
 struct PIIAuditTableState : public GlobalTableFunctionState {
-    idx_t current_index = 0;
-    std::vector<PIIAuditTableResult> results;
-    bool scanned = false;
+    bool initialized = false;
+    // Columns to audit (resolved from the catalog on first call)
+    std::vector<std::string> columns_to_scan;
+    idx_t column_idx = 0;
+    // Active streaming scan over the current column; the connection must
+    // outlive its streaming query result
+    unique_ptr<Connection> connection;
+    unique_ptr<QueryResult> column_result;
+    int64_t source_row = 0;  // 1-based row position within the current column scan
+    // Configuration snapshot taken once for the whole audit
+    PIIConfigSnapshot config;
+    MaskStrategy mask_strategy = MaskStrategy::REDACT;
+    // Matches detected but not yet emitted (bounded: refilled only when drained)
+    std::vector<PIIAuditTableResult> pending;
+    idx_t pending_offset = 0;
 };
 
 unique_ptr<GlobalTableFunctionState> PIIAuditTableInit(ClientContext &, TableFunctionInitInput &) {
@@ -2778,139 +2816,132 @@ unique_ptr<FunctionData> PIIAuditTableBind(ClientContext &context, TableFunction
 void PIIAuditTableFunction(ClientContext &context, TableFunctionInput &input, DataChunk &output) {
     auto &state = input.global_state->Cast<PIIAuditTableState>();
     auto &bind_data = input.bind_data->Cast<PIIAuditTableBindData>();
+    auto &engine = PIIEngine::Instance();
 
-    // On first call, scan the table
-    if (!state.scanned) {
-        state.scanned = true;
+    try {
+        if (!state.initialized) {
+            state.initialized = true;
+            // Resolve the VARCHAR columns to audit and snapshot the
+            // configuration once for the whole scan; enabled_types and
+            // min_confidence are applied centrally by PIIEngine::Detect
+            state.columns_to_scan = ResolvePIIScanColumns(context, bind_data.table_name, bind_data.column_filter);
+            state.config = PIIConfig::Get().Snapshot();
+            state.mask_strategy = state.config.default_mask_strategy;
+        }
 
-        try {
-            // Get table metadata from catalog
-            auto qname = QualifiedName::Parse(bind_data.table_name);
-            auto &catalog = Catalog::GetCatalog(context, qname.catalog);
-            auto &entry = catalog.GetEntry(context, CatalogType::TABLE_ENTRY, qname.schema, qname.name).Cast<TableCatalogEntry>();
+        // Refill the pending buffer by streaming input chunks until at least
+        // one match is found or all columns are exhausted. The buffer only
+        // ever holds the matches of a single input chunk.
+        while (state.pending_offset >= state.pending.size()) {
+            state.pending.clear();
+            state.pending_offset = 0;
 
-            // Get list of VARCHAR columns to scan
-            std::vector<std::string> columns_to_scan;
-            for (auto &col : entry.GetColumns().Logical()) {
-                if (col.Type().id() == LogicalTypeId::VARCHAR) {
-                    // If column filter is set, check if this column is in the filter
-                    if (!bind_data.column_filter.empty()) {
-                        bool found = false;
-                        for (const auto &filter_col : bind_data.column_filter) {
-                            if (filter_col == col.Name()) {
-                                found = true;
-                                break;
-                            }
-                        }
-                        if (!found) continue;
-                    }
-                    columns_to_scan.push_back(col.Name());
+            if (!state.column_result) {
+                if (state.column_idx >= state.columns_to_scan.size()) {
+                    break;  // All columns audited
                 }
-            }
+                const auto &col_name = state.columns_to_scan[state.column_idx];
+                std::string query =
+                    "SELECT " + QuoteSqlIdentifier(col_name) + " FROM " + BuildQueryTableRef(bind_data.table_name);
 
-            // Get PII engine and a snapshot of the configuration (taken once
-            // for the whole scan; enabled_types and min_confidence are
-            // applied centrally by PIIEngine::Detect)
-            auto &engine = PIIEngine::Instance();
-            const auto config = PIIConfig::Get().Snapshot();
-            auto mask_strategy = config.default_mask_strategy;
-
-            // For each column, query values and detect PII (row-level)
-            for (const auto &col_name : columns_to_scan) {
-                // Build query to get column values with row numbers
-                std::string query = "SELECT row_number() OVER () as _row_id, " + QuoteSqlIdentifier(col_name) +
-                                    " FROM " + BuildQueryTableRef(bind_data.table_name);
-
-                // Execute query using a new connection
-                Connection con(*context.db);
-                auto result = con.Query(query);
-
+                // Execute as a streaming query on a dedicated connection
+                // (the connection must outlive the streaming result)
+                state.connection = make_uniq<Connection>(*context.db);
+                auto result = state.connection->SendQuery(query);
                 if (result->HasError()) {
                     AnofoxTrace(AnofoxLogLevel::Warn, "pii_audit_table: Error querying column " + col_name);
+                    state.connection.reset();
+                    state.column_idx++;
                     continue;
                 }
-
-                while (true) {
-                    auto chunk = result->Fetch();
-                    if (!chunk || chunk->size() == 0) break;
-
-                    // Process each row
-                    for (idx_t row = 0; row < chunk->size(); row++) {
-                        auto row_id_val = chunk->GetValue(0, row);
-                        auto text_val = chunk->GetValue(1, row);
-
-                        if (text_val.IsNull()) continue;
-
-                        int64_t row_id = row_id_val.GetValue<int64_t>();
-                        std::string text = text_val.GetValue<std::string>();
-
-                        // Detect PII in this value (the snapshot's
-                        // enabled_types and min_confidence are applied)
-                        auto matches = engine.Detect(text, {}, config);
-
-                        // Add each match as a result row
-                        for (const auto &match : matches) {
-                            PIIAuditTableResult res;
-                            res.row_id = row_id;
-                            res.column_name = col_name;
-                            res.pii_type = match.type;
-                            res.original_value = text;
-                            res.masked_value = engine.Mask(text, mask_strategy, {}, config);
-                            res.start_pos = static_cast<int64_t>(match.start_pos);
-                            res.end_pos = static_cast<int64_t>(match.end_pos);
-                            res.confidence = match.confidence;
-
-                            state.results.push_back(std::move(res));
-                        }
-                    }
-                }
+                state.column_result = std::move(result);
+                state.source_row = 0;
             }
 
-        } catch (const std::exception &e) {
-            throw InvalidInputException("pii_audit_table: Failed to audit table - %s", e.what());
+            auto chunk = state.column_result->Fetch();
+            if (!chunk || chunk->size() == 0) {
+                if (state.column_result->HasError()) {
+                    AnofoxTrace(AnofoxLogLevel::Warn, "pii_audit_table: Error querying column " +
+                                                          state.columns_to_scan[state.column_idx]);
+                }
+                state.column_result.reset();
+                state.connection.reset();
+                state.column_idx++;
+                continue;
+            }
+
+            const auto &col_name = state.columns_to_scan[state.column_idx];
+            UnifiedVectorFormat fmt;
+            chunk->data[0].ToUnifiedFormat(chunk->size(), fmt);
+            auto values = UnifiedVectorFormat::GetData<string_t>(fmt);
+
+            for (idx_t row = 0; row < chunk->size(); row++) {
+                state.source_row++;  // NULL rows keep their position in the numbering
+                auto idx = fmt.sel->get_index(row);
+                if (!fmt.validity.RowIsValid(idx)) {
+                    continue;
+                }
+                std::string text = values[idx].GetString();
+
+                // Detect PII in this value (the snapshot's enabled_types and
+                // min_confidence are applied)
+                auto matches = engine.Detect(text, {}, state.config);
+                if (matches.empty()) {
+                    continue;
+                }
+                // Mask covers the whole value, so it is identical for every
+                // match of this row; compute it once
+                std::string masked = engine.Mask(text, state.mask_strategy, {}, state.config);
+
+                for (const auto &match : matches) {
+                    PIIAuditTableResult res;
+                    res.row_id = state.source_row;
+                    res.column_name = col_name;
+                    res.pii_type = match.type;
+                    res.original_value = text;
+                    res.masked_value = masked;
+                    res.start_pos = static_cast<int64_t>(match.start_pos);
+                    res.end_pos = static_cast<int64_t>(match.end_pos);
+                    res.confidence = match.confidence;
+
+                    state.pending.push_back(std::move(res));
+                }
+            }
         }
+    } catch (const std::exception &e) {
+        throw InvalidInputException("pii_audit_table: Failed to audit table - %s", e.what());
     }
 
-    // Output results
-    if (state.current_index >= state.results.size()) {
-        output.SetCardinality(0);
+    // Emit up to STANDARD_VECTOR_SIZE pending match rows
+    idx_t remaining = state.pending.size() - state.pending_offset;
+    idx_t count = MinValue<idx_t>(remaining, STANDARD_VECTOR_SIZE);
+    output.SetCardinality(count);
+    if (count == 0) {
         return;
     }
 
-    idx_t remaining = state.results.size() - state.current_index;
-    idx_t count = MinValue<idx_t>(remaining, STANDARD_VECTOR_SIZE);
-
-    output.SetCardinality(count);
+    auto row_ids = FlatVector::GetData<int64_t>(output.data[0]);
+    auto column_names = FlatVector::GetData<string_t>(output.data[1]);
+    auto pii_types = FlatVector::GetData<string_t>(output.data[2]);
+    auto original_values = FlatVector::GetData<string_t>(output.data[3]);
+    auto masked_values = FlatVector::GetData<string_t>(output.data[4]);
+    auto start_positions = FlatVector::GetData<int64_t>(output.data[5]);
+    auto end_positions = FlatVector::GetData<int64_t>(output.data[6]);
+    auto confidences = FlatVector::GetData<double>(output.data[7]);
 
     for (idx_t i = 0; i < count; i++) {
-        const auto &res = state.results[state.current_index + i];
-
-        // Column 0: row_id
-        output.SetValue(0, i, Value::BIGINT(res.row_id));
-
-        // Column 1: column_name
-        output.SetValue(1, i, Value(res.column_name));
-
-        // Column 2: pii_type
-        output.SetValue(2, i, Value(PIITypeToString(res.pii_type)));
-
-        // Column 3: original_value
-        output.SetValue(3, i, Value(res.original_value));
-
-        // Column 4: masked_value
-        output.SetValue(4, i, Value(res.masked_value));
-
-        // Column 5: start_pos
-        output.SetValue(5, i, Value::BIGINT(res.start_pos));
-
-        // Column 6: end_pos
-        output.SetValue(6, i, Value::BIGINT(res.end_pos));
-
-        // Column 7: confidence
-        output.SetValue(7, i, Value::DOUBLE(res.confidence));
+        const auto &res = state.pending[state.pending_offset + i];
+        row_ids[i] = res.row_id;
+        column_names[i] = StringVector::AddString(output.data[1], res.column_name);
+        pii_types[i] = StringVector::AddString(output.data[2], PIITypeToString(res.pii_type));
+        original_values[i] = StringVector::AddString(output.data[3], res.original_value);
+        masked_values[i] = StringVector::AddString(output.data[4], res.masked_value);
+        start_positions[i] = res.start_pos;
+        end_positions[i] = res.end_pos;
+        confidences[i] = res.confidence;
     }
 
-    state.current_index += count;
+    state.pending_offset += count;
 }
 
 TableFunctionSet CreatePIIAuditTableFunctionSet() {
@@ -2953,10 +2984,19 @@ struct PIIScanTableResult {
     PIIScanTableResult() : pii_type(PIIType::UNKNOWN), match_count(0), confidence(1.0) {}
 };
 
+// Streaming scan state: columns are scanned one at a time with streamed
+// input chunks; only the (small) per-column aggregates of columns that have
+// not been emitted yet are buffered.
 struct PIIScanTableState : public GlobalTableFunctionState {
-    idx_t current_index = 0;
-    std::vector<PIIScanTableResult> results;
-    bool scanned = false;
+    bool initialized = false;
+    // Columns to scan (resolved from the catalog on first call)
+    std::vector<std::string> columns_to_scan;
+    idx_t column_idx = 0;
+    // Configuration snapshot taken once for the whole scan
+    PIIConfigSnapshot config;
+    // Aggregated results of scanned columns that have not been emitted yet
+    std::vector<PIIScanTableResult> pending;
+    idx_t pending_offset = 0;
 };
 
 unique_ptr<GlobalTableFunctionState> PIIScanTableInit(ClientContext &, TableFunctionInitInput &) {
@@ -3012,121 +3052,102 @@ unique_ptr<FunctionData> PIIScanTableBind(ClientContext &context, TableFunctionB
 void PIIScanTableFunction(ClientContext &context, TableFunctionInput &input, DataChunk &output) {
     auto &state = input.global_state->Cast<PIIScanTableState>();
     auto &bind_data = input.bind_data->Cast<PIIScanTableBindData>();
+    auto &engine = PIIEngine::Instance();
 
-    // On first call, scan the table
-    if (!state.scanned) {
-        state.scanned = true;
-
-        try {
-            // Get table metadata from catalog
-            auto qname = QualifiedName::Parse(bind_data.table_name);
-            auto &catalog = Catalog::GetCatalog(context, qname.catalog);
-            auto &entry = catalog.GetEntry(context, CatalogType::TABLE_ENTRY, qname.schema, qname.name).Cast<TableCatalogEntry>();
-
-            // Get list of VARCHAR columns to scan
-            std::vector<std::string> columns_to_scan;
-            for (auto &col : entry.GetColumns().Logical()) {
-                if (col.Type().id() == LogicalTypeId::VARCHAR) {
-                    // If column filter is set, check if this column is in the filter
-                    if (!bind_data.column_filter.empty()) {
-                        bool found = false;
-                        for (const auto &filter_col : bind_data.column_filter) {
-                            if (filter_col == col.Name()) {
-                                found = true;
-                                break;
-                            }
-                        }
-                        if (!found) continue;
-                    }
-                    columns_to_scan.push_back(col.Name());
-                }
-            }
-
-            // For each column, query values and detect PII. The
-            // configuration snapshot is taken once for the whole scan.
-            auto &engine = PIIEngine::Instance();
-            const auto config = PIIConfig::Get().Snapshot();
-
-            for (const auto &col_name : columns_to_scan) {
-                // Build query to get column values
-                std::string query = "SELECT " + QuoteSqlIdentifier(col_name) + " FROM " +
-                                   BuildQueryTableRef(bind_data.table_name) +
-                                   " WHERE " + QuoteSqlIdentifier(col_name) + " IS NOT NULL";
-
-                // Execute query using a new connection
-                Connection con(*context.db);
-                auto result = con.Query(query);
-
-                if (result->HasError()) {
-                    AnofoxTrace(AnofoxLogLevel::Warn, "pii_scan_table: Error querying column " + col_name);
-                    continue;
-                }
-
-                // Aggregate PII detections by type
-                std::unordered_map<PIIType, PIIScanTableResult> col_results;
-
-                while (true) {
-                    auto chunk = result->Fetch();
-                    if (!chunk || chunk->size() == 0) break;
-
-                    // Collect all texts from this chunk for batch processing
-                    std::vector<std::string> batch_texts;
-                    batch_texts.reserve(chunk->size());
-
-                    for (idx_t row = 0; row < chunk->size(); row++) {
-                        auto val = chunk->GetValue(0, row);
-                        if (val.IsNull()) {
-                            batch_texts.push_back("");  // Placeholder for null values
-                        } else {
-                            batch_texts.push_back(val.GetValue<std::string>());
-                        }
-                    }
-
-                    // Run batch detection (pre-warms NER cache)
-                    auto batch_matches = engine.DetectBatch(batch_texts, {}, config);
-
-                    // Process results
-                    for (size_t i = 0; i < batch_matches.size(); i++) {
-                        for (const auto &match : batch_matches[i]) {
-                            auto &res = col_results[match.type];
-                            res.column_name = col_name;
-                            res.pii_type = match.type;
-                            res.match_count++;
-                            // Keep up to 5 samples
-                            if (res.sample_values.size() < 5) {
-                                res.sample_values.push_back(match.matched_text);
-                            }
-                            res.confidence = 1.0;  // Regex matches have full confidence
-                        }
-                    }
-                }
-
-                // Add results to output
-                for (auto &[type, res] : col_results) {
-                    state.results.push_back(std::move(res));
-                }
-            }
-
-        } catch (const std::exception &e) {
-            throw InvalidInputException("pii_scan_table: Failed to scan table - %s", e.what());
+    try {
+        if (!state.initialized) {
+            state.initialized = true;
+            // Resolve the VARCHAR columns to scan and snapshot the
+            // configuration once for the whole scan
+            state.columns_to_scan = ResolvePIIScanColumns(context, bind_data.table_name, bind_data.column_filter);
+            state.config = PIIConfig::Get().Snapshot();
         }
+
+        // Scan one source column at a time until at least one aggregate row
+        // is available; input chunks are streamed and never fully
+        // materialized. Per-type aggregation requires consuming a full
+        // column before its summary rows can be emitted.
+        while (state.pending_offset >= state.pending.size() && state.column_idx < state.columns_to_scan.size()) {
+            state.pending.clear();
+            state.pending_offset = 0;
+
+            const auto &col_name = state.columns_to_scan[state.column_idx];
+            state.column_idx++;
+
+            // Build query to get the non-NULL column values
+            std::string query = "SELECT " + QuoteSqlIdentifier(col_name) + " FROM " +
+                                BuildQueryTableRef(bind_data.table_name) + " WHERE " +
+                                QuoteSqlIdentifier(col_name) + " IS NOT NULL";
+
+            // Execute as a streaming query using a new connection
+            Connection con(*context.db);
+            auto result = con.SendQuery(query);
+            if (result->HasError()) {
+                AnofoxTrace(AnofoxLogLevel::Warn, "pii_scan_table: Error querying column " + col_name);
+                continue;
+            }
+
+            // Aggregate PII detections by type
+            std::unordered_map<PIIType, PIIScanTableResult> col_results;
+            std::vector<std::string> batch_texts;
+
+            while (true) {
+                auto chunk = result->Fetch();
+                if (!chunk || chunk->size() == 0) break;
+
+                UnifiedVectorFormat fmt;
+                chunk->data[0].ToUnifiedFormat(chunk->size(), fmt);
+                auto values = UnifiedVectorFormat::GetData<string_t>(fmt);
+
+                // Collect all texts from this chunk for batch processing
+                // (NULLs are filtered in the query; keep a placeholder for safety)
+                batch_texts.clear();
+                batch_texts.reserve(chunk->size());
+                for (idx_t row = 0; row < chunk->size(); row++) {
+                    auto idx = fmt.sel->get_index(row);
+                    batch_texts.emplace_back(fmt.validity.RowIsValid(idx) ? values[idx].GetString()
+                                                                          : std::string());
+                }
+
+                // Run batch detection (pre-warms NER cache)
+                auto batch_matches = engine.DetectBatch(batch_texts, {}, state.config);
+
+                // Process results
+                for (size_t i = 0; i < batch_matches.size(); i++) {
+                    for (const auto &match : batch_matches[i]) {
+                        auto &res = col_results[match.type];
+                        res.column_name = col_name;
+                        res.pii_type = match.type;
+                        res.match_count++;
+                        // Keep up to 5 samples
+                        if (res.sample_values.size() < 5) {
+                            res.sample_values.push_back(match.matched_text);
+                        }
+                        res.confidence = 1.0;  // Regex matches have full confidence
+                    }
+                }
+            }
+            if (result->HasError()) {
+                AnofoxTrace(AnofoxLogLevel::Warn, "pii_scan_table: Error querying column " + col_name);
+                continue;
+            }
+
+            // Stage this column's aggregates for emission
+            for (auto &[type, res] : col_results) {
+                state.pending.push_back(std::move(res));
+            }
+        }
+    } catch (const std::exception &e) {
+        throw InvalidInputException("pii_scan_table: Failed to scan table - %s", e.what());
     }
 
-    // Output results
-    if (state.current_index >= state.results.size()) {
-        output.SetCardinality(0);
-        return;
-    }
-
-    idx_t remaining = state.results.size() - state.current_index;
+    // Emit pending aggregate rows (at most a handful per column)
+    idx_t remaining = state.pending.size() - state.pending_offset;
     idx_t count = MinValue<idx_t>(remaining, STANDARD_VECTOR_SIZE);
-
     output.SetCardinality(count);
 
-    auto &sample_vec = output.data[3];
-
     for (idx_t i = 0; i < count; i++) {
-        const auto &res = state.results[state.current_index + i];
+        const auto &res = state.pending[state.pending_offset + i];
 
         // Column 0: column_name
         output.SetValue(0, i, Value(res.column_name));
@@ -3148,7 +3169,7 @@ void PIIScanTableFunction(ClientContext &context, TableFunctionInput &input, Dat
         output.SetValue(4, i, Value::DOUBLE(res.confidence));
     }
 
-    state.current_index += count;
+    state.pending_offset += count;
 }
 
 TableFunctionSet CreatePIIScanTableFunctionSet() {

--- a/test/sql/anofox_streaming_pin.test
+++ b/test/sql/anofox_streaming_pin.test
@@ -1,0 +1,283 @@
+# name: test/sql/anofox_streaming_pin.test
+# description: Pin table-function outputs on larger range()-generated fixtures (#59).
+#              These tests pin the exact observable behavior of the whole-table
+#              materializing table functions (pii_scan_table, pii_audit_table,
+#              outlier_tree, isolation_forest, dbscan) before/after the
+#              streaming refactor. Deterministic functions are pinned exactly;
+#              the RNG-based isolation forest is pinned via row counts,
+#              data-derived values, and cross-mode invariants (std::mt19937
+#              distributions are implementation-defined, so seeded counts are
+#              not portable across standard libraries).
+# group: [anofox_tabular]
+
+require anofox_tabular
+
+statement ok
+LOAD anofox_tabular
+
+statement ok
+SET anofox_tab_trace_enabled = false
+
+# ===--------------------------------------------------------------------===
+# Fixtures (a few thousand generated rows)
+# ===--------------------------------------------------------------------===
+
+statement ok
+CREATE TABLE pin_pii AS
+SELECT i AS id,
+  CASE WHEN i % 50 = 0 THEN 'contact user' || i || '@example.com now'
+       WHEN i % 97 = 0 THEN 'server ip is 192.168.1.42 ok'
+       ELSE 'clean text ' || i END AS notes,
+  CASE WHEN i % 200 = 0 THEN 'card 4111111111111111 on file' ELSE 'ok' END AS extra
+FROM range(1, 4001) t(i);
+
+statement ok
+CREATE TABLE pin_ot AS
+SELECT i AS id,
+  CASE WHEN i % 2 = 0 THEN 'A' ELSE 'B' END AS grp,
+  CASE WHEN i = 1500 THEN 100000.0
+       WHEN i % 2 = 0 THEN 100.0 + (i % 7)
+       ELSE 500.0 + (i % 11) END AS val
+FROM range(1, 3001) t(i);
+
+statement ok
+CREATE TABLE pin_if AS
+SELECT i AS id,
+  CASE WHEN i = 1000 THEN 10000.0 ELSE 100.0 + (i % 13) END AS val,
+  CASE WHEN i = 2000 THEN 9999.0 ELSE 50.0 + (i % 7) END AS val2,
+  CASE WHEN i % 3 = 0 THEN 'x' ELSE 'y' END AS cat,
+  1.0 + (i % 2) AS w
+FROM range(1, 3001) t(i);
+
+statement ok
+CREATE TABLE pin_db AS
+SELECT i AS id,
+  CASE WHEN i <= 1000 THEN 10.0 + (i % 5) * 0.1
+       WHEN i <= 2000 THEN 50.0 + (i % 5) * 0.1
+       ELSE 1000.0 + i * 10 END AS val,
+  CASE WHEN i <= 1000 THEN 20.0 + (i % 5) * 0.1
+       WHEN i <= 2000 THEN 80.0 + (i % 5) * 0.1
+       ELSE 5000.0 + i * 10 END AS val2
+FROM range(1, 2010) t(i);
+
+# ===--------------------------------------------------------------------===
+# pii_scan_table — exact summary per column/type
+# ===--------------------------------------------------------------------===
+
+query TTIR
+SELECT column_name, pii_type, match_count, confidence
+FROM anofox_tab_pii_scan_table('pin_pii')
+ORDER BY column_name, pii_type;
+----
+extra	CREDIT_CARD	20	1.0
+notes	EMAIL	80	1.0
+notes	IP_ADDRESS	41	1.0
+
+# Sample values keep the first five matches in scan order
+query T
+SELECT sample_values = ['user50@example.com', 'user100@example.com', 'user150@example.com',
+                        'user200@example.com', 'user250@example.com']
+FROM anofox_tab_pii_scan_table('pin_pii')
+WHERE pii_type = 'EMAIL';
+----
+true
+
+query T
+SELECT sample_values = ['4111111111111111', '4111111111111111', '4111111111111111',
+                        '4111111111111111', '4111111111111111']
+FROM anofox_tab_pii_scan_table('pin_pii')
+WHERE pii_type = 'CREDIT_CARD';
+----
+true
+
+# Column-filter overload only scans the listed columns
+query TTI
+SELECT column_name, pii_type, match_count
+FROM anofox_tab_pii_scan_table('pin_pii', 'notes')
+ORDER BY column_name, pii_type;
+----
+notes	EMAIL	80
+notes	IP_ADDRESS	41
+
+# ===--------------------------------------------------------------------===
+# pii_audit_table — exact per-match rows
+# ===--------------------------------------------------------------------===
+
+query I
+SELECT COUNT(*) FROM anofox_tab_pii_audit_table('pin_pii');
+----
+141
+
+# Aggregates over all match rows (row ids, positions, confidence)
+query TTIIIIR
+SELECT column_name, pii_type, COUNT(*),
+       SUM(row_id)::BIGINT, SUM(start_pos)::BIGINT, SUM(end_pos)::BIGINT,
+       ROUND(SUM(confidence), 2)
+FROM anofox_tab_pii_audit_table('pin_pii')
+GROUP BY column_name, pii_type
+ORDER BY column_name, pii_type;
+----
+extra	CREDIT_CARD	20	42000	100	420	20.0
+notes	EMAIL	80	162000	640	2220	80.0
+notes	IP_ADDRESS	41	83517	533	1025	41.0
+
+# Exact first match rows per type (original and masked values retained per match)
+query ITTTTIIR
+SELECT row_id, column_name, pii_type, original_value, masked_value, start_pos, end_pos, confidence
+FROM anofox_tab_pii_audit_table('pin_pii')
+WHERE (row_id = 50 AND pii_type = 'EMAIL')
+   OR (row_id = 97 AND pii_type = 'IP_ADDRESS')
+   OR (row_id = 200 AND pii_type = 'CREDIT_CARD')
+ORDER BY column_name, row_id;
+----
+200	extra	CREDIT_CARD	card 4111111111111111 on file	card [CREDIT_CARD] on file	5	21	1.0
+50	notes	EMAIL	contact user50@example.com now	contact [EMAIL] now	8	26	1.0
+97	notes	IP_ADDRESS	server ip is 192.168.1.42 ok	server ip is [IP_ADDRESS] ok	13	25	1.0
+
+# Column-filter overload
+query I
+SELECT COUNT(*) FROM anofox_tab_pii_audit_table('pin_pii', 'extra');
+----
+20
+
+# ===--------------------------------------------------------------------===
+# outlier_tree — deterministic algorithm, exact pins
+# ===--------------------------------------------------------------------===
+
+query TIIIIIT
+SELECT status, total_rows, outlier_count, columns_analyzed, clusters_evaluated, max_depth_reached, message
+FROM anofox_tab_outlier_tree('pin_ot', 'grp,val', 'summary');
+----
+fail	3000	2	2	14	3	2 outlier(s) detected
+
+query ITTRRIRRRTTR
+SELECT row_id, column_name, outlier_value, ROUND(cluster_mean, 4), ROUND(cluster_sd, 4), cluster_size,
+       ROUND(z_score, 4), ROUND(lower_bound, 4), ROUND(upper_bound, 4), conditions, explanation,
+       ROUND(outlier_score, 4)
+FROM anofox_tab_outlier_tree('pin_ot', 'grp,val', 'outliers')
+ORDER BY row_id, column_name;
+----
+1500	grp	A	0.0	0.0	1365	36.9459	0.0	0.0	[{"column":"val","type":"numeric","operator":">","value":500}]	Value A for column 'grp' is unusually rare (cluster size: 1365) when val > 500	0.0007
+1500	val	100000	169.5987	2579.3302	1500	33689.8017	-6717.213	7056.4103	[{"column":"grp","type":"categorical","operator":"in","values":["A"]}]	Value 100000 for column 'val' is unusually high (mean: 169.60, SD: 2579.33, z-score: 33689.80) when grp IN ('A')	0.0
+
+# ===--------------------------------------------------------------------===
+# isolation_forest — pinned via row counts, data-derived values, and
+# cross-mode invariants (seeded RNG is stdlib-implementation-defined)
+# ===--------------------------------------------------------------------===
+
+# Summary: data-derived columns are exact; outlier_count is sane and non-zero
+query TIRRIT
+SELECT total_count, outlier_count BETWEEN 1 AND 300, ROUND(avg_value, 4), contamination, n_trees, status
+FROM anofox_tab_isolation_forest('pin_if', 'val', 100, 256, 0.05, 'summary', 42);
+----
+3000	true	109.2943	0.05	100	fail
+
+# Scores mode: one row per non-NULL input row, 1-indexed; value column is the raw input
+query IIIR
+SELECT COUNT(*), MIN(row_id)::BIGINT, MAX(row_id)::BIGINT, ROUND(SUM(value), 2)
+FROM anofox_tab_isolation_forest('pin_if', 'val', 100, 256, 0.05, 'scores', 42);
+----
+3000	1	3000	327883.0
+
+# The planted extreme value is flagged as an anomaly; scores are in [0, 1]
+query TRTT
+SELECT value::VARCHAR, ROUND(value, 1), is_anomaly,
+       (SELECT MIN(anomaly_score) >= 0.0 AND MAX(anomaly_score) <= 1.0
+        FROM anofox_tab_isolation_forest('pin_if', 'val', 100, 256, 0.05, 'scores', 42))
+FROM anofox_tab_isolation_forest('pin_if', 'val', 100, 256, 0.05, 'scores', 42)
+WHERE row_id = 1000;
+----
+10000.0	10000.0	true	true
+
+# Cross-mode invariant: summary outlier_count equals the scores-mode anomaly count for the same seed
+query T
+SELECT (SELECT outlier_count FROM anofox_tab_isolation_forest('pin_if', 'val', 100, 256, 0.05, 'summary', 42))
+     = (SELECT SUM(CASE WHEN is_anomaly THEN 1 ELSE 0 END)
+        FROM anofox_tab_isolation_forest('pin_if', 'val', 100, 256, 0.05, 'scores', 42));
+----
+true
+
+# Multivariate (numeric-only path)
+query ITIRIT
+SELECT total_count, outlier_count BETWEEN 1 AND 300, n_columns, contamination, n_trees, status
+FROM anofox_tab_isolation_forest_mv('pin_if', 'val,val2', 100, 256, 0.05, 'summary', 42);
+----
+3000	true	2	0.05	100	fail
+
+query T
+SELECT (SELECT outlier_count
+        FROM anofox_tab_isolation_forest_mv('pin_if', 'val,val2', 100, 256, 0.05, 'summary', 42))
+     = (SELECT SUM(CASE WHEN is_anomaly THEN 1 ELSE 0 END)
+        FROM anofox_tab_isolation_forest_mv('pin_if', 'val,val2', 100, 256, 0.05, 'scores', 42));
+----
+true
+
+# Multivariate mixed path (categorical column + weight column)
+query ITIRIT
+SELECT total_count, outlier_count BETWEEN 1 AND 600, n_columns, contamination, n_trees, status
+FROM anofox_tab_isolation_forest_mv('pin_if', 'val,cat', 100, 256, 0.05, 'summary', 42, 1,
+                                    'uniform', 'depth', 'w');
+----
+3000	true	2	0.05	100	fail
+
+query T
+SELECT (SELECT outlier_count
+        FROM anofox_tab_isolation_forest_mv('pin_if', 'val,cat', 100, 256, 0.05, 'summary', 42, 1,
+                                            'uniform', 'depth', 'w'))
+     = (SELECT SUM(CASE WHEN is_anomaly THEN 1 ELSE 0 END)
+        FROM anofox_tab_isolation_forest_mv('pin_if', 'val,cat', 100, 256, 0.05, 'scores', 42, 1,
+                                            'uniform', 'depth', 'w'));
+----
+true
+
+# ===--------------------------------------------------------------------===
+# dbscan — deterministic algorithm, exact pins
+# ===--------------------------------------------------------------------===
+
+query TIIIRIRIT
+SELECT status, cluster_count, noise_count, total_count, ROUND(noise_rate, 6), largest_cluster_size,
+       eps, min_pts, message
+FROM anofox_tab_dbscan('pin_db', 'val', 0.5, 5, 'summary');
+----
+fail	2	9	2009	0.00448	1000	0.5	5	9 noise point(s) detected
+
+# Exact per-cluster aggregates over the full clusters output
+query ITIRIR
+SELECT cluster_id, point_type, COUNT(*), ROUND(SUM(value), 2), SUM(neighbor_count)::BIGINT,
+       ROUND(SUM(anomaly_score), 4)
+FROM anofox_tab_dbscan('pin_db', 'val', 0.5, 5, 'clusters')
+GROUP BY cluster_id, point_type
+ORDER BY cluster_id, point_type;
+----
+-1	NOISE	9	189450.0	0	9.0
+0	CORE	1000	10200.0	999000	100.0
+1	CORE	1000	50200.0	999000	100.0
+
+# Exact individual rows (first member of each cluster and one noise point)
+query IRITIRT
+SELECT row_id, value, cluster_id, point_type, neighbor_count, ROUND(anomaly_score, 4), is_anomaly
+FROM anofox_tab_dbscan('pin_db', 'val', 0.5, 5, 'clusters')
+WHERE row_id IN (1, 1001, 2005)
+ORDER BY row_id;
+----
+1	10.1	0	CORE	999	0.1	false
+1001	50.1	1	CORE	999	0.1	false
+2005	21050.0	-1	NOISE	0	1.0	true
+
+# Multivariate dbscan
+query TIIIRIRIIT
+SELECT status, cluster_count, noise_count, total_count, ROUND(noise_rate, 6), largest_cluster_size,
+       eps, min_pts, n_columns, message
+FROM anofox_tab_dbscan_mv('pin_db', 'val,val2', 2.0, 5, 'summary');
+----
+fail	2	9	2009	0.00448	1000	2.0	5	2	9 noise point(s) detected
+
+query ITI
+SELECT cluster_id, point_type, COUNT(*)
+FROM anofox_tab_dbscan_mv('pin_db', 'val,val2', 2.0, 5, 'clusters')
+GROUP BY cluster_id, point_type
+ORDER BY cluster_id, point_type;
+----
+-1	NOISE	9
+0	CORE	1000
+1	CORE	1000


### PR DESCRIPTION
Implements theme T4 of the 2026-06 code review. Builds on the integration branch of PRs #62–#78.

Closes #59

## Scope

The whole-table materializing table functions previously fetched the entire source table through a nested connection (materialized query result), copied cells one by one via `DataChunk::GetValue`, and held a second full copy of all results before emitting the first row.

- **`pii_audit_table`** (`src/anofox_pii.cpp`): now fully streamed. The function state holds the active column cursor and a streaming query result (`Connection::SendQuery`); input chunks are fetched on demand and only the matches of the most recent chunk are buffered — the full original+masked value set per match is no longer retained. The `row_number() OVER ()` window (which forced input materialization) is replaced by a running counter with identical numbering. Output is written through flat vectors.
- **`pii_scan_table`**: scans one column at a time with streamed input and emits its per-type aggregates as soon as the column is consumed (aggregation inherently requires consuming a column before its summary row exists).
- **`outlier_tree`** (`src/anofox_outlier_tree.cpp`): input is streamed and read through `UnifiedVectorFormat` typed accessors (types detected via a `LIMIT 0` query, data query casts to VARCHAR/DOUBLE). Tree fitting genuinely needs the complete dataset, so the `ColumnData` copy is kept and documented — but the second copy held by the materialized query result is gone. Outlier rows are emitted through flat-vector writes. Algorithm internals untouched.
- **`isolation_forest` / `isolation_forest_mv` / `dbscan` / `dbscan_mv`** (`src/anofox_metric.cpp`): streamed input + `UnifiedVectorFormat` reads; the duplicate `IsolationForestResult` vector is dropped — the state keeps the model's score vector and threshold, and row ids / anomaly flags are derived during emission. Scores/clusters output is written through flat vectors. Algorithm classes untouched.

No output schema, value, or row-order changes.

## Pin coverage (committed first, green before and after)

`test/sql/anofox_streaming_pin.test` pins behavior on `range()`-generated fixtures (2k–4k rows):

- `pii_scan_table` / `pii_audit_table`: exact per-column/type summaries, sample values, per-match rows (row ids, positions, masked values), aggregates over all 141 match rows, and both column-filter overloads
- `outlier_tree`: exact summary and full outlier-explanation rows (deterministic algorithm)
- `isolation_forest(_mv)`: row counts, data-derived values (`avg_value`, raw `value` passthrough), planted-extreme anomaly flag, score range, and cross-mode invariants (summary `outlier_count` = scores-mode anomaly count for the same seed) for the numeric, multivariate, and mixed (categorical + weight) paths. Exact seeded counts are deliberately not pinned: `std::mt19937` distribution output is stdlib-implementation-defined, so they are not portable across platforms.
- `dbscan(_mv)`: exact summary, per-cluster aggregates over the full clusters output, and individual rows (deterministic algorithm)

## Memory evidence (peak RSS via /proc VmHWM, release build)

| benchmark | before | after |
|---|---|---|
| `pii_audit_table`, 500k rows (EMAIL-only config) | 140.2 MB | **97.1 MB** |
| `pii_scan_table`, 500k rows | 113.2 MB | **100.7 MB** |
| `isolation_forest` scores, 2M rows | 329.8 MB | **273.4 MB** (9.4s → 8.6s) |
| `outlier_tree` outliers, 2M rows | 337.5 MB | **276.1 MB** (4.9s → 3.2s) |
| `dbscan` clusters, 20k rows | 74.6 MB | 75.0 MB (unchanged: peak dominated by algorithm-internal neighbor lists; the removed input copy is small at this size) |
| fixture-only baselines | 76–125 MB | 76–125 MB |

The remaining full copies are the feature matrices required for model fitting (documented in code); the audit path now scales O(chunk) instead of O(table + matches) in transient memory, and the removed copies (materialized nested query results, duplicate per-row result vectors) grow linearly with input, so the gap widens with table size.

## Tests

- `make test` (SQL logic tests): all passed, 2427 assertions in 28 cases (+ 3 OpenVINO-gated skips)
- Catch2 via unittest `test/cpp/*`: 243 assertions in 9 cases; standalone `anofox_tabular_cpp_tests`: 1085 assertions in 14 cases
- Python: 253 passed