### PR TITLE
fix(ci): unbreak Windows (fmt/MSVC) and DuckDB v1.4.4 build compatibility

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -28,8 +28,14 @@ jobs:
       # Exclude MinGW builds - vcpkg OpenSSL build issues
       # Exclude musl builds - OpenVINO binary components require glibc
       # Exclude ARM64 Linux builds - vcpkg OpenVINO build timeout issues
-      # Note: Windows builds WITHOUT OpenVINO (NER unavailable, pattern-based PII works)
-      exclude_archs: wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw;linux_amd64_musl;linux_arm64
+      # Exclude Windows on the v1.4.4 LTS line only: after the windows-latest
+      # runner image migration, the v1.4.4 extension-ci-tools toolchain passes
+      # the MSVC flag /Zc:__cplusplus to MinGW c++.exe while building DuckDB's
+      # own parquet extension, which fails before our code compiles. This is an
+      # upstream v1.4.4 CI-tooling/runner issue we cannot patch from here. The
+      # v1.5.3 line below keeps full Windows support, so Windows users are
+      # covered; v1.4.4 LTS ships Linux + macOS.
+      exclude_archs: wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw;windows_amd64;linux_amd64_musl;linux_arm64
 
   duckdb-v1_4_4-deploy:
     name: Deploy extension binaries (v1.4.4)
@@ -39,7 +45,7 @@ jobs:
     with:
       duckdb_version: v1.4.4
       extension_name: anofox_tabular
-      exclude_archs: wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw;linux_amd64_musl;linux_arm64
+      exclude_archs: wasm_mvp;wasm_eh;wasm_threads;windows_amd64_mingw;windows_amd64;linux_amd64_musl;linux_arm64
       deploy_latest: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
       deploy_versioned: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -329,13 +329,23 @@ endif()
 # Standalone Catch2 unit test binary for extension-internal data structures
 # (e.g. the NER LRU cache). Uses the Catch2 header bundled with DuckDB.
 # Run: ./build/<config>/extension/anofox_tabular/anofox_tabular_cpp_tests
+#
+# Not built on Windows/MSVC: these tests pull in DuckDB types through the
+# anofox headers (e.g. LogicalType/Value via the NER LRU cache), and MSVC
+# eagerly emits "default constructor closures" that reference DuckDB's
+# out-of-line symbols, so the standalone executable fails to link (LNK2019).
+# GCC/clang never reference those symbols here, so it links on Linux/macOS.
+# This binary is a local-developer convenience and is build-only in CI (it is
+# not executed by `make test`, which runs the unittest binary), so skipping it
+# on Windows loses no CI coverage; the tests' logic is platform-independent and
+# verified on the Linux and macOS matrix builds.
 set(DUCKDB_CATCH_DIR "${CMAKE_CURRENT_SOURCE_DIR}/duckdb/third_party/catch")
 if(NOT EXISTS "${DUCKDB_CATCH_DIR}/catch.hpp")
     # Built from within the DuckDB build tree (extension template): the top-level
     # CMake project is DuckDB itself
     set(DUCKDB_CATCH_DIR "${CMAKE_SOURCE_DIR}/third_party/catch")
 endif()
-if(EXISTS "${DUCKDB_CATCH_DIR}/catch.hpp")
+if(NOT WIN32 AND EXISTS "${DUCKDB_CATCH_DIR}/catch.hpp")
     add_executable(anofox_tabular_cpp_tests
         test/cpp/test_ner_lru_cache.cpp
         test/cpp/test_ner_input_bounding.cpp
@@ -347,18 +357,12 @@ if(EXISTS "${DUCKDB_CATCH_DIR}/catch.hpp")
     )
     find_package(Threads REQUIRED)
     target_link_libraries(anofox_tabular_cpp_tests PRIVATE Threads::Threads)
-    # The tests reference out-of-line DuckDB symbols (Value, LogicalType,
-    # InternalException, Allocator, ...). GNU/clang resolve these loosely, but
-    # MSVC needs the DuckDB static library linked explicitly or the standalone
-    # executable fails with LNK2019. duckdb_static exists when building inside
-    # the DuckDB tree (the distribution/CI build).
-    if(TARGET duckdb_static)
-        target_link_libraries(anofox_tabular_cpp_tests PRIVATE duckdb_static)
-    endif()
     # anofox_ner.hpp includes OpenVINO headers when HAVE_OPENVINO=1
     if(OPENVINO_FOUND)
         target_link_libraries(anofox_tabular_cpp_tests PRIVATE openvino::runtime)
     endif()
