### PR TITLE
feat: exact money amounts (DECIMAL) and metadata-driven formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,8 +336,8 @@ International monetary value handling with currency-aware arithmetic and formatt
 **Key Features:**
 - 17 SQL functions for financial operations
 - 10 major currencies (USD, EUR, GBP, JPY, CAD, AUD, CHF, CNY, INR, BRL)
-- Currency-safe arithmetic (prevents mixing currencies)
-- Locale-aware formatting (symbol placement, decimal marks)
+- Exact DECIMAL(18,3) amounts with overflow-checked, currency-safe arithmetic
+- Locale-aware formatting (symbol placement, per-currency scale, decimal marks, thousands separators)
 - Quality validation (range checks, currency consistency)
 
 ```sql
@@ -840,12 +840,14 @@ WHERE money_in_range(amount, 0.01, 99999.99)
 
 ### Money & Currency Functions
 
+Money values are `STRUCT(amount DECIMAL(18,3), currency VARCHAR)`: amounts are exact decimals (no binary floating point drift), NaN/Inf are unrepresentable, and arithmetic raises a clear error on overflow instead of producing Inf. `money()` accepts a DOUBLE amount, which must be finite and is rounded half away from zero to 3 decimals; use `money_from_cents()` for fully exact construction from integer subunits.
+
 #### Basic Operations
 | Function | Signature | Returns | Description |
 |----------|-----------|---------|-------------|
-| `anofox_tab_money` | `(amount, currency_code)` | STRUCT | Create a money value from amount and currency code |
-| `anofox_tab_money_from_cents` | `(cents, currency_code)` | STRUCT | Create a money value from an integer amount in the smallest currency unit (e.g. 10050 cents → 100.50 USD) |
-| `anofox_tab_money_amount` | `(money)` | DOUBLE | Extract amount from money struct |
+| `anofox_tab_money` | `(amount, currency_code)` | STRUCT | Create a money value from amount and currency code (amount must be finite and within the DECIMAL(18,3) range) |
+| `anofox_tab_money_from_cents` | `(cents, currency_code)` | STRUCT | Create a money value from an integer amount in the smallest currency unit, exactly (e.g. 10050 cents → 100.50 USD) |
+| `anofox_tab_money_amount` | `(money)` | DECIMAL(18,3) | Extract the exact amount from money struct |
 | `anofox_tab_money_currency` | `(money)` | VARCHAR | Extract currency code from money struct |
 
 #### Currency Information
@@ -858,7 +860,7 @@ WHERE money_in_range(amount, 0.01, 99999.99)
 #### Formatting
 | Function | Signature | Returns | Description |
 |----------|-----------|---------|-------------|
-| `anofox_tab_money_format` | `(money, style)` | VARCHAR | Format money for display (3 styles: 'symbol', 'code', 'long') |
+| `anofox_tab_money_format` | `(money, style)` | VARCHAR | Format money for display (3 styles: 'symbol', 'code', 'long'). The scale comes from the currency's `subunit_to_unit` (JPY has no decimals); 'symbol' and 'long' localize with the currency's thousands separator and decimal mark (`$1,234,567.89`, `1.234.567,89 €`, `¥1,235`), 'code' stays canonical (dot decimal mark, no grouping: `1234567.89 USD`) |
 
 #### Validation & Properties
 | Function | Signature | Returns | Description |

--- a/docs/API_REFERENCE.md
+++ b/docs/API_REFERENCE.md
@@ -39,7 +39,7 @@ All functions have aliases without the `anofox_tab_` prefix. For example:
 - `address`: Street address - `VARCHAR`
 - `number`: Phone number - `VARCHAR`
 - `region`: ISO region code - `VARCHAR`
-- `money`: Money struct - `STRUCT(amount DOUBLE, currency VARCHAR)`
+- `money`: Money struct - `STRUCT(amount DECIMAL(18,3), currency VARCHAR)` (exact decimal amounts; NaN/Inf unrepresentable, overflow raises)
 - `vat_string`: VAT number - `VARCHAR`
 - `table_name`: Source table - `VARCHAR`
 - `column_name`: Column name - `VARCHAR`
@@ -428,6 +428,8 @@ anofox_tab_phonenumber_status() → TABLE
 
 International monetary value handling with currency-aware arithmetic and formatting.
 
+Money amounts are exact `DECIMAL(18,3)` values: arithmetic never drifts, NaN/Inf are unrepresentable, and results outside the DECIMAL(18,3) range raise an out-of-range error instead of overflowing to Inf. `money()` takes a DOUBLE amount (must be finite, rounded half away from zero to 3 decimals); `money_from_cents()` constructs exactly from integer subunits.
+
 ### Supported Currencies
 
 10 major currencies: USD, EUR, GBP, JPY, CAD, AUD, CHF, CNY, INR, BRL
@@ -440,7 +442,7 @@ Create a money value from amount and currency code.
 
 **Signature:**
 ```sql
