### PR TITLE
test: reconcile alias-fidelity test with strict dbscan output modes

### DIFF
--- a/test/sql/anofox_alias_fidelity.test
+++ b/test/sql/anofox_alias_fidelity.test
@@ -120,9 +120,10 @@ CREATE TABLE alias_fidelity_points(v DOUBLE);
 statement ok
 INSERT INTO alias_fidelity_points VALUES (1.0), (1.1), (1.2), (10.0);
 
+# output_mode 'clusters': dbscan only accepts 'summary'/'clusters' since #52
 query I
-SELECT (SELECT count(*) FROM anofox_tab_dbscan('alias_fidelity_points', 'v', 0.5, 2, 'all'))
-     = (SELECT count(*) FROM dbscan('alias_fidelity_points', 'v', 0.5, 2, 'all'));
+SELECT (SELECT count(*) FROM anofox_tab_dbscan('alias_fidelity_points', 'v', 0.5, 2, 'clusters'))
+     = (SELECT count(*) FROM dbscan('alias_fidelity_points', 'v', 0.5, 2, 'clusters'));
 ----
 true
 


### PR DESCRIPTION
Cross-PR interaction discovered on the integration branch: #78's alias-fidelity test used dbscan `output_mode='all'`, which #71/#73 made a binder error (strict mode validation). On current main that test fails. This applies the same reconciliation the verified integration branch used (`'all'` → `'clusters'`, still exercising bind_replace fidelity through the alias) and ties the integration history into main.

Part of #61.