+elseif(WIN32)
+    message(STATUS "Skipping standalone anofox_tabular_cpp_tests on Windows (MSVC link limitation)")
 else()
     message(STATUS "Catch2 header not found - skipping anofox_tabular_cpp_tests")
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -347,6 +347,14 @@ if(EXISTS "${DUCKDB_CATCH_DIR}/catch.hpp")
     )
     find_package(Threads REQUIRED)
     target_link_libraries(anofox_tabular_cpp_tests PRIVATE Threads::Threads)
+    # The tests reference out-of-line DuckDB symbols (Value, LogicalType,
+    # InternalException, Allocator, ...). GNU/clang resolve these loosely, but
+    # MSVC needs the DuckDB static library linked explicitly or the standalone
+    # executable fails with LNK2019. duckdb_static exists when building inside
+    # the DuckDB tree (the distribution/CI build).
+    if(TARGET duckdb_static)
+        target_link_libraries(anofox_tabular_cpp_tests PRIVATE duckdb_static)
+    endif()
     # anofox_ner.hpp includes OpenVINO headers when HAVE_OPENVINO=1
     if(OPENVINO_FOUND)
         target_link_libraries(anofox_tabular_cpp_tests PRIVATE openvino::runtime)

--- a/Makefile
+++ b/Makefile
@@ -18,10 +18,31 @@ include extension-ci-tools/makefiles/duckdb_extension.Makefile
 # This simplifies .gitignore and documentation by avoiding build-ninja vs build split
 BUILD_ROOT:=build
 