-anofox_tab_money (alias: money(amount DOUBLE, currency_code VARCHAR) → STRUCT(amount DOUBLE, currency VARCHAR)
+anofox_tab_money (alias: money(amount DOUBLE, currency_code VARCHAR) → STRUCT(amount DECIMAL(18,3), currency VARCHAR)
 ```
 
 **Example:**
@@ -457,7 +459,7 @@ Create a money value from an integer amount in the currency's smallest unit (e.g
 
 **Signature:**
 ```sql
-anofox_tab_money (alias: money_from_cents(cents BIGINT, currency_code VARCHAR) → STRUCT(amount DOUBLE, currency VARCHAR)
+anofox_tab_money (alias: money_from_cents(cents BIGINT, currency_code VARCHAR) → STRUCT(amount DECIMAL(18,3), currency VARCHAR)
 ```
 
 **Example:**
@@ -474,7 +476,7 @@ Extract amount from money struct.
 
 **Signature:**
 ```sql
-anofox_tab_money (alias: money_amount(money STRUCT) → DOUBLE
+anofox_tab_money (alias: money_amount(money STRUCT) → DECIMAL(18,3)
 ```
 
 **Example:**
@@ -559,7 +561,7 @@ SELECT anofox_tab_currency_ (alias: currency_name('USD');
 
 #### `anofox_tab_money (alias: money_format`
 
-Format money for display.
+Format money for display. The number of decimals is derived from the currency's `subunit_to_unit` (JPY has none, USD/EUR have two). The `'symbol'` and `'long'` styles localize the amount with the currency's thousands separator and decimal mark; the `'code'` style stays canonical (dot decimal mark, no grouping).
 
 **Signature:**
 ```sql
@@ -567,7 +569,7 @@ anofox_tab_money (alias: money_format(money STRUCT, style VARCHAR) → VARCHAR
 ```
 
 **Parameters:**
-- `style`: Format style - `'symbol'`, `'code'`, or `'long'`
+- `style`: Format style - `'symbol'` (e.g. `$1,234,567.89`, `1.234.567,89 €`, `¥1,235`), `'code'` (e.g. `1234567.89 USD`), or `'long'` (e.g. `1.234,50 Euro`)
 
 **Example:**
 ```sql
@@ -618,7 +620,7 @@ Get absolute value (sign removed).
 
 **Signature:**
 ```sql
-anofox_tab_money (alias: money_abs(money STRUCT) → STRUCT(amount DOUBLE, currency VARCHAR)
+anofox_tab_money (alias: money_abs(money STRUCT) → STRUCT(amount DECIMAL(18,3), currency VARCHAR)
 ```
 
 ---
@@ -631,7 +633,7 @@ Add two money values (same currency required).
 
 **Signature:**
 ```sql
-anofox_tab_money (alias: money_add(money1 STRUCT, money2 STRUCT) → STRUCT(amount DOUBLE, currency VARCHAR)
+anofox_tab_money (alias: money_add(money1 STRUCT, money2 STRUCT) → STRUCT(amount DECIMAL(18,3), currency VARCHAR)
 ```
 
 **Example:**
@@ -651,7 +653,7 @@ Subtract money2 from money1 (same currency required).
 
 **Signature:**
 ```sql
-anofox_tab_money (alias: money_subtract(money1 STRUCT, money2 STRUCT) → STRUCT(amount DOUBLE, currency VARCHAR)
+anofox_tab_money (alias: money_subtract(money1 STRUCT, money2 STRUCT) → STRUCT(amount DECIMAL(18,3), currency VARCHAR)
 ```
 
 ---
@@ -662,7 +664,7 @@ Multiply money by a scalar factor.
 
 **Signature:**
 ```sql
-anofox_tab_money (alias: money_multiply(money STRUCT, factor DOUBLE) → STRUCT(amount DOUBLE, currency VARCHAR)
+anofox_tab_money (alias: money_multiply(money STRUCT, factor DOUBLE) → STRUCT(amount DECIMAL(18,3), currency VARCHAR)
 ```
 
 ---
@@ -2039,7 +2041,7 @@ SET anofox_telemetry_key = 'your_custom_key';
    - **OpenSSL**: Optional for SMTP email validation
    - **libphonenumber**: Embedded implementation, no external dependencies
 
-6. **Money struct format**: All money functions use `STRUCT(amount DOUBLE, currency VARCHAR)` format. Currency codes must match supported currencies (USD, EUR, GBP, JPY, CAD, AUD, CHF, CNY, INR, BRL).
+6. **Money struct format**: All money functions use `STRUCT(amount DECIMAL(18,3), currency VARCHAR)` format. Currency codes must match supported currencies (USD, EUR, GBP, JPY, CAD, AUD, CHF, CNY, INR, BRL).
 
 7. **VAT country codes**: Use ISO 3166-1 alpha-2 country codes (e.g., 'DE', 'FR', 'GB'). The extension supports 29 countries (28 EU + UK).
 

--- a/python/src/anofox/money.py
+++ b/python/src/anofox/money.py
@@ -1,13 +1,16 @@
 """
 Money type wrappers.
 
-The extension represents money as a STRUCT(amount DOUBLE, currency VARCHAR).
+The extension represents money as a STRUCT(amount DECIMAL(18,3), currency VARCHAR).
+Amounts are exact decimals: DuckDB returns them as :class:`decimal.Decimal`, and
+the wrappers preserve that type so no binary floating point drift is introduced.
 Python-side results come back as dicts with ``amount`` and ``currency`` keys
 when DuckDB returns a struct, or as plain scalars for scalar-returning functions.
 """
 
 from __future__ import annotations
 
+from decimal import Decimal
 from typing import Any
 
 
@@ -20,14 +23,15 @@ def make_money(conn: Any, amount: float, currency: str) -> dict:
     conn:
         An :class:`~anofox.AnofoxConnection`.
     amount:
-        Monetary amount.
+        Monetary amount. Must be finite (NaN/Inf raise) and within the
+        DECIMAL(18,3) range; it is rounded half away from zero to 3 decimals.
     currency:
         ISO 4217 currency code, e.g. ``"USD"`` or ``"EUR"``.
 
     Returns
     -------
     dict
-        ``{"amount": float, "currency": str}``
+        ``{"amount": decimal.Decimal, "currency": str}``
     """
     result = conn.execute(
         f"SELECT anofox_tab_money({amount}, '{currency}')"
@@ -51,9 +55,10 @@ def money_from_cents(conn: Any, cents: int, currency: str) -> dict:
     Returns
     -------
     dict
-        ``{"amount": float, "currency": str}`` where ``amount`` is in major
-        units (the cents value divided by the currency's ``subunit_to_unit``,
-        e.g. ``1000`` cents -> ``10.0`` USD).
+        ``{"amount": decimal.Decimal, "currency": str}`` where ``amount`` is in
+        major units (the cents value divided by the currency's
+        ``subunit_to_unit``, e.g. ``1000`` cents -> ``Decimal("10.000")`` USD).
+        The conversion is exact for the full BIGINT cents range.
     """
     result = conn.execute(
         f"SELECT anofox_tab_money_from_cents({cents}, '{currency}')"
@@ -61,14 +66,14 @@ def money_from_cents(conn: Any, cents: int, currency: str) -> dict:
     return _struct_to_dict(result[0])
 
 
-def money_amount(conn: Any, money: dict) -> float:
-    """Extract the numeric amount from a money dict."""
+def money_amount(conn: Any, money: dict) -> Decimal:
+    """Extract the exact numeric amount (``decimal.Decimal``) from a money dict."""
     amount = money.get("amount", 0)
     currency = money.get("currency", "USD")
     result = conn.execute(
         f"SELECT anofox_tab_money_amount(anofox_tab_money({amount}, '{currency}'))"
     ).fetchone()
-    return float(result[0])
+    return Decimal(result[0]) if not isinstance(result[0], Decimal) else result[0]
 
 
 def money_currency(conn: Any, money: dict) -> str:
@@ -226,10 +231,11 @@ def money_same_currency(conn: Any, m1: dict, m2: dict) -> bool:
 # ---------------------------------------------------------------------------
 
 def _struct_to_dict(value: Any) -> dict:
-    """Convert a DuckDB struct value to a Python dict."""
+    """Convert a DuckDB struct value to a Python dict (amount stays an exact Decimal)."""
     if isinstance(value, dict):
         return value
     # DuckDB may return structs as tuples in some driver versions
     if isinstance(value, (list, tuple)) and len(value) == 2:
-        return {"amount": float(value[0]), "currency": str(value[1])}
+        amount = value[0] if isinstance(value[0], Decimal) else Decimal(str(value[0]))
+        return {"amount": amount, "currency": str(value[1])}
     return {"raw": value}

--- a/python/tests/test_money.py
+++ b/python/tests/test_money.py
@@ -1,8 +1,12 @@
 """
-Tests for money.py — assert return types and basic arithmetic correctness.
+Tests for money.py — assert return types and exact arithmetic correctness.
+
+Money amounts are DECIMAL(18,3) in the extension and surface as
+``decimal.Decimal`` in Python (issue #57).
 """
 
 import sys
+from decimal import Decimal
 from pathlib import Path
 
 import pytest
@@ -20,7 +24,8 @@ class TestMakeMoney:
         from anofox import money
         result = money.make_money(conn, 42.5, "EUR")
         assert "amount" in result
-        assert abs(result["amount"] - 42.5) < 0.001
+        assert isinstance(result["amount"], Decimal)
+        assert result["amount"] == Decimal("42.500")
 
     def test_currency_field(self, conn):
         from anofox import money
@@ -39,13 +44,13 @@ class TestMoneyFromCents:
         from anofox import money
         result = money.money_from_cents(conn, 1000, "USD")
         # 1000 cents = 10.00 USD (divided by the currency's subunit_to_unit)
-        assert abs(result["amount"] - 10.0) < 0.001
+        assert result["amount"] == Decimal("10.000")
 
     def test_zero_decimal_currency_unchanged(self, conn):
         from anofox import money
         result = money.money_from_cents(conn, 1000, "JPY")
         # JPY has no subunit (subunit_to_unit = 1), value is unchanged
-        assert abs(result["amount"] - 1000.0) < 0.001
+        assert result["amount"] == Decimal("1000.000")
 
 
 class TestIsValidCurrency:
@@ -104,7 +109,7 @@ class TestMoneyArithmetic:
         m1 = {"amount": 10.0, "currency": "USD"}
         m2 = {"amount": 5.0, "currency": "USD"}
         result = money.money_add(conn, m1, m2)
-        assert abs(result["amount"] - 15.0) < 0.001
+        assert result["amount"] == Decimal("15.000")
 
     def test_subtract_returns_dict(self, conn):
         from anofox import money
@@ -112,14 +117,14 @@ class TestMoneyArithmetic:
         m2 = {"amount": 3.0, "currency": "EUR"}
         result = money.money_subtract(conn, m1, m2)
         assert isinstance(result, dict)
-        assert abs(result["amount"] - 7.0) < 0.001
+        assert result["amount"] == Decimal("7.000")
 
     def test_multiply_returns_dict(self, conn):
         from anofox import money
         m = {"amount": 10.0, "currency": "USD"}
         result = money.money_multiply(conn, m, 2.5)
         assert isinstance(result, dict)
-        assert abs(result["amount"] - 25.0) < 0.001
+        assert result["amount"] == Decimal("25.000")
 
 
 class TestMoneyPredicates:
@@ -164,3 +169,54 @@ class TestMoneyPredicates:
         m1 = {"amount": 10.0, "currency": "USD"}
         m2 = {"amount": 20.0, "currency": "EUR"}
         assert money.money_same_currency(conn, m1, m2) is False
+
+
+class TestMoneyExactness:
+    """Amounts are exact DECIMAL(18,3): no binary floating point drift (issue #57)."""
+
+    def test_amount_is_decimal(self, conn):
+        from anofox import money
+        result = money.make_money(conn, 10.0, "USD")
+        assert isinstance(result["amount"], Decimal)
+
+    def test_point_one_plus_point_two_is_exactly_point_three(self, conn):
+        from anofox import money
+        m1 = {"amount": 0.1, "currency": "USD"}
+        m2 = {"amount": 0.2, "currency": "USD"}
+        result = money.money_add(conn, m1, m2)
+        assert result["amount"] == Decimal("0.300")
+
+    def test_money_amount_returns_exact_decimal(self, conn):
+        from anofox import money
+        amount = money.money_amount(conn, {"amount": 19.99, "currency": "USD"})
+        assert isinstance(amount, Decimal)
+        assert amount == Decimal("19.990")
+
+    def test_cents_round_trip_is_exact(self, conn):
+        from anofox import money
+        result = money.money_from_cents(conn, 123456789, "USD")
+        assert result["amount"] == Decimal("1234567.890")
+
+    def test_nan_amount_raises(self, conn):
+        import duckdb
+        with pytest.raises(duckdb.Error):
+            conn.execute("SELECT anofox_tab_money('NaN'::DOUBLE, 'USD')").fetchone()
+
+    def test_overflow_raises(self, conn):
+        import duckdb
+        with pytest.raises(duckdb.Error):
+            conn.execute("SELECT anofox_tab_money(1e16, 'USD')").fetchone()
+
+
+class TestMoneyFormatting:
+    """money_format derives scale and separators from currency metadata (issue #57)."""
+
+    def test_jpy_has_no_decimals(self, conn):
+        from anofox import money
+        result = money.money_format(conn, {"amount": 1000, "currency": "JPY"}, "symbol")
+        assert result == "\u00a51,000"
+
+    def test_usd_thousands_separator(self, conn):
+        from anofox import money
+        result = money.money_format(conn, {"amount": 1234567.89, "currency": "USD"}, "symbol")
+        assert result == "$1,234,567.89"

--- a/src/anofox_money.cpp
+++ b/src/anofox_money.cpp
@@ -6,8 +6,13 @@
 #include "duckdb/common/types/value.hpp"
 #include "duckdb/common/types/vector.hpp"
 #include "duckdb/common/types/decimal.hpp"
+#include "duckdb/common/operator/add.hpp"
+#include "duckdb/common/operator/multiply.hpp"
+#include "duckdb/common/operator/subtract.hpp"
 #include "duckdb/function/scalar_function.hpp"
 #include "duckdb/common/string_util.hpp"
+
+#include <cmath>
 
 namespace duckdb {
 namespace anofox {
@@ -18,9 +23,89 @@ namespace anofox {
 
 static LogicalType GetMoneyType() {
     child_list_t<LogicalType> children;
-    children.push_back(make_pair("amount", LogicalTypeId::DOUBLE));
+    children.push_back(make_pair("amount", LogicalType::DECIMAL(MONEY_WIDTH, MONEY_SCALE)));
     children.push_back(make_pair("currency", LogicalTypeId::VARCHAR));
     return LogicalType::STRUCT(children);
+}
+
+static LogicalType GetMoneyAmountType() {
+    return LogicalType::DECIMAL(MONEY_WIDTH, MONEY_SCALE);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// Exact Amount Helpers (scaled DECIMAL(18,3) arithmetic, issue #57)
+//----------------------------------------------------------------------------------------------------------------------
+
+//! Converts a DOUBLE amount in major units to the scaled DECIMAL(18,3) representation.
+//! Rejects NaN/Inf and rounds half away from zero to MONEY_SCALE fractional digits.
+static int64_t ScaledFromDouble(double amount) {
+    if (!std::isfinite(amount)) {
+        throw InvalidInputException("Money amount must be finite, got: %s", std::to_string(amount));
+    }
+    double scaled = std::round(amount * static_cast<double>(MONEY_SCALE_FACTOR));
+    if (!(scaled >= -static_cast<double>(MONEY_MAX_SCALED) && scaled <= static_cast<double>(MONEY_MAX_SCALED))) {
+        throw OutOfRangeException("Money amount %s is out of range for DECIMAL(%d,%d)", std::to_string(amount),
+                                  MONEY_WIDTH, MONEY_SCALE);
+    }
+    return static_cast<int64_t>(scaled);
+}
+
+//! Verifies that a scaled value fits the DECIMAL(18,3) width.
+static int64_t CheckScaledRange(int64_t scaled, bool in_range, const char *operation) {
+    if (!in_range || scaled > MONEY_MAX_SCALED || scaled < -MONEY_MAX_SCALED) {
+        throw OutOfRangeException("Money %s result is out of range for DECIMAL(%d,%d)", operation, MONEY_WIDTH,
+                                  MONEY_SCALE);
+    }
+    return scaled;
+}
+
+static int64_t CheckedAddScaled(int64_t left, int64_t right) {
+    int64_t result = 0;
+    bool ok = TryAddOperator::Operation<int64_t, int64_t, int64_t>(left, right, result);
+    return CheckScaledRange(result, ok, "addition");
+}
+
+static int64_t CheckedSubtractScaled(int64_t left, int64_t right) {
+    int64_t result = 0;
+    bool ok = TrySubtractOperator::Operation<int64_t, int64_t, int64_t>(left, right, result);
+    return CheckScaledRange(result, ok, "subtraction");
+}
+
+//! Converts an amount in the smallest currency unit (e.g. cents) to the scaled
+//! representation exactly: scaled = cents * (MONEY_SCALE_FACTOR / subunit_to_unit).
+static int64_t ScaledFromCents(int64_t cents, const CurrencyInfo &currency) {
+    const auto divisor = currency.subunit_to_unit;
+    if (divisor <= 0) {
+        throw InternalException("Invalid subunit_to_unit %d for currency: %s", divisor, currency.iso_code.c_str());
+    }
+    if (MONEY_SCALE_FACTOR % divisor != 0) {
+        // No registered currency has such a subunit; reject instead of losing precision.
+        throw NotImplementedException("Currency %s with subunit_to_unit %d is not representable in DECIMAL(%d,%d)",
+                                      currency.iso_code.c_str(), divisor, MONEY_WIDTH, MONEY_SCALE);
+    }
+    const int64_t factor = MONEY_SCALE_FACTOR / divisor;
+    int64_t result = 0;
+    bool ok = TryMultiplyOperator::Operation<int64_t, int64_t, int64_t>(cents, factor, result);
+    if (!ok || result > MONEY_MAX_SCALED || result < -MONEY_MAX_SCALED) {
+        throw OutOfRangeException("Money amount of %s %s subunits is out of range for DECIMAL(%d,%d)",
+                                  std::to_string(cents), currency.iso_code.c_str(), MONEY_WIDTH, MONEY_SCALE);
+    }
+    return result;
+}
+
+//! Multiplies a scaled amount by a DOUBLE factor with explicit overflow checks,
+//! rounding half away from zero to MONEY_SCALE fractional digits.
+static int64_t CheckedMultiplyFactor(int64_t scaled, double factor) {
+    if (!std::isfinite(factor)) {
+        throw InvalidInputException("Money multiply factor must be finite, got: %s", std::to_string(factor));
+    }
+    long double product = static_cast<long double>(scaled) * static_cast<long double>(factor);
+    if (!(product >= -static_cast<long double>(MONEY_MAX_SCALED) &&
+          product <= static_cast<long double>(MONEY_MAX_SCALED))) {
+        throw OutOfRangeException("Money multiplication result is out of range for DECIMAL(%d,%d)", MONEY_WIDTH,
+                                  MONEY_SCALE);
+    }
+    return static_cast<int64_t>(llroundl(product));
 }
 
 //! Looks up a currency in the registry (case-insensitive) and throws for unknown codes.
@@ -61,8 +146,9 @@ static void AnofoxMoneyFunction(DataChunk &args, ExpressionState &state, Vector 
         } else {
             auto currency_code = currency_values[currency_idx].GetString();
             auto &currency = LookupCurrencyOrThrow(registry, currency_code);
-            // Store the canonical ISO code so that downstream comparisons work regardless of input case
-            SetMoneyResult(builder, i, amount_values[amount_idx], currency.iso_code, result);
+            // Store the canonical ISO code so that downstream comparisons work regardless of input case.
+            // The DOUBLE input is validated (finite) and rounded to the exact DECIMAL(18,3) representation.
+            SetMoneyResult(builder, i, ScaledFromDouble(amount_values[amount_idx]), currency.iso_code, result);
         }
     }
 }
@@ -97,21 +183,14 @@ static void AnofoxMoneyFromCentsFunction(DataChunk &args, ExpressionState &state
             auto currency_code = currency_values[currency_idx].GetString();
             auto &currency = LookupCurrencyOrThrow(registry, currency_code);
 
-            const auto divisor = currency.subunit_to_unit;
-            if (divisor <= 0) {
-                throw InternalException("Invalid subunit_to_unit %d for currency: %s", divisor,
-                                        currency.iso_code.c_str());
-            }
-
-            // Convert the smallest-unit amount to major units (e.g. 10050 cents -> 100.50 USD)
-            double amount = static_cast<double>(cents_values[cents_idx]) / static_cast<double>(divisor);
-            SetMoneyResult(builder, i, amount, currency.iso_code, result);
+            // Convert the smallest-unit amount to major units exactly (e.g. 10050 cents -> 100.500 USD)
+            SetMoneyResult(builder, i, ScaledFromCents(cents_values[cents_idx], currency), currency.iso_code, result);
         }
     }
 }
 
 //----------------------------------------------------------------------------------------------------------------------
-// Scalar Function: anofox_money_amount(money) -> DOUBLE
+// Scalar Function: anofox_money_amount(money) -> DECIMAL(18,3)
 //----------------------------------------------------------------------------------------------------------------------
 
 static void AnofoxMoneyAmountFunction(DataChunk &args, ExpressionState &state, Vector &result) {
@@ -119,7 +198,7 @@ static void AnofoxMoneyAmountFunction(DataChunk &args, ExpressionState &state, V
     idx_t count = args.size();
 
     auto data = ExtractMoneyStruct(money_vec, count);
-    auto result_data = FlatVector::GetData<double>(result);
+    auto result_data = FlatVector::GetData<int64_t>(result);
 
     for (idx_t i = 0; i < count; i++) {
         if (!data.RowIsValid(i)) {
@@ -179,6 +258,68 @@ static void AnofoxCurrencySymbolFunction(DataChunk &args, ExpressionState &state
 // Scalar Function: anofox_money_format(money, format_style) -> VARCHAR
 //----------------------------------------------------------------------------------------------------------------------
 
+//! Number of fractional digits implied by a currency's subunit_to_unit
+//! (100 -> 2, 1 -> 0, 1000 -> 3, 5 -> 1), capped at the storage scale.
+static int CurrencyDecimalDigits(const CurrencyInfo &currency) {
+    int digits = 0;
+    int64_t power = 1;
+    while (power < currency.subunit_to_unit && digits < MONEY_SCALE) {
+        power *= 10;
+        digits++;
+    }
+    return digits;
+}
+
+//! Renders a scaled amount with the currency's scale. When `localized` is set,
+//! the currency's decimal_mark and thousands_separator are applied; otherwise
+//! the output is canonical (dot decimal mark, no grouping). Shared across the
+//! 'symbol', 'long' and 'code' styles so validation and rounding are uniform.
+static std::string FormatMoneyAmount(int64_t scaled, const CurrencyInfo &currency, bool localized) {
+    const int decimals = CurrencyDecimalDigits(currency);
+
+    // Round half away from zero to the currency scale
+    int64_t drop = 1;
+    for (int d = decimals; d < MONEY_SCALE; d++) {
+        drop *= 10;
+    }
+    const int64_t half = drop / 2;
+    int64_t rounded = scaled >= 0 ? (scaled + half) / drop : -((-scaled + half) / drop);
+
+    int64_t frac_divisor = 1;
+    for (int d = 0; d < decimals; d++) {
+        frac_divisor *= 10;
+    }
+
+    const bool negative = rounded < 0;
+    const uint64_t abs_value = negative ? static_cast<uint64_t>(-rounded) : static_cast<uint64_t>(rounded);
+    const uint64_t int_part = abs_value / static_cast<uint64_t>(frac_divisor);
+    const uint64_t frac_part = abs_value % static_cast<uint64_t>(frac_divisor);
+
+    // Integer digits with optional grouping
+    std::string digits = std::to_string(int_part);
+    const std::string &separator = currency.thousands_separator;
+    if (localized && !separator.empty()) {
+        std::string grouped;
+        const idx_t length = digits.size();
+        for (idx_t pos = 0; pos < length; pos++) {
+            if (pos > 0 && (length - pos) % 3 == 0) {
+                grouped += separator;
+            }
+            grouped += digits[pos];
+        }
+        digits = std::move(grouped);
+    }
+
+    std::string formatted = negative ? "-" : "";
+    formatted += digits;
+    if (decimals > 0) {
+        const std::string &mark = (localized && !currency.decimal_mark.empty()) ? currency.decimal_mark : ".";
+        std::string frac_digits = std::to_string(frac_part);
+        formatted += mark + std::string(static_cast<idx_t>(decimals) - frac_digits.size(), '0') + frac_digits;
+    }
+    return formatted;
+}
+
 static void AnofoxMoneyFormatFunction(DataChunk &args, ExpressionState &state, Vector &result) {
     auto &money_vec = args.data[0];
     auto &style_vec = args.data[1];
@@ -199,43 +340,29 @@ static void AnofoxMoneyFormatFunction(DataChunk &args, ExpressionState &state, V
         if (!data.RowIsValid(i) || !style_data.validity.RowIsValid(style_idx)) {
             FlatVector::SetNull(result, i, true);
         } else {
-            double amount = data.Amount(i);
+            auto scaled = data.Amount(i);
             auto currency_code = data.Currency(i);
             auto format_style = style_values[style_idx].GetString();
 
             auto &currency = LookupCurrencyOrThrow(registry, currency_code);
 
-            // Format based on style
+            // Format based on style; the amount rendering is shared (scale and
+            // rounding from currency metadata, issue #57)
             std::string formatted;
             if (format_style == "symbol") {
-                // Format: $100.50 or 100,50 € depending on symbol_first
-                char buffer[256];
-                snprintf(buffer, sizeof(buffer), "%.2f", amount);
-                std::string amount_str(buffer);
-
-                // Replace decimal mark if needed
-                if (currency.decimal_mark != ".") {
-                    size_t dot_pos = amount_str.find('.');
-                    if (dot_pos != std::string::npos) {
-                        amount_str[dot_pos] = currency.decimal_mark[0];
-                    }
-                }
-
+                // Localized: $1,234.56 or 1.234,56 € depending on symbol_first
+                auto amount_str = FormatMoneyAmount(scaled, currency, true);
                 if (currency.symbol_first) {
                     formatted = currency.symbol + amount_str;
                 } else {
                     formatted = amount_str + " " + currency.symbol;
                 }
             } else if (format_style == "long") {
-                // Format: 100.50 United States Dollar
-                char buffer[512];
-                snprintf(buffer, sizeof(buffer), "%.2f %s", amount, currency.name.c_str());
-                formatted = buffer;
+                // Localized amount with the full currency name: 1.234,56 Euro
+                formatted = FormatMoneyAmount(scaled, currency, true) + " " + currency.name;
             } else {
-                // 'code' and default: ISO format with the canonical currency code
-                char buffer[256];
-                snprintf(buffer, sizeof(buffer), "%.2f %s", amount, currency.iso_code.c_str());
-                formatted = buffer;
+                // 'code' and default: canonical machine-readable amount with the ISO code
+                formatted = FormatMoneyAmount(scaled, currency, false) + " " + currency.iso_code;
             }
 
             result_data[i] = StringVector::AddString(result, formatted);
@@ -248,8 +375,8 @@ static void AnofoxMoneyFormatFunction(DataChunk &args, ExpressionState &state, V
 //----------------------------------------------------------------------------------------------------------------------
 
 static void AnofoxMoneyIsPositiveFunction(DataChunk &args, ExpressionState &state, Vector &result) {
-    IterateMoneyComparison(args, result, [](double amount) {
-        return amount > 0.0;
+    IterateMoneyComparison(args, result, [](int64_t scaled) {
+        return scaled > 0;
     });
 }
 
@@ -258,8 +385,8 @@ static void AnofoxMoneyIsPositiveFunction(DataChunk &args, ExpressionState &stat
 //----------------------------------------------------------------------------------------------------------------------
 
 static void AnofoxMoneyIsNegativeFunction(DataChunk &args, ExpressionState &state, Vector &result) {
-    IterateMoneyComparison(args, result, [](double amount) {
-        return amount < 0.0;
+    IterateMoneyComparison(args, result, [](int64_t scaled) {
+        return scaled < 0;
     });
 }
 
@@ -268,8 +395,8 @@ static void AnofoxMoneyIsNegativeFunction(DataChunk &args, ExpressionState &stat
 //----------------------------------------------------------------------------------------------------------------------
 
 static void AnofoxMoneyIsZeroFunction(DataChunk &args, ExpressionState &state, Vector &result) {
-    IterateMoneyComparison(args, result, [](double amount) {
-        return amount == 0.0;
+    IterateMoneyComparison(args, result, [](int64_t scaled) {
+        return scaled == 0;
     });
 }
 
@@ -288,7 +415,9 @@ static void AnofoxMoneyAbsFunction(DataChunk &args, ExpressionState &state, Vect
         if (!data.RowIsValid(i)) {
             SetMoneyResultNull(result, i);
         } else {
-            SetMoneyResult(builder, i, std::fabs(data.Amount(i)), data.Currency(i), result);
+            // The scaled amount is range-checked at construction, so negation cannot overflow
+            auto scaled = data.Amount(i);
+            SetMoneyResult(builder, i, scaled < 0 ? -scaled : scaled, data.Currency(i), result);
         }
     }
 }
@@ -299,9 +428,9 @@ static void AnofoxMoneyAbsFunction(DataChunk &args, ExpressionState &state, Vect
 
 static void AnofoxMoneyAddFunction(DataChunk &args, ExpressionState &state, Vector &result) {
     IterateBinaryMoneyOp(args, result, true, [](MoneyResultBuilder& builder, idx_t i,
-                                                double amount1, double amount2,
+                                                int64_t scaled1, int64_t scaled2,
                                                 const std::string& currency, Vector& result) {
-        SetMoneyResult(builder, i, amount1 + amount2, currency, result);
+        SetMoneyResult(builder, i, CheckedAddScaled(scaled1, scaled2), currency, result);
     });
 }
 
@@ -311,9 +440,9 @@ static void AnofoxMoneyAddFunction(DataChunk &args, ExpressionState &state, Vect
 
 static void AnofoxMoneySubtractFunction(DataChunk &args, ExpressionState &state, Vector &result) {
     IterateBinaryMoneyOp(args, result, true, [](MoneyResultBuilder& builder, idx_t i,
-                                                double amount1, double amount2,
+                                                int64_t scaled1, int64_t scaled2,
                                                 const std::string& currency, Vector& result) {
-        SetMoneyResult(builder, i, amount1 - amount2, currency, result);
+        SetMoneyResult(builder, i, CheckedSubtractScaled(scaled1, scaled2), currency, result);
     });
 }
 
@@ -339,7 +468,8 @@ static void AnofoxMoneyMultiplyFunction(DataChunk &args, ExpressionState &state,
         if (!data.RowIsValid(i) || !factor_data.validity.RowIsValid(factor_idx)) {
             SetMoneyResultNull(result, i);
         } else {
-            SetMoneyResult(builder, i, data.Amount(i) * factor_values[factor_idx], data.Currency(i), result);
+            SetMoneyResult(builder, i, CheckedMultiplyFactor(data.Amount(i), factor_values[factor_idx]),
+                           data.Currency(i), result);
         }
     }
 }
@@ -372,7 +502,7 @@ static void AnofoxMoneyInRangeFunction(DataChunk &args, ExpressionState &state, 
             !max_data.validity.RowIsValid(max_idx)) {
             FlatVector::SetNull(result, i, true);
         } else {
-            double amount = data.Amount(i);
+            double amount = static_cast<double>(data.Amount(i)) / static_cast<double>(MONEY_SCALE_FACTOR);
             double min_val = min_values[min_idx];
             double max_val = max_values[max_idx];
             result_data[i] = (amount >= min_val && amount <= max_val);
@@ -538,12 +668,12 @@ void RegisterMoneyFunctions(ExtensionLoader &loader) {
     }
     {
         FunctionDescription desc;
-        desc.description = "Extracts the numeric amount from a money value.";
+        desc.description = "Extracts the exact numeric amount (DECIMAL(18,3)) from a money value.";
         desc.parameter_names = {"money"};
         desc.parameter_types = {GetMoneyType()};
         desc.examples = {"SELECT money_amount(money(19.99, 'USD'));"};
         desc.categories = {"money"};
-        ScalarFunction money_amount_func("anofox_tab_money_amount", {GetMoneyType()}, LogicalTypeId::DOUBLE, AnofoxMoneyAmountFunction);
+        ScalarFunction money_amount_func("anofox_tab_money_amount", {GetMoneyType()}, GetMoneyAmountType(), AnofoxMoneyAmountFunction);
         money_amount_func.bind = MoneyAmountBind;
         money_amount_func.SetFallible();
         RegisterScalarFunctionWithAlias(loader, money_amount_func, "money_amount", {std::move(desc)});

--- a/src/include/anofox_money.hpp
+++ b/src/include/anofox_money.hpp
@@ -9,6 +9,26 @@ namespace duckdb {
 namespace anofox {
 
 // ============================================================================
+// Money representation (issue #57)
+//
+// Money amounts are stored as DECIMAL(18,3): exact decimal semantics, three
+// fractional digits (covers 2-decimal currencies plus 3-decimal currencies
+// such as BHD/KWD/TND). DuckDB stores DECIMAL(18,3) physically as an int64
+// scaled by 10^3, so all C++ arithmetic below is checked integer math on the
+// scaled representation. NaN/Inf are unrepresentable by construction and
+// overflow raises a clear error instead of wrapping or producing Inf.
+// ============================================================================
+
+//! Number of fractional digits of the money DECIMAL type.
+static constexpr uint8_t MONEY_SCALE = 3;
+//! Total precision (width) of the money DECIMAL type.
+static constexpr uint8_t MONEY_WIDTH = 18;
+//! Scaling factor between major units and the stored representation (10^MONEY_SCALE).
+static constexpr int64_t MONEY_SCALE_FACTOR = 1000;
+//! Largest scaled value representable in DECIMAL(18,3): 18 nines.
+static constexpr int64_t MONEY_MAX_SCALED = 999999999999999999LL;
+
+// ============================================================================
 // Helper: Money Struct Data Accessor
 // ============================================================================
 struct MoneyStructData {
@@ -17,7 +37,7 @@ struct MoneyStructData {
   UnifiedVectorFormat struct_data;
   UnifiedVectorFormat amount_data;
   UnifiedVectorFormat currency_data;
-  double* amount_values;
+  int64_t* amount_values;
   string_t* currency_values;
 
   //! A money row is only usable if the parent struct and both children are non-NULL.
@@ -31,7 +51,8 @@ struct MoneyStructData {
            currency_data.validity.RowIsValid(currency_data.sel->get_index(row));
   }
 
-  double Amount(idx_t i) const {
+  //! Returns the amount in the scaled DECIMAL(18,3) representation (milli-units).
+  int64_t Amount(idx_t i) const {
     auto row = struct_data.sel->get_index(i);
     return amount_values[amount_data.sel->get_index(row)];
   }
@@ -56,7 +77,7 @@ inline MoneyStructData ExtractMoneyStruct(Vector& money_vec, idx_t count) {
   money_vec.ToUnifiedFormat(count, data.struct_data);
   data.amount_vec.ToUnifiedFormat(count, data.amount_data);
   data.currency_vec.ToUnifiedFormat(count, data.currency_data);
-  data.amount_values = reinterpret_cast<double*>(data.amount_data.data);
+  data.amount_values = reinterpret_cast<int64_t*>(data.amount_data.data);
   data.currency_values = reinterpret_cast<string_t*>(data.currency_data.data);
 
   return data;
@@ -66,7 +87,7 @@ inline MoneyStructData ExtractMoneyStruct(Vector& money_vec, idx_t count) {
 // Helper: Money Result Builder
 // ============================================================================
 struct MoneyResultBuilder {
-  double* amount_ptr;
+  int64_t* amount_ptr;
   string_t* currency_ptr;
   ValidityMask& amount_validity;
   ValidityMask& currency_validity;
@@ -85,7 +106,7 @@ inline MoneyResultBuilder PrepareMoneyResult(Vector& result) {
   currency_vec.SetVectorType(VectorType::FLAT_VECTOR);
 
   return MoneyResultBuilder{
-    FlatVector::GetData<double>(amount_vec),
+    FlatVector::GetData<int64_t>(amount_vec),
     FlatVector::GetData<string_t>(currency_vec),
     FlatVector::Validity(amount_vec),
     FlatVector::Validity(currency_vec),
@@ -93,9 +114,9 @@ inline MoneyResultBuilder PrepareMoneyResult(Vector& result) {
 }
 
 inline void SetMoneyResult(MoneyResultBuilder& builder, idx_t i,
-                          double amount, const std::string& currency,
+                          int64_t scaled_amount, const std::string& currency,
                           Vector& result) {
-  builder.amount_ptr[i] = amount;
+  builder.amount_ptr[i] = scaled_amount;
   auto& children = StructVector::GetEntries(result);
   builder.currency_ptr[i] = StringVector::AddString(*children[1], currency);
 }

--- a/test/sql/anofox_money.test
+++ b/test/sql/anofox_money.test
@@ -4,40 +4,40 @@ require anofox_tabular
 query T
 SELECT anofox_tab_money(100.50, 'USD');
 ----
-{'amount': 100.5, 'currency': USD}
+{'amount': 100.500, 'currency': USD}
 
 # Test anofox_tab_money with different currencies
 query T
 SELECT anofox_tab_money(50.00, 'EUR');
 ----
-{'amount': 50.0, 'currency': EUR}
+{'amount': 50.000, 'currency': EUR}
 
 query T
 SELECT anofox_tab_money(1000.0, 'JPY');
 ----
-{'amount': 1000.0, 'currency': JPY}
+{'amount': 1000.000, 'currency': JPY}
 
 # Test anofox_tab_money_from_cents (divides by the currency's subunit_to_unit)
 query T
 SELECT anofox_tab_money_from_cents(10050, 'USD');
 ----
-{'amount': 100.5, 'currency': USD}
+{'amount': 100.500, 'currency': USD}
 
 query T
 SELECT anofox_tab_money_from_cents(5000, 'EUR');
 ----
-{'amount': 50.0, 'currency': EUR}
+{'amount': 50.000, 'currency': EUR}
 
 # Test anofox_tab_money_amount extraction
-query I
+query R
 SELECT anofox_tab_money_amount(anofox_tab_money(100.50, 'USD'));
 ----
-100
+100.5
 
-query I
+query R
 SELECT anofox_tab_money_amount(anofox_tab_money(75.25, 'EUR'));
 ----
-75
+75.25
 
 # Test anofox_tab_money_currency extraction
 query T
@@ -218,9 +218,9 @@ SELECT anofox_tab_money(amount, code) FROM (
     SELECT 1000.0 as amount, 'JPY' as code
 ) ORDER BY amount DESC;
 ----
-{'amount': 1000.0, 'currency': JPY}
-{'amount': 100.5, 'currency': USD}
-{'amount': 75.0, 'currency': EUR}
+{'amount': 1000.000, 'currency': JPY}
+{'amount': 100.500, 'currency': USD}
+{'amount': 75.000, 'currency': EUR}
 
 # Test currency validation on vectors
 query I
@@ -243,12 +243,12 @@ SELECT COUNT(*) FROM (
 # SELECT anofox_tab_money(100.50, 'INVALID');
 
 # Test money field access via column reference
-query TI
-SELECT anofox_tab_money_currency(m), CAST(anofox_tab_money_amount(m) AS INTEGER) FROM (
+query TR
+SELECT anofox_tab_money_currency(m), anofox_tab_money_amount(m) FROM (
     SELECT anofox_tab_money(100.50, 'USD') as m
 );
 ----
-USD	100
+USD	100.5
 
 # Test chaining operations
 query T
@@ -260,7 +260,7 @@ SELECT anofox_tab_currency_symbol(anofox_tab_money_currency(anofox_tab_money(50.
 query T
 SELECT anofox_tab_money(100.0, 'usd');
 ----
-{'amount': 100.0, 'currency': USD}
+{'amount': 100.000, 'currency': USD}
 
 # Test anofox_tab_money_format with 'symbol' style
 query T
@@ -276,7 +276,7 @@ SELECT anofox_tab_money_format(anofox_tab_money(75.25, 'EUR'), 'symbol');
 query T
 SELECT anofox_tab_money_format(anofox_tab_money(1000.00, 'JPY'), 'symbol');
 ----
-¥1000.00
+¥1,000
 
 # Test anofox_tab_money_format with 'code' style
 query T
@@ -298,12 +298,12 @@ SELECT anofox_tab_money_format(anofox_tab_money(100.50, 'USD'), 'long');
 query T
 SELECT anofox_tab_money_format(anofox_tab_money(75.25, 'EUR'), 'long');
 ----
-75.25 Euro
+75,25 Euro
 
 query T
 SELECT anofox_tab_money_format(anofox_tab_money(1000.00, 'JPY'), 'long');
 ----
-1000.00 Japanese Yen
+1,000 Japanese Yen
 
 # Test anofox_tab_money_format with default/unknown style (defaults to code)
 query T
@@ -345,12 +345,12 @@ $0.01
 query T
 SELECT anofox_tab_money_format(anofox_tab_money(999999.99, 'USD'), 'symbol');
 ----
-$999999.99
+$999,999.99
 
 query T
 SELECT anofox_tab_money_format(anofox_tab_money(1000.00, 'USD'), 'symbol');
 ----
-$1000.00
+$1,000.00
 
 # Test anofox_tab_money_is_positive
 query I
@@ -424,17 +424,17 @@ NULL
 query T
 SELECT anofox_tab_money_abs(anofox_tab_money(-100.0, 'USD'));
 ----
-{'amount': 100.0, 'currency': USD}
+{'amount': 100.000, 'currency': USD}
 
 query T
 SELECT anofox_tab_money_abs(anofox_tab_money(100.0, 'USD'));
 ----
-{'amount': 100.0, 'currency': USD}
+{'amount': 100.000, 'currency': USD}
 
 query T
 SELECT anofox_tab_money_abs(anofox_tab_money(0.0, 'EUR'));
 ----
-{'amount': 0.0, 'currency': EUR}
+{'amount': 0.000, 'currency': EUR}
 
 query T
 SELECT anofox_tab_money_abs(NULL);
@@ -486,17 +486,17 @@ SELECT anofox_tab_money_format(anofox_tab_money_abs(anofox_tab_money(-123.45, 'E
 query T
 SELECT anofox_tab_money_add(anofox_tab_money(100.0, 'USD'), anofox_tab_money(50.0, 'USD'));
 ----
-{'amount': 150.0, 'currency': USD}
+{'amount': 150.000, 'currency': USD}
 
 query T
 SELECT anofox_tab_money_add(anofox_tab_money(25.50, 'EUR'), anofox_tab_money(75.50, 'EUR'));
 ----
-{'amount': 101.0, 'currency': EUR}
+{'amount': 101.000, 'currency': EUR}
 
 query T
 SELECT anofox_tab_money_add(anofox_tab_money(-10.0, 'USD'), anofox_tab_money(10.0, 'USD'));
 ----
-{'amount': 0.0, 'currency': USD}
+{'amount': 0.000, 'currency': USD}
 
 # Test anofox_tab_money_add with NULL values
 query T
@@ -513,17 +513,17 @@ NULL
 query T
 SELECT anofox_tab_money_subtract(anofox_tab_money(100.0, 'USD'), anofox_tab_money(30.0, 'USD'));
 ----
-{'amount': 70.0, 'currency': USD}
+{'amount': 70.000, 'currency': USD}
 
 query T
 SELECT anofox_tab_money_subtract(anofox_tab_money(50.0, 'EUR'), anofox_tab_money(75.0, 'EUR'));
 ----
-{'amount': -25.0, 'currency': EUR}
+{'amount': -25.000, 'currency': EUR}
 
 query T
 SELECT anofox_tab_money_subtract(anofox_tab_money(100.0, 'USD'), anofox_tab_money(100.0, 'USD'));
 ----
-{'amount': 0.0, 'currency': USD}
+{'amount': 0.000, 'currency': USD}
 
 # Test anofox_tab_money_subtract with NULL values
 query T
@@ -540,27 +540,27 @@ NULL
 query T
 SELECT anofox_tab_money_multiply(anofox_tab_money(25.0, 'USD'), 2.0);
 ----
-{'amount': 50.0, 'currency': USD}
+{'amount': 50.000, 'currency': USD}
 
 query T
 SELECT anofox_tab_money_multiply(anofox_tab_money(100.0, 'EUR'), 0.5);
 ----
-{'amount': 50.0, 'currency': EUR}
+{'amount': 50.000, 'currency': EUR}
 
 query T
 SELECT anofox_tab_money_multiply(anofox_tab_money(50.0, 'USD'), 1.0);
 ----
-{'amount': 50.0, 'currency': USD}
+{'amount': 50.000, 'currency': USD}
 
 query T
 SELECT anofox_tab_money_multiply(anofox_tab_money(50.0, 'USD'), 0.0);
 ----
-{'amount': 0.0, 'currency': USD}
+{'amount': 0.000, 'currency': USD}
 
 query T
 SELECT anofox_tab_money_multiply(anofox_tab_money(10.0, 'USD'), 1.5);
 ----
-{'amount': 15.0, 'currency': USD}
+{'amount': 15.000, 'currency': USD}
 
 # Test anofox_tab_money_multiply with NULL values
 query T
@@ -581,8 +581,8 @@ SELECT anofox_tab_money_add(anofox_tab_money(amount1, 'USD'), anofox_tab_money(a
     SELECT 200.0 as amount1, 75.0 as amount2
 ) ORDER BY amount1;
 ----
-{'amount': 150.0, 'currency': USD}
-{'amount': 275.0, 'currency': USD}
+{'amount': 150.000, 'currency': USD}
+{'amount': 275.000, 'currency': USD}
 
 # Test chaining arithmetic operations
 query T

--- a/test/sql/anofox_money_correctness.test
+++ b/test/sql/anofox_money_correctness.test
@@ -16,7 +16,7 @@ require anofox_tabular
 query T
 SELECT anofox_tab_money_from_cents(10050, 'USD');
 ----
-{'amount': 100.5, 'currency': USD}
+{'amount': 100.500, 'currency': USD}
 
 query R
 SELECT anofox_tab_money_amount(anofox_tab_money_from_cents(1999, 'EUR'));
@@ -27,13 +27,13 @@ SELECT anofox_tab_money_amount(anofox_tab_money_from_cents(1999, 'EUR'));
 query T
 SELECT anofox_tab_money_from_cents(1000, 'JPY');
 ----
-{'amount': 1000.0, 'currency': JPY}
+{'amount': 1000.000, 'currency': JPY}
 
 # Negative cents
 query T
 SELECT anofox_tab_money_from_cents(-500, 'USD');
 ----
-{'amount': -5.0, 'currency': USD}
+{'amount': -5.000, 'currency': USD}
 
 # Large cent values
 query R
@@ -48,17 +48,17 @@ SELECT anofox_tab_money_amount(anofox_tab_money_from_cents(922337203685477, 'USD
 query T
 SELECT anofox_tab_money(100.0, 'usd');
 ----
-{'amount': 100.0, 'currency': USD}
+{'amount': 100.000, 'currency': USD}
 
 query T
 SELECT anofox_tab_money(50.0, 'eUr');
 ----
-{'amount': 50.0, 'currency': EUR}
+{'amount': 50.000, 'currency': EUR}
 
 query T
 SELECT anofox_tab_money_from_cents(1000, 'usd');
 ----
-{'amount': 10.0, 'currency': USD}
+{'amount': 10.000, 'currency': USD}
 
 query T
 SELECT anofox_tab_money_currency(anofox_tab_money(1.0, 'gbp'));
@@ -69,12 +69,12 @@ GBP
 query T
 SELECT anofox_tab_money_add(anofox_tab_money(1.0, 'usd'), anofox_tab_money(1.0, 'USD'));
 ----
-{'amount': 2.0, 'currency': USD}
+{'amount': 2.000, 'currency': USD}
 
 query T
 SELECT anofox_tab_money_subtract(anofox_tab_money(5.0, 'Eur'), anofox_tab_money(2.0, 'EUR'));
 ----
-{'amount': 3.0, 'currency': EUR}
+{'amount': 3.000, 'currency': EUR}
 
 query I
 SELECT anofox_tab_money_same_currency(anofox_tab_money(1.0, 'usd'), anofox_tab_money(1.0, 'USD'));
@@ -164,19 +164,19 @@ DROP TABLE money_null_tbl;
 # the parent struct of the result must be SQL NULL.
 query I
 SELECT anofox_tab_money_abs(s) IS NULL
-FROM (SELECT {'amount': NULL, 'currency': 'USD'}::STRUCT(amount DOUBLE, currency VARCHAR) AS s) t;
+FROM (SELECT {'amount': NULL, 'currency': 'USD'}::STRUCT(amount DECIMAL(18,3), currency VARCHAR) AS s) t;
 ----
 true
 
 query I
 SELECT anofox_tab_money_add(s, anofox_tab_money(1.0, 'USD')) IS NULL
-FROM (SELECT {'amount': 2.0, 'currency': NULL}::STRUCT(amount DOUBLE, currency VARCHAR) AS s) t;
+FROM (SELECT {'amount': 2.0, 'currency': NULL}::STRUCT(amount DECIMAL(18,3), currency VARCHAR) AS s) t;
 ----
 true
 
 query I
 SELECT anofox_tab_money_amount(s) IS NULL
-FROM (SELECT {'amount': NULL, 'currency': 'USD'}::STRUCT(amount DOUBLE, currency VARCHAR) AS s) t;
+FROM (SELECT {'amount': NULL, 'currency': 'USD'}::STRUCT(amount DECIMAL(18,3), currency VARCHAR) AS s) t;
 ----
 true
 

--- a/test/sql/anofox_money_decimal.test
+++ b/test/sql/anofox_money_decimal.test
@@ -1,0 +1,170 @@
+# name: test/sql/anofox_money_decimal.test
+# description: Exact money representation and metadata-driven formatting (issue #57):
+#   - money amounts are DECIMAL(18,3): arithmetic is exact, no binary-float drift
+#   - NaN/Inf are unrepresentable; out-of-range amounts raise clear errors (no Inf/wraparound)
+#   - money_format derives the scale from subunit_to_unit (JPY -> 0 decimals) and
+#     inserts thousands_separator / decimal_mark from the currency metadata
+# group: [anofox_tabular]
+
+require anofox_tabular
+
+#----------------------------------------------------------------------------------------------------------------------
+# Representation: the money struct carries an exact DECIMAL(18,3) amount
+#----------------------------------------------------------------------------------------------------------------------
+
+query T
+SELECT typeof(anofox_tab_money(1.0, 'USD'));
+----
+STRUCT(amount DECIMAL(18,3), currency VARCHAR)
+
+query T
+SELECT typeof(anofox_tab_money_amount(anofox_tab_money(1.0, 'USD')));
+----
+DECIMAL(18,3)
+
+#----------------------------------------------------------------------------------------------------------------------
+# Exact arithmetic: no binary floating point drift
+#----------------------------------------------------------------------------------------------------------------------
+
+# 0.1 + 0.2 must be exactly 0.3
+query I
+SELECT anofox_tab_money_amount(anofox_tab_money_add(anofox_tab_money(0.1, 'USD'), anofox_tab_money(0.2, 'USD'))) = 0.3;
+----
+true
+
+# Summing 0.10 a thousand times via money_add must be exactly 100.00
+# (under DOUBLE this drifts to 99.9999999999986)
+query I
+WITH RECURSIVE acc(i, m) AS (
+    SELECT 1, anofox_tab_money(0.10, 'USD')
+    UNION ALL
+    SELECT i + 1, anofox_tab_money_add(m, anofox_tab_money(0.10, 'USD')) FROM acc WHERE i < 1000
+)
+SELECT anofox_tab_money_amount(m) = 100.00 FROM acc WHERE i = 1000;
+----
+true
+
+# Aggregating extracted amounts must also be exact (DECIMAL SUM, not DOUBLE SUM)
+query I
+SELECT SUM(anofox_tab_money_amount(anofox_tab_money(0.10, 'USD'))) = 100.00 FROM range(1000);
+----
+true
+
+# money_subtract is exact as well
+query I
+SELECT anofox_tab_money_amount(anofox_tab_money_subtract(anofox_tab_money(0.3, 'USD'), anofox_tab_money(0.1, 'USD'))) = 0.2;
+----
+true
+
+# Cents round-trip exactly (no precision loss above 2^53 raw cents)
+query I
+SELECT anofox_tab_money_amount(anofox_tab_money_from_cents(123456789, 'USD')) = 1234567.89;
+----
+true
+
+query T
+SELECT anofox_tab_money_amount(anofox_tab_money_from_cents(99999999999999999, 'USD'))::VARCHAR;
+----
+999999999999999.990
+
+#----------------------------------------------------------------------------------------------------------------------
+# NaN / Inf are unrepresentable
+#----------------------------------------------------------------------------------------------------------------------
+
+statement error
+SELECT anofox_tab_money('NaN'::DOUBLE, 'USD');
+----
+finite
+
+statement error
+SELECT anofox_tab_money('Infinity'::DOUBLE, 'USD');
+----
+finite
+
+statement error
+SELECT anofox_tab_money_multiply(anofox_tab_money(1.0, 'USD'), 'NaN'::DOUBLE);
+----
+finite
+
+#----------------------------------------------------------------------------------------------------------------------
+# Overflow raises a clear error (no Inf, no wraparound)
+#----------------------------------------------------------------------------------------------------------------------
+
+statement error
+SELECT anofox_tab_money(1e16, 'USD');
+----
+out of range
+
+statement error
+SELECT anofox_tab_money_add(anofox_tab_money(900000000000000.0, 'USD'), anofox_tab_money(900000000000000.0, 'USD'));
+----
+out of range
+
+statement error
+SELECT anofox_tab_money_multiply(anofox_tab_money(900000000000000.0, 'USD'), 10000000000.0);
+----
+out of range
+
+statement error
+SELECT anofox_tab_money_from_cents(200000000000000000, 'USD');
+----
+out of range
+
+#----------------------------------------------------------------------------------------------------------------------
+# Metadata-driven formatting: scale from subunit_to_unit
+#----------------------------------------------------------------------------------------------------------------------
+
+# JPY is a zero-decimal currency: no decimals in any style
+query T
+SELECT anofox_tab_money_format(anofox_tab_money(1000, 'JPY'), 'symbol');
+----
+¥1,000
+
+query T
+SELECT anofox_tab_money_format(anofox_tab_money(1000, 'JPY'), 'code');
+----
+1000 JPY
+
+# Amounts with more precision than the currency scale are rounded half away from zero
+query T
+SELECT anofox_tab_money_format(anofox_tab_money(1234.5, 'JPY'), 'symbol');
+----
+¥1,235
+
+#----------------------------------------------------------------------------------------------------------------------
+# Metadata-driven formatting: thousands_separator and decimal_mark per currency
+#----------------------------------------------------------------------------------------------------------------------
+
+query T
+SELECT anofox_tab_money_format(anofox_tab_money(1234567.89, 'USD'), 'symbol');
+----
+$1,234,567.89
+
+query T
+SELECT anofox_tab_money_format(anofox_tab_money(1234567.89, 'EUR'), 'symbol');
+----
+1.234.567,89 €
+
+query T
+SELECT anofox_tab_money_format(anofox_tab_money(1234.56, 'CHF'), 'symbol');
+----
+1'234.56 CHF
+
+# Grouping applies to the integer digits only, the sign stays with the amount
+query T
+SELECT anofox_tab_money_format(anofox_tab_money(-1234.56, 'USD'), 'symbol');
+----
+$-1,234.56
+
+# 'long' style localizes the amount the same way as 'symbol'
+query T
+SELECT anofox_tab_money_format(anofox_tab_money(1234.5, 'EUR'), 'long');
+----
+1.234,50 Euro
+
+# 'code' style stays canonical/machine-readable: dot decimal mark, no grouping,
+# but still uses the currency scale
+query T
+SELECT anofox_tab_money_format(anofox_tab_money(1234567.89, 'USD'), 'code');
+----
+1234567.89 USD


### PR DESCRIPTION
Recreation of #74, which was auto-closed when its stacked base branch (`fix/43-money-correctness`, PR #63) was deleted on merge. Identical content; #63 is now in main so the diff shows only the #57 changes.

See #74 for the original review discussion, design decision (DECIMAL(18,3)), red/green evidence, and test results.

Closes #57