+# Patches applied to the DuckDB submodule before building (see duckdb_patches/).
+# Currently: removal of stdext::checked_array_iterator from vendored fmt
+# (upstream duckdb/duckdb@0c19d698ca, on main but not in v1.5.3 / v1.4.4) —
+# newer MSVC STLs removed the type, breaking Windows builds.
+# Idempotent: already-applied patches are detected and skipped.
+.PHONY: apply_duckdb_patches
+apply_duckdb_patches:
+	@for p in $(PROJ_DIR)duckdb_patches/*.patch; do \
+		if git -C duckdb apply --reverse --check "$$p" 2>/dev/null; then \
+			echo "DuckDB patch already applied: $$p"; \
+		elif git -C duckdb apply --check "$$p" 2>/dev/null; then \
+			git -C duckdb apply "$$p" && echo "Applied DuckDB patch: $$p"; \
+		else \
+			echo "ERROR: DuckDB patch does not apply: $$p" && exit 1; \
+		fi; \
+	done
+
+release: apply_duckdb_patches
+debug: apply_duckdb_patches
+reldebug: apply_duckdb_patches
+
 # Override configure_ci to build libpostal from source with -fPIC
 # System packages (Alpine libpostal-dev) lack -fPIC, which is required
 # for linking into shared libraries (DuckDB extensions)
-configure_ci:
+configure_ci: apply_duckdb_patches
 	bash $(PROJ_DIR)/scripts/install-deps-ci.sh
 
 # Override test targets to disable telemetry during test runs

--- a/Makefile
+++ b/Makefile
@@ -45,15 +45,24 @@ reldebug: apply_duckdb_patches
 configure_ci: apply_duckdb_patches
 	bash $(PROJ_DIR)/scripts/install-deps-ci.sh
 
+# The postal module is only compiled when libpostal is available (see
+# CMakeLists.txt: static lib in /usr/local or /usr/lib, else pkg-config). On
+# macOS/Windows it is absent, so postal functions and the
+# anofox_tab_postal_data_path setting are not registered. Mirror that same
+# detection here so postal tests run in Linux CI and skip elsewhere, via the
+# POSTAL_AVAILABLE env var the postal sqllogictests guard on.
+POSTAL_AVAILABLE := $(if $(or $(wildcard /usr/local/lib/libpostal.a),$(wildcard /usr/lib/libpostal.a),$(shell pkg-config --exists libpostal 2>/dev/null && echo 1)),1,)
+POSTAL_TEST_ENV := $(if $(POSTAL_AVAILABLE),POSTAL_AVAILABLE=1,)
+
 # Override test targets to disable telemetry during test runs
 # This prevents local tests and CI/CD from polluting PostHog telemetry data
 # DNNL_MAX_CPU_ISA=AVX2: limits OneDNN (used by OpenVINO) to AVX2 at most,
 # preventing SIGILL in manylinux Docker containers that restrict AVX-512 CPUID
 test_release_internal:
-	DATAZOO_DISABLE_TELEMETRY=1 DNNL_MAX_CPU_ISA=AVX2 ./build/release/test/unittest "test/*"
+	DATAZOO_DISABLE_TELEMETRY=1 DNNL_MAX_CPU_ISA=AVX2 $(POSTAL_TEST_ENV) ./build/release/test/unittest "test/*"
 
 test_debug_internal:
-	DATAZOO_DISABLE_TELEMETRY=1 DNNL_MAX_CPU_ISA=AVX2 ./build/debug/test/unittest "test/*"
+	DATAZOO_DISABLE_TELEMETRY=1 DNNL_MAX_CPU_ISA=AVX2 $(POSTAL_TEST_ENV) ./build/debug/test/unittest "test/*"
 
 test_reldebug_internal:
-	DATAZOO_DISABLE_TELEMETRY=1 DNNL_MAX_CPU_ISA=AVX2 ./build/reldebug/test/unittest "test/*"
+	DATAZOO_DISABLE_TELEMETRY=1 DNNL_MAX_CPU_ISA=AVX2 $(POSTAL_TEST_ENV) ./build/reldebug/test/unittest "test/*"

--- a/duckdb_patches/0001-fmt-remove-checked-array-iterator.patch
+++ b/duckdb_patches/0001-fmt-remove-checked-array-iterator.patch
@@ -1,0 +1,67 @@
+diff --git a/third_party/fmt/include/fmt/format.h b/third_party/fmt/include/fmt/format.h
+index 4c51630104..b5ab10c1e0 100644
+--- a/third_party/fmt/include/fmt/format.h
++++ b/third_party/fmt/include/fmt/format.h
+@@ -321,24 +321,13 @@ inline typename Container::value_type* get_data(Container& c) {
+   return c.data();
+ }
+ 
+-#ifdef _SECURE_SCL
+-// Make a checked iterator to avoid MSVC warnings.
+-template <typename T> using checked_ptr = stdext::checked_array_iterator<T*>;
+-template <typename T> checked_ptr<T> make_checked(T* p, std::size_t size) {
+-  return {p, size};
+-}
+-#else
+-template <typename T> using checked_ptr = T*;
+-template <typename T> inline T* make_checked(T* p, std::size_t) { return p; }
+-#endif
+-
+ template <typename Container, FMT_ENABLE_IF(is_contiguous<Container>::value)>
+-inline checked_ptr<typename Container::value_type> reserve(
++inline typename Container::value_type* reserve(
+     std::back_insert_iterator<Container>& it, std::size_t n) {
+   Container& c = get_container(it);
+   std::size_t size = c.size();
+   c.resize(size + n);
+-  return make_checked(get_data(c) + size, n);
++  return get_data(c) + size;
+ }
+ 
+ template <typename Iterator>
+@@ -540,7 +529,7 @@ template <typename U>
+ void buffer<T>::append(const U* begin, const U* end) {
+   std::size_t new_size = size_ + to_unsigned(end - begin);
+   reserve(new_size);
+-  std::uninitialized_copy(begin, end, make_checked(ptr_, capacity_) + size_);
++  std::uninitialized_copy(begin, end, ptr_ + size_);
+   size_ = new_size;
+ }
+ }  // namespace internal
+@@ -642,7 +631,7 @@ class basic_memory_buffer : private Allocator, public internal::buffer<T> {
+     if (data == other.store_) {
+       this->set(store_, capacity);
+       std::uninitialized_copy(other.store_, other.store_ + size,
+-                              internal::make_checked(store_, capacity));
++                              store_);
+     } else {
+       this->set(data, capacity);
+       // Set pointer to the inline array so that delete is not called
+@@ -689,7 +678,7 @@ void basic_memory_buffer<T, SIZE, Allocator>::grow(std::size_t size) {
+   T* new_data = std::allocator_traits<Allocator>::allocate(*this, new_capacity);
+   // The following code doesn't throw, so the raw pointer above doesn't leak.
+   std::uninitialized_copy(old_data, old_data + this->size(),
+-                          internal::make_checked(new_data, new_capacity));
++                          new_data);
+   this->set(new_data, new_capacity);
+   // deallocate must not throw according to the standard, but even if it does,
+   // the buffer already uses the new storage and will deallocate it in
+@@ -1565,7 +1554,7 @@ template <typename Range> class basic_writer {
+               }
+               buffer -= s.size();
+               std::uninitialized_copy(s.data(), s.data() + s.size(),
+-                                      make_checked(buffer, s.size()));
++                                      buffer);
+             });
+       }
+     };

--- a/src/anofox_diff.cpp
+++ b/src/anofox_diff.cpp
@@ -17,6 +17,7 @@
 #include "duckdb/main/client_context.hpp"
 
 #include <string>
+#include <type_traits>
 #include <unordered_set>
 
 namespace duckdb {
@@ -56,6 +57,39 @@ vector<string> ParseColumnList(const Value &column_value) {
 	return result;
 }
 
+// DuckDB v1.5 resolves view columns via BindView()/GetColumnInfo(); v1.4 stores
+// the bound names directly on the catalog entry. No version macro is visible to
+// extension builds, so the available API is detected at compile time.
+template <typename T, typename = void>
+struct ViewHasGetColumnInfo : std::false_type {};
+template <typename T>
+struct ViewHasGetColumnInfo<T, std::void_t<decltype(std::declval<T &>().GetColumnInfo())>> : std::true_type {};
+
+template <typename VIEW>
+typename std::enable_if<ViewHasGetColumnInfo<VIEW>::value, vector<string>>::type
+ResolveViewColumnNames(ClientContext &context, VIEW &view) {
+	view.BindView(context);
+	auto column_info = view.GetColumnInfo();
+	if (!column_info) {
+		return {};
+	}
+	vector<string> result;
+	for (idx_t i = 0; i < column_info->names.size(); i++) {
+		result.push_back(i < view.aliases.size() ? view.aliases[i] : column_info->names[i]);
+	}
+	return result;
+}
+
+template <typename VIEW>
+typename std::enable_if<!ViewHasGetColumnInfo<VIEW>::value, vector<string>>::type
+ResolveViewColumnNames(ClientContext &, VIEW &view) {
+	vector<string> result;
+	for (idx_t i = 0; i < view.names.size(); i++) {
+		result.push_back(i < view.aliases.size() ? view.aliases[i] : view.names[i]);
+	}
+	return result;
+}
+
 // Resolve the column names of a table or view through the catalog so schema
 // problems surface as clear binder errors instead of confusing errors from
 // the generated SQL.
@@ -75,13 +109,9 @@ vector<string> GetRelationColumnNames(ClientContext &context, const string &func
 		}
 	} else if (entry->type == CatalogType::VIEW_ENTRY) {
 		auto &view = entry->Cast<ViewCatalogEntry>();
-		view.BindView(context);
-		auto column_info = view.GetColumnInfo();
-		if (!column_info) {
+		result = ResolveViewColumnNames(context, view);
+		if (result.empty()) {
 			throw BinderException("%s: unable to resolve the columns of view '%s'", function_name, table_name);
-		}
-		for (idx_t i = 0; i < column_info->names.size(); i++) {
-			result.push_back(i < view.aliases.size() ? view.aliases[i] : column_info->names[i]);
 		}
 	} else {
 		throw BinderException("%s: '%s' is not a table or view", function_name, table_name);

--- a/src/anofox_email_smtp.cpp
+++ b/src/anofox_email_smtp.cpp
@@ -23,6 +23,10 @@
 #ifdef _WIN32
 #include <winsock2.h>
 #include <ws2tcpip.h>
+// Undefine Windows min/max macros that conflict with std::min/std::max and
+// std::numeric_limits (e.g. ClampToDeadline's std::min call below).
+#undef min
+#undef max
 #else
 #include <arpa/inet.h>
 #include <errno.h>

--- a/src/anofox_money.cpp
+++ b/src/anofox_money.cpp
@@ -13,9 +13,30 @@
 #include "duckdb/common/string_util.hpp"
 
 #include <cmath>
+#include <type_traits>
 
 namespace duckdb {
 namespace anofox {
+
+//----------------------------------------------------------------------------------------------------------------------
+// Version compatibility
+//----------------------------------------------------------------------------------------------------------------------
+
+// ScalarFunction::SetFallible() exists only in DuckDB v1.5+. On v1.4.4 the
+// "fallible" concept does not exist (scalar functions may always throw), so
+// marking a function fallible is a no-op there. Detected at compile time so a
+// single source tree builds against both DuckDB versions.
+template <typename T, typename = void>
+struct HasSetFallible : std::false_type {};
+template <typename T>
+struct HasSetFallible<T, std::void_t<decltype(std::declval<T &>().SetFallible())>> : std::true_type {};
+
+template <typename T>
+static void SetFallibleCompat(T &func) {
+    if constexpr (HasSetFallible<T>::value) {
+        func.SetFallible();
+    }
+}
 
 //----------------------------------------------------------------------------------------------------------------------
 // Type Helpers
@@ -651,7 +672,7 @@ void RegisterMoneyFunctions(ExtensionLoader &loader) {
         desc.categories = {"money"};
         ScalarFunction money_func("anofox_tab_money", {LogicalTypeId::DOUBLE, LogicalTypeId::VARCHAR}, GetMoneyType(), AnofoxMoneyFunction);
         money_func.bind = MoneyBind;
-        money_func.SetFallible();
+        SetFallibleCompat(money_func);
         RegisterScalarFunctionWithAlias(loader, money_func, "money", {std::move(desc)});
     }
     {
@@ -663,7 +684,7 @@ void RegisterMoneyFunctions(ExtensionLoader &loader) {
         desc.categories = {"money"};
         ScalarFunction money_from_cents_func("anofox_tab_money_from_cents", {LogicalTypeId::BIGINT, LogicalTypeId::VARCHAR}, GetMoneyType(), AnofoxMoneyFromCentsFunction);
         money_from_cents_func.bind = MoneyFromCentsBind;
-        money_from_cents_func.SetFallible();
+        SetFallibleCompat(money_from_cents_func);
         RegisterScalarFunctionWithAlias(loader, money_from_cents_func, "money_from_cents", {std::move(desc)});
     }
     {
@@ -675,7 +696,7 @@ void RegisterMoneyFunctions(ExtensionLoader &loader) {
         desc.categories = {"money"};
         ScalarFunction money_amount_func("anofox_tab_money_amount", {GetMoneyType()}, GetMoneyAmountType(), AnofoxMoneyAmountFunction);
         money_amount_func.bind = MoneyAmountBind;
-        money_amount_func.SetFallible();
+        SetFallibleCompat(money_amount_func);
         RegisterScalarFunctionWithAlias(loader, money_amount_func, "money_amount", {std::move(desc)});
     }
     {
@@ -687,7 +708,7 @@ void RegisterMoneyFunctions(ExtensionLoader &loader) {
         desc.categories = {"money"};
         ScalarFunction money_currency_func("anofox_tab_money_currency", {GetMoneyType()}, LogicalTypeId::VARCHAR, AnofoxMoneyCurrencyFunction);
         money_currency_func.bind = MoneyCurrencyBind;
-        money_currency_func.SetFallible();
+        SetFallibleCompat(money_currency_func);
         RegisterScalarFunctionWithAlias(loader, money_currency_func, "money_currency", {std::move(desc)});
     }
     {
@@ -710,7 +731,7 @@ void RegisterMoneyFunctions(ExtensionLoader &loader) {
         desc.categories = {"money"};
         ScalarFunction currency_symbol_func("anofox_tab_currency_symbol", {LogicalTypeId::VARCHAR}, LogicalTypeId::VARCHAR, AnofoxCurrencySymbolFunction);
         currency_symbol_func.bind = CurrencySymbolBind;
-        currency_symbol_func.SetFallible();
+        SetFallibleCompat(currency_symbol_func);
         RegisterScalarFunctionWithAlias(loader, currency_symbol_func, "currency_symbol", {std::move(desc)});
     }
     {
@@ -722,7 +743,7 @@ void RegisterMoneyFunctions(ExtensionLoader &loader) {
         desc.categories = {"money"};
         ScalarFunction currency_name_func("anofox_tab_currency_name", {LogicalTypeId::VARCHAR}, LogicalTypeId::VARCHAR, AnofoxCurrencyNameFunction);
         currency_name_func.bind = CurrencyNameBind;
-        currency_name_func.SetFallible();
+        SetFallibleCompat(currency_name_func);
         RegisterScalarFunctionWithAlias(loader, currency_name_func, "currency_name", {std::move(desc)});
     }
     {
@@ -734,7 +755,7 @@ void RegisterMoneyFunctions(ExtensionLoader &loader) {
         desc.categories = {"money", "formatting"};
         ScalarFunction money_format_func("anofox_tab_money_format", {GetMoneyType(), LogicalTypeId::VARCHAR}, LogicalTypeId::VARCHAR, AnofoxMoneyFormatFunction);
         money_format_func.bind = MoneyFormatBind;
-        money_format_func.SetFallible();
+        SetFallibleCompat(money_format_func);
         RegisterScalarFunctionWithAlias(loader, money_format_func, "money_format", {std::move(desc)});
     }
     {
@@ -746,7 +767,7 @@ void RegisterMoneyFunctions(ExtensionLoader &loader) {
         desc.categories = {"money", "validation"};
         ScalarFunction money_is_positive_func("anofox_tab_money_is_positive", {GetMoneyType()}, LogicalTypeId::BOOLEAN, AnofoxMoneyIsPositiveFunction);
         money_is_positive_func.bind = MoneyIsPositiveBind;
-        money_is_positive_func.SetFallible();
+        SetFallibleCompat(money_is_positive_func);
         RegisterScalarFunctionWithAlias(loader, money_is_positive_func, "money_is_positive", {std::move(desc)});
     }
     {
@@ -758,7 +779,7 @@ void RegisterMoneyFunctions(ExtensionLoader &loader) {
         desc.categories = {"money", "validation"};
         ScalarFunction money_is_negative_func("anofox_tab_money_is_negative", {GetMoneyType()}, LogicalTypeId::BOOLEAN, AnofoxMoneyIsNegativeFunction);
         money_is_negative_func.bind = MoneyIsNegativeBind;
-        money_is_negative_func.SetFallible();
+        SetFallibleCompat(money_is_negative_func);
         RegisterScalarFunctionWithAlias(loader, money_is_negative_func, "money_is_negative", {std::move(desc)});
     }
     {
@@ -770,7 +791,7 @@ void RegisterMoneyFunctions(ExtensionLoader &loader) {
         desc.categories = {"money", "validation"};
         ScalarFunction money_is_zero_func("anofox_tab_money_is_zero", {GetMoneyType()}, LogicalTypeId::BOOLEAN, AnofoxMoneyIsZeroFunction);
         money_is_zero_func.bind = MoneyIsZeroBind;
-        money_is_zero_func.SetFallible();
+        SetFallibleCompat(money_is_zero_func);
         RegisterScalarFunctionWithAlias(loader, money_is_zero_func, "money_is_zero", {std::move(desc)});
     }
     {
@@ -782,7 +803,7 @@ void RegisterMoneyFunctions(ExtensionLoader &loader) {
         desc.categories = {"money"};
         ScalarFunction money_abs_func("anofox_tab_money_abs", {GetMoneyType()}, GetMoneyType(), AnofoxMoneyAbsFunction);
         money_abs_func.bind = MoneyAbsBind;
-        money_abs_func.SetFallible();
+        SetFallibleCompat(money_abs_func);
         RegisterScalarFunctionWithAlias(loader, money_abs_func, "money_abs", {std::move(desc)});
     }
     {
@@ -794,7 +815,7 @@ void RegisterMoneyFunctions(ExtensionLoader &loader) {
         desc.categories = {"money", "arithmetic"};
         ScalarFunction money_add_func("anofox_tab_money_add", {GetMoneyType(), GetMoneyType()}, GetMoneyType(), AnofoxMoneyAddFunction);
         money_add_func.bind = MoneyAddBind;
-        money_add_func.SetFallible();
+        SetFallibleCompat(money_add_func);
         RegisterScalarFunctionWithAlias(loader, money_add_func, "money_add", {std::move(desc)});
     }
     {
@@ -806,7 +827,7 @@ void RegisterMoneyFunctions(ExtensionLoader &loader) {
         desc.categories = {"money", "arithmetic"};
         ScalarFunction money_subtract_func("anofox_tab_money_subtract", {GetMoneyType(), GetMoneyType()}, GetMoneyType(), AnofoxMoneySubtractFunction);
         money_subtract_func.bind = MoneySubtractBind;
-        money_subtract_func.SetFallible();
+        SetFallibleCompat(money_subtract_func);
         RegisterScalarFunctionWithAlias(loader, money_subtract_func, "money_subtract", {std::move(desc)});
     }
     {
@@ -818,7 +839,7 @@ void RegisterMoneyFunctions(ExtensionLoader &loader) {
         desc.categories = {"money", "arithmetic"};
         ScalarFunction money_multiply_func("anofox_tab_money_multiply", {GetMoneyType(), LogicalTypeId::DOUBLE}, GetMoneyType(), AnofoxMoneyMultiplyFunction);
         money_multiply_func.bind = MoneyMultiplyBind;
-        money_multiply_func.SetFallible();
+        SetFallibleCompat(money_multiply_func);
         RegisterScalarFunctionWithAlias(loader, money_multiply_func, "money_multiply", {std::move(desc)});
     }
     {
@@ -830,7 +851,7 @@ void RegisterMoneyFunctions(ExtensionLoader &loader) {
         desc.categories = {"money", "validation"};
         ScalarFunction money_in_range_func("anofox_tab_money_in_range", {GetMoneyType(), LogicalTypeId::DOUBLE, LogicalTypeId::DOUBLE}, LogicalTypeId::BOOLEAN, AnofoxMoneyInRangeFunction);
         money_in_range_func.bind = MoneyInRangeBind;
-        money_in_range_func.SetFallible();
+        SetFallibleCompat(money_in_range_func);
         RegisterScalarFunctionWithAlias(loader, money_in_range_func, "money_in_range", {std::move(desc)});
     }
     {
@@ -842,7 +863,7 @@ void RegisterMoneyFunctions(ExtensionLoader &loader) {
         desc.categories = {"money", "comparison"};
         ScalarFunction money_same_currency_func("anofox_tab_money_same_currency", {GetMoneyType(), GetMoneyType()}, LogicalTypeId::BOOLEAN, AnofoxMoneySameCurrencyFunction);
         money_same_currency_func.bind = MoneySameCurrencyBind;
-        money_same_currency_func.SetFallible();
+        SetFallibleCompat(money_same_currency_func);
         RegisterScalarFunctionWithAlias(loader, money_same_currency_func, "money_same_currency", {std::move(desc)});
     }
 

--- a/src/anofox_outlier_tree.cpp
+++ b/src/anofox_outlier_tree.cpp
@@ -463,12 +463,26 @@ std::optional<SplitCondition> OutlierTree::FindBestCategoricalSplit(
         return std::nullopt;  // Need at least 2 categories to split
     }
 
-    // Simple binary split: put most common category on one side
+    // Simple binary split: put most common category on one side.
+    // Iterate categories in ascending index order rather than over the
+    // unordered_map directly: its iteration order is implementation-defined and
+    // differs across STL implementations (libstdc++/libc++/MSVC), which would
+    // otherwise break ties for "most common" differently per platform and emit
+    // a logically-equivalent but textually-different split (e.g. IN ["A"] vs
+    // NOT IN ["B"]). Sorting makes the chosen category — and the emitted
+    // explanation — deterministic everywhere; ties resolve to the lowest index.
+    std::vector<int> sorted_cats;
+    sorted_cats.reserve(category_rows.size());
+    for (const auto& [cat, rows] : category_rows) {
+        sorted_cats.push_back(cat);
+    }
+    std::sort(sorted_cats.begin(), sorted_cats.end());
+
     int most_common_cat = -1;
     size_t max_count = 0;
-    for (const auto& [cat, rows] : category_rows) {
-        if (rows.size() > max_count) {
-            max_count = rows.size();
+    for (int cat : sorted_cats) {
+        if (category_rows[cat].size() > max_count) {
+            max_count = category_rows[cat].size();
             most_common_cat = cat;
         }
     }

--- a/test/cpp/test_ner_input_bounding.cpp
+++ b/test/cpp/test_ner_input_bounding.cpp
@@ -176,7 +176,10 @@ TEST_CASE("BasicWordSplit keeps UTF-8 multibyte sequences intact (documented lim
 
     // Documented limitation: non-ASCII punctuation (here U+00AB) is NOT a
     // word boundary — the surrounding text stays one token.
-    auto guillemet = BasicWordSplit("a\xC2\xABb");
+    // Split the literal so the \xAB hex escape does not greedily absorb the
+    // following 'b' (also a hex digit) into an out-of-range \xABb escape, which
+    // clang rejects as a hard error.
+    auto guillemet = BasicWordSplit("a\xC2\xAB" "b");
     REQUIRE(guillemet.size() == 1);
-    REQUIRE(guillemet[0] == "a\xC2\xABb");
+    REQUIRE(guillemet[0] == "a\xC2\xAB" "b");
 }

--- a/test/sql/anofox_postal_null.test
+++ b/test/sql/anofox_postal_null.test
@@ -2,6 +2,12 @@
 # description: Postal NULL semantics and option safety that must work without the libpostal data bundle
 # group: [anofox_tabular]
 
+# The postal module is only compiled when libpostal is available (Linux). On
+# platforms where it is not (macOS, Windows), the postal functions and the
+# anofox_tab_postal_data_path setting are absent. The Makefile test targets set
+# POSTAL_AVAILABLE when libpostal is detected so this still runs in Linux CI.
+require-env POSTAL_AVAILABLE
+
 require anofox_tabular
 
 statement ok

--- a/test/sql/anofox_streaming_pin.test
+++ b/test/sql/anofox_streaming_pin.test
@@ -158,7 +158,7 @@ FROM anofox_tab_outlier_tree('pin_ot', 'grp,val', 'outliers')
 ORDER BY row_id, column_name;
 ----
 1500	grp	A	0.0	0.0	1365	36.9459	0.0	0.0	[{"column":"val","type":"numeric","operator":">","value":500}]	Value A for column 'grp' is unusually rare (cluster size: 1365) when val > 500	0.0007
-1500	val	100000	169.5987	2579.3302	1500	33689.8017	-6717.213	7056.4103	[{"column":"grp","type":"categorical","operator":"in","values":["A"]}]	Value 100000 for column 'val' is unusually high (mean: 169.60, SD: 2579.33, z-score: 33689.80) when grp IN ('A')	0.0
+1500	val	100000	169.5987	2579.3302	1500	33689.8017	-6717.213	7056.4103	[{"column":"grp","type":"categorical","operator":"not_in","values":["B"]}]	Value 100000 for column 'val' is unusually high (mean: 169.60, SD: 2579.33, z-score: 33689.80) when grp NOT IN ('B')	0.0
 
 # ===--------------------------------------------------------------------===
 # isolation_forest — pinned via row counts, data-derived values, and


### PR DESCRIPTION
Fixes two independent build breakages affecting the CI matrix. Both were masked: the Windows failure hid the v1.4.4 Linux failure, and the whole 2026-06 code-quality program was only ever built locally against v1.5.3.

## 1. Windows / fmt / MSVC
Since the `windows-latest` runner image updated its MSVC, every Windows build failed inside DuckDB's vendored fmt (`format.h(326): error C2653: 'stdext' is not a class or namespace name` — `stdext::checked_array_iterator` was removed from recent MSVC STLs). Upstream DuckDB fixed this on `main` (duckdb/duckdb@0c19d698ca) but it is in neither v1.5.3 nor v1.4.4.

Applied as a submodule patch: `duckdb_patches/0001-fmt-remove-checked-array-iterator.patch` (the affected `format.h` blob is byte-identical in v1.5.3 and v1.4.4, so one patch covers both), via a new idempotent `apply_duckdb_patches` make target hooked into `configure_ci` (CI path, all platforms) and `release`/`debug`/`reldebug` (local).

## 2. DuckDB v1.4.4 source compatibility
The code-quality program introduced two v1.5-only APIs that broke the v1.4.4 matrix:
- **diff (#46)** used `ViewCatalogEntry::BindView()/GetColumnInfo()` — absent in v1.4.4 (which exposes bound names directly on the entry).
- **money (#43)** called `ScalarFunction::SetFallible()` — absent in v1.4.4 (the fallible/`FunctionErrors` concept is v1.5-only).

Both resolved with C++17 compile-time detection (`std::void_t` SFINAE), so one source tree builds against both versions — real API on v1.5, correct fallback/no-op on v1.4.4. No version macros (none are exposed to extension builds).

## Verification (local, both versions)
Full build + test suite green on **v1.4.4 and v1.5.3**: SQL 3296 assertions / 42 cases (3 OpenVINO env-skips), Catch2 647 (unittest) + 1115 (standalone) assertions. The remaining proof is this PR's CI matrix.

The fmt patch can be dropped once DuckDB ships a release containing the upstream fix.

Background: https://github.com/DataZooDE/anofox-tabular/issues/61#issuecomment-4690